### PR TITLE
Add Rust CI/CD workflow

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,4 +1,4 @@
-name: Rust CI/CD
+name: Rust
 
 on:
   push:
@@ -10,23 +10,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  format-check:
+  static_checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v5
-    - name: Format check
-      run: cargo fmt --all -- --check
+    - name: Static analysis
+      run: make static
 
-  clippy-check:
+  tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v5
-    - name: Clippy check
-      run: cargo clippy --all-targets --all-features -- -D warnings
-
-  unit-test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v5
-    - name: Run tests
-      run: cargo test --lib --all-features
+    - name: Tests
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+COMPOSE := docker compose
+
+.PHONY: all
+all: static test down
+
+.PHONY: static
+static: fmt-check check clippy
+
+.PHONY: fmt
+fmt:
+	cargo fmt --all
+
+.PHONY: fmt-check
+fmt-check:
+	cargo fmt --all -- --check
+
+.PHONY: check
+check:
+	cargo check --all-targets
+
+.PHONY: clippy
+clippy:
+	cargo clippy --all-targets -- -D warnings
+	
+.PHONY: test
+test: up
+	cargo test
+
+.PHONY: up
+up:
+	$(COMPOSE) up -d --wait
+	@echo
+	@echo "A 2-node cluster is running in the background. Use 'make down' to stop it and remove all the volumes."
+	@echo
+
+.PHONY: down
+down:
+	$(COMPOSE) down --remove-orphans -v
+
+.PHONY: logs
+logs:
+	$(COMPOSE) logs -f
+
+.PHONY: cqlsh
+cqlsh:
+	$(COMPOSE) exec scylla1 cqlsh -u cassandra -p cassandra
+
+.PHONY: shell
+shell:
+	$(COMPOSE) exec scylla1 bash
+
+.PHONY: volumes
+volumes:
+	docker volume ls
+
+.PHONY: prune
+prune:
+	docker system prune -a --volumes
+
+.PHONY: clean
+clean: down
+	cargo clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+networks:
+  default:
+    name: scylla_2_nodes
+services:
+  scylla1:
+    image: scylladb/scylla
+    container_name: scylla1
+    command: |
+      --smp 1
+      --memory 1G
+      --developer-mode 1
+      --overprovisioned 1
+      --alternator-write-isolation always
+      --listen-address scylla1
+      --rpc-address scylla1
+      --alternator-port 8000
+      --seeds scylla1
+    ports:
+      - "9042:9042"
+      - "8000:8000"
+    healthcheck:
+      test: [ "CMD", "cqlsh", "scylla1", "-e", "select * from system.local WHERE key='local'" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60
+  scylla2:
+    image: scylladb/scylla
+    container_name: scylla2
+    command: |
+      --smp 1
+      --memory 1G
+      --developer-mode 1
+      --overprovisioned 1
+      --alternator-write-isolation always
+      --listen-address scylla2
+      --rpc-address scylla2
+      --alternator-port 8000
+      --seeds scylla1
+    ports:
+      - "9043:9042"
+      - "8001:8000"
+    depends_on:
+      scylla1:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "cqlsh", "scylla2", "-e", "select * from system.local WHERE key='local'" ]
+      interval: 5s
+      timeout: 5s
+      retries: 60


### PR DESCRIPTION
Adds initial CI for formatting, linting, and unit tests.

Integration tests are not run yet. Need to figure out the best way  to start ScyllaDB in the workflow.

Close #2 Close #7 Close #8 