### PR TITLE
Add CCM wrapper

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -23,5 +23,9 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v5
+    - name: Install scylla-ccm
+      run: pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
+    - name: CCM wrapper tests
+      run: make ccm-wrapper-tests
     - name: Tests
       run: make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1.0.102"
 aws-sdk-dynamodb = "1.97.0"
+itertools = "0.14.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,15 @@ edition = "2024"
 anyhow = "1.0.102"
 aws-sdk-dynamodb = "1.97.0"
 itertools = "0.14.0"
+reqwest = { version = "0.11", features = ["json"] }
+
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+uuid = { version = "1", features = ["v4"] }
+
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(ccm_tests)',
+] }

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ clippy:
 test: up
 	cargo test
 
+.PHONY: ccm-wrapper-tests
+ccm-wrapper-tests:
+	RUSTFLAGS="--cfg ccm_tests" cargo test --test ccm_wrapper_tests -- --nocapture
+
 .PHONY: up
 up:
 	$(COMPOSE) up -d --wait

--- a/tests/ccm_wrapper/ccm.rs
+++ b/tests/ccm_wrapper/ccm.rs
@@ -1,0 +1,397 @@
+//! Simple CLI ccm wrapper intended for testing network traffic.
+//!
+//! To create and start a cluster, build a topology (see [`TopologySpecBuilder`] for how to construct a topology), then:
+//! ```no_run
+//! let mut cluster = Ccm::create_cluster(name, &topology, ip_prefix, 8000, scylla_version).unwrap();
+//! Ccm::start_cluster(&mut cluster).unwrap();
+//! ```
+//! This will create a cluster of given topology with alternator running on every node on the same address as a node and given port.
+//!
+
+use crate::ccm_wrapper::cluster::*;
+use crate::ccm_wrapper::topology_spec::*;
+use anyhow::Context;
+use itertools::Itertools;
+use std::ffi::OsStr;
+use std::ops::{Deref, DerefMut};
+use std::process::{Command, Output, Stdio};
+
+pub(crate) struct Ccm;
+
+impl Ccm {
+    // Logic behind cluster creation comes from the way ccm operates. Initially it creates given amount of datacenters,
+    // each with 1 rack and given amount of nodes on it. For example ccm create -n 2:1:2 would result in the following structure:
+    // dc1
+    //     RAC1
+    //         node1
+    //         node2
+    // dc2
+    //     RAC1
+    //         node3
+    // dc3
+    //     RAC1
+    //         node4
+    //         node5
+    // Nodes are given names and ips ordered by datacenters. Ips are of the form prefix{n} where n is the index of the node.
+    // Adding node on a different rack than the first one, has to be done with ccm add with --data-center and --rack.
+    // That means, that when we want to create cluster with, for example 3 datacenters, each with 2 nodes on the first rack, 1 on second, and 1 on third,
+    // we first have to run ccm create -n 2:2:2 and then 6 times ccm add. Since first nodes have imposed names and ips, in order to be consistent
+    // we give the nodes that are being added, the first free ip with given prefix and matching name. This means that we end up with:
+    // dc1
+    //     RAC1
+    //         node1
+    //         node2
+    //     RAC2
+    //         node7
+    //     RAC3
+    //         node8
+    // dc2
+    //     RAC1
+    //         node3
+    //         node4
+    //     RAC2
+    //         node9
+    //     RAC3
+    //         node10
+    // dc3
+    //     RAC1
+    //         node5
+    //         node6
+    //     RAC2
+    //         node11
+    //     RAC3
+    //         node12
+    pub(crate) fn create_cluster(
+        cluster_name: String,
+        topology: &TopologySpec,
+        ip_prefix: IpPrefix,
+        alternator_port: u16,
+        scylla_version: String,
+    ) -> anyhow::Result<Cluster> {
+        // String of form nodes_in_dc1_RAC1:nodes_in_dc2_RAC1:nodes_in_dc3_RAC1...
+        let first_rack_nodes_per_dc = topology.datacenters.iter().map(|dc| dc.racks[0]).join(":");
+
+        CcmCommandRunner::create_cluster(
+            &cluster_name,
+            &first_rack_nodes_per_dc,
+            ip_prefix.as_str(),
+            &scylla_version,
+        )?;
+
+        match Self::create_cluster_impl(
+            cluster_name.clone(),
+            ip_prefix,
+            topology,
+            scylla_version,
+            alternator_port,
+        ) {
+            Ok(cluster) => Ok(cluster),
+            Err(e) => {
+                let err = e.context("Cluster creation failed.");
+                // Cluster is already existing so it needs to be removed.
+                match CcmCommandRunner::remove_cluster(&cluster_name) {
+                    Ok(_) => Err(err),
+                    Err(remove_error) => Err(err.context(format!(
+                        "Failed to clean up after error during creation: {remove_error}"
+                    ))),
+                }
+            }
+        }
+    }
+
+    fn create_cluster_impl(
+        cluster_name: String,
+        ip_prefix: IpPrefix,
+        topology: &TopologySpec,
+        scylla_version: String,
+        alternator_port: u16,
+    ) -> anyhow::Result<Cluster> {
+        let mut cluster = Cluster::new(cluster_name, ip_prefix, scylla_version);
+
+        let total_first_rack_nodes: usize = topology.datacenters.iter().map(|dc| dc.racks[0]).sum();
+
+        // These 2 counters determine the index (and thus name/IP) of each node.
+        // Nodes in RAC1 of each datacenter are created by ccm create and receive indices 1..=total_first_rack_nodes,
+        // so we track them separately with first_rack_nodes_count. This is necessary, because we still have
+        // to attach alternator to them with ccm {node_name} updateconf.
+        // Nodes on additional racks are added later with ccm add and receive
+        // indices starting from total_first_rack_nodes+1, tracked by total_nodes_count.
+        let mut first_rack_nodes_count: usize = 0;
+        let mut total_nodes_count: usize = total_first_rack_nodes;
+
+        // We can't run add node asynchronously because of race condition to cluster.conf file, but we can do it with updateconf.
+        // Once the node is added, alternator adding process is spawned. Here we keep all these processes and wait on them later.
+        let mut pending_updateconfs = BatchCcmHandler::new("updateconf");
+
+        // Run the main cluster-building logic in a closure so that we can
+        // always run wait_all() afterwards, even if an error occurs.
+        let main_result: anyhow::Result<()> = (|| {
+            for (datacenter_idx, datacenter_spec) in topology.datacenters.iter().enumerate() {
+                let dc_name = format!("dc{}", datacenter_idx + 1);
+                let mut datacenter = Datacenter::new(dc_name.clone());
+                for (rack_idx, nodes_num) in datacenter_spec.racks.iter().enumerate() {
+                    let rack_name = format!("RAC{}", rack_idx + 1);
+                    let mut rack = Rack::new(rack_name.clone());
+                    for _ in 0..*nodes_num {
+                        let node_idx = match rack_idx {
+                            0 => {
+                                first_rack_nodes_count += 1;
+                                first_rack_nodes_count
+                            }
+                            _ => {
+                                total_nodes_count += 1;
+                                total_nodes_count
+                            }
+                        };
+                        let ip = format!("{}{}", cluster.ip_prefix.as_str(), node_idx);
+                        let node_name = format!("node{}", node_idx);
+                        // If node is not on the first rack, we create it.
+                        if rack_idx > 0 {
+                            CcmCommandRunner::add_node(&node_name, &ip, &dc_name, &rack_name)?;
+                        }
+                        let node = Node::new(node_name, ip, alternator_port);
+                        let child = Self::add_alternator_to_node(&node)?;
+                        pending_updateconfs.push(node.name.clone(), child);
+                        rack.add_node(node);
+                    }
+                    datacenter.add_rack(rack);
+                }
+                cluster.add_datacenter(datacenter);
+            }
+            Ok(())
+        })();
+        let wait_result = pending_updateconfs.wait_all();
+        match (main_result, wait_result) {
+            (Ok(()), Ok(())) => Ok(cluster),
+            (Err(e), Ok(())) => Err(e),
+            (Ok(()), Err(e)) => Err(e),
+            (Err(e1), Err(e2)) => Err(e1.context(format!(
+                "Additionally, waiting for pending 'ccm updateconf' processes failed: {e2}"
+            ))),
+        }
+    }
+
+    pub(crate) fn remove_cluster(cluster: &mut Cluster) -> anyhow::Result<()> {
+        CcmCommandRunner::remove_cluster(&cluster.name)
+    }
+
+    pub(crate) fn start_cluster(cluster: &mut Cluster) -> anyhow::Result<()> {
+        CcmCommandRunner::start_cluster()?;
+
+        cluster.is_up = true;
+        for node in cluster.nodes_mut() {
+            node.is_up = true;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn stop_cluster(cluster: &mut Cluster) -> anyhow::Result<()> {
+        CcmCommandRunner::stop_cluster()?;
+        cluster.is_up = false;
+        for node in cluster.nodes_mut() {
+            node.is_up = false;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn stop_node(node: &mut Node) -> anyhow::Result<()> {
+        CcmCommandRunner::stop_node(&node.name)?;
+        node.is_up = false;
+        Ok(())
+    }
+
+    pub(crate) fn start_node(node: &mut Node) -> anyhow::Result<()> {
+        CcmCommandRunner::start_node(&node.name)?;
+        node.is_up = true;
+        Ok(())
+    }
+
+    fn add_alternator_to_node(node: &Node) -> anyhow::Result<std::process::Child> {
+        let address = format!("alternator_address:{}", node.ip);
+        let port = format!("alternator_port:{}", node.alternator_port);
+        CcmCommandRunner::spawn_update_node_conf(
+            &node.name,
+            &[&address, &port, "alternator_write_isolation:always"],
+        )
+    }
+}
+
+// Struct used to communicate with cli.
+pub(crate) struct CcmCommandRunner;
+
+impl CcmCommandRunner {
+    fn run<I, S>(args: I) -> anyhow::Result<()>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let args: Vec<std::ffi::OsString> = args
+            .into_iter()
+            .map(|a| a.as_ref().to_os_string())
+            .collect();
+
+        let command_str = format!("ccm {}", args.iter().map(|a| a.to_string_lossy()).join(" "));
+        let output: Output = Command::new("ccm")
+            .args(args)
+            .output()
+            .with_context(|| format!("Failed to run {}", command_str))?;
+
+        // ccm outputs errors on stdout.
+        anyhow::ensure!(
+            output.status.success(),
+            "\nCommand failed: {}\nccm error message: {}",
+            command_str,
+            String::from_utf8_lossy(&output.stdout),
+        );
+
+        Ok(())
+    }
+
+    fn create_cluster(
+        cluster_name: &str,
+        first_rack_nodes_per_dc: &str,
+        ip_prefix: &str,
+        scylla_version: &str,
+    ) -> anyhow::Result<()> {
+        Self::run([
+            "create",
+            cluster_name,
+            "-n",
+            first_rack_nodes_per_dc,
+            "-i",
+            ip_prefix,
+            "--scylla",
+            "-v",
+            scylla_version,
+        ])
+    }
+
+    fn add_node(node_name: &str, ip: &str, dc_name: &str, rack_name: &str) -> anyhow::Result<()> {
+        Self::run([
+            "add",
+            node_name,
+            "-i",
+            ip,
+            "--data-center",
+            dc_name,
+            "--rack",
+            rack_name,
+            "--scylla",
+        ])
+    }
+
+    // The start/stop commands do not take any arguments, they just run on currently active cluster.
+    // Newly created cluster automatically becomes the active one and it remains after stopping
+    // which allows us to reset the clusters during tests.
+    fn start_cluster() -> anyhow::Result<()> {
+        Self::run(["start", "--wait-for-binary-proto", "--wait-other-notice"])
+    }
+
+    fn stop_cluster() -> anyhow::Result<()> {
+        Self::run(["stop"])
+    }
+
+    fn stop_node(node_name: &str) -> anyhow::Result<()> {
+        Self::run([node_name, "stop"])
+    }
+
+    fn start_node(node_name: &str) -> anyhow::Result<()> {
+        Self::run([
+            node_name,
+            "start",
+            "--wait-for-binary-proto",
+            "--wait-other-notice",
+        ])
+    }
+
+    fn remove_cluster(cluster_name: &str) -> anyhow::Result<()> {
+        Self::run(["remove", cluster_name])
+    }
+
+    // This command is run by different processes to speed up cluster creation.
+    // It can be done safely because each process only changes 1 separate config file.
+    fn spawn_update_node_conf(
+        node_name: &str,
+        conf: &[&str],
+    ) -> anyhow::Result<std::process::Child> {
+        let mut args: Vec<&str> = vec![node_name, "updateconf"];
+        args.extend_from_slice(conf);
+
+        let command_str = format!("ccm {}", args.join(" "));
+        Command::new("ccm")
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .with_context(|| format!("Failed to spawn: {}", command_str))
+    }
+}
+
+// This struct is used to handle child processes spawned by ccm.
+pub(crate) struct BatchCcmHandler {
+    command: String,
+    // Node name and process.
+    pending: Vec<(String, std::process::Child)>,
+}
+
+impl BatchCcmHandler {
+    fn new(command: &str) -> Self {
+        Self {
+            command: command.to_string(),
+            pending: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, node_name: String, child: std::process::Child) {
+        self.pending.push((node_name, child));
+    }
+
+    fn wait_all(self) -> anyhow::Result<()> {
+        let mut errors: Vec<String> = Vec::new();
+        for (node_name, child) in self.pending {
+            match child.wait_with_output() {
+                Ok(output) if output.status.success() => {}
+                Ok(output) => {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    errors.push(format!(
+                        "{} for {} failed: {}",
+                        self.command, node_name, stdout
+                    ))
+                }
+                Err(e) => errors.push(format!(
+                    "{} for {} wait failed: {}",
+                    self.command, node_name, e
+                )),
+            }
+        }
+        anyhow::ensure!(
+            errors.is_empty(),
+            "Some {} commands failed:\n{}",
+            self.command,
+            errors.join("\n")
+        );
+        Ok(())
+    }
+}
+
+// Guard for Cluster that removes the cluster on drop.
+pub(crate) struct ClusterGuard(pub(crate) Cluster);
+
+impl Deref for ClusterGuard {
+    type Target = Cluster;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for ClusterGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+impl Drop for ClusterGuard {
+    fn drop(&mut self) {
+        let _ = Ccm::remove_cluster(&mut self.0);
+    }
+}

--- a/tests/ccm_wrapper/cluster.rs
+++ b/tests/ccm_wrapper/cluster.rs
@@ -1,0 +1,232 @@
+use anyhow::Context;
+
+// Struct for ip prefix of form X.X.X.
+#[derive(Debug, Clone)]
+pub(crate) struct IpPrefix(String);
+
+impl IpPrefix {
+    pub(crate) fn new(ip_prefix: &str) -> anyhow::Result<Self> {
+        Self::validate_ip_prefix(ip_prefix)?;
+        Ok(Self(ip_prefix.to_string()))
+    }
+    fn validate_ip_prefix(ip_prefix: &str) -> anyhow::Result<()> {
+        let prefix = ip_prefix
+            .strip_suffix('.')
+            .context("IP prefix must end with '.'")?;
+
+        let octets: Vec<&str> = prefix.split('.').collect();
+        anyhow::ensure!(
+            octets.len() == 3,
+            "IP prefix must have exactly 3 octets, got {}",
+            octets.len()
+        );
+
+        for octet in octets {
+            octet
+                .parse::<u8>()
+                .with_context(|| format!("Invalid octet '{}' in IP prefix", octet))?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Node {
+    pub(crate) name: String,
+    pub(crate) ip: String,
+    pub(crate) alternator_port: u16,
+    pub(crate) is_up: bool,
+}
+
+impl Node {
+    pub(crate) fn new(name: String, ip: String, alternator_port: u16) -> Self {
+        Self {
+            name,
+            ip,
+            alternator_port,
+            is_up: false,
+        }
+    }
+
+    pub(crate) fn address(&self) -> String {
+        format!("http://{}:{}", &self.ip, &self.alternator_port)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Rack {
+    pub(crate) name: String,
+    nodes: Vec<Node>,
+}
+
+impl Rack {
+    pub(crate) fn new(name: String) -> Self {
+        Self {
+            name,
+            nodes: Vec::new(),
+        }
+    }
+
+    pub(crate) fn node_ips(&self) -> Vec<&str> {
+        self.nodes.iter().map(|node| node.ip.as_str()).collect()
+    }
+
+    pub(crate) fn working_nodes_ips(&self) -> Vec<&str> {
+        self.nodes
+            .iter()
+            .filter(|node| node.is_up)
+            .map(|node| node.ip.as_str())
+            .collect()
+    }
+
+    pub(crate) fn add_node(&mut self, node: Node) {
+        self.nodes.push(node);
+    }
+
+    pub(crate) fn first_working_node_address(&self) -> Option<String> {
+        self.nodes
+            .iter()
+            .find(|node| node.is_up)
+            .map(|node| node.address())
+    }
+
+    pub(crate) fn nodes(&self) -> &[Node] {
+        &self.nodes
+    }
+
+    pub(crate) fn nodes_mut(&mut self) -> &mut [Node] {
+        &mut self.nodes
+    }
+
+    pub(crate) fn node_mut(&mut self, node_idx: usize) -> Option<&mut Node> {
+        self.nodes_mut().get_mut(node_idx)
+    }
+}
+
+pub(crate) struct Datacenter {
+    pub(crate) name: String,
+    racks: Vec<Rack>,
+}
+
+impl Datacenter {
+    pub(crate) fn new(name: String) -> Self {
+        Self {
+            name,
+            racks: Vec::new(),
+        }
+    }
+
+    pub(crate) fn add_rack(&mut self, rack: Rack) {
+        self.racks.push(rack);
+    }
+
+    pub(crate) fn node_ips(&self) -> Vec<&str> {
+        self.racks
+            .iter()
+            .flat_map(|rack| rack.nodes.iter())
+            .map(|node| node.ip.as_str())
+            .collect()
+    }
+
+    pub(crate) fn working_nodes_ips(&self) -> Vec<&str> {
+        self.racks
+            .iter()
+            .flat_map(|rack| rack.nodes.iter())
+            .filter(|node| node.is_up)
+            .map(|node| node.ip.as_str())
+            .collect()
+    }
+
+    pub(crate) fn first_working_node_address(&self) -> Option<String> {
+        self.racks
+            .iter()
+            .flat_map(|rack| rack.nodes.iter())
+            .find(|node| node.is_up)
+            .map(|node| node.address())
+    }
+
+    pub(crate) fn racks(&self) -> &[Rack] {
+        &self.racks
+    }
+
+    pub(crate) fn racks_mut(&mut self) -> &mut [Rack] {
+        &mut self.racks
+    }
+
+    pub(crate) fn node_mut(&mut self, rack_idx: usize, node_idx: usize) -> Option<&mut Node> {
+        self.racks.get_mut(rack_idx)?.node_mut(node_idx)
+    }
+}
+
+pub(crate) struct Cluster {
+    pub(crate) name: String,
+    pub(crate) ip_prefix: IpPrefix,
+    pub(crate) datacenters: Vec<Datacenter>,
+    pub(crate) scylla_version: String,
+    pub(crate) is_up: bool,
+}
+
+impl Cluster {
+    pub(crate) fn new(name: String, ip_prefix: IpPrefix, scylla_version: String) -> Self {
+        Self {
+            name,
+            ip_prefix,
+            datacenters: Vec::new(),
+            is_up: false,
+            scylla_version,
+        }
+    }
+
+    pub(crate) fn add_datacenter(&mut self, datacenter: Datacenter) {
+        self.datacenters.push(datacenter);
+    }
+
+    pub(crate) fn nodes(&self) -> Vec<&Node> {
+        self.datacenters
+            .iter()
+            .flat_map(|dc| dc.racks().iter())
+            .flat_map(|rack| rack.nodes().iter())
+            .collect()
+    }
+
+    pub(crate) fn node_mut(
+        &mut self,
+        datacenter_idx: usize,
+        rack_idx: usize,
+        node_idx: usize,
+    ) -> Option<&mut Node> {
+        self.datacenters
+            .get_mut(datacenter_idx)?
+            .node_mut(rack_idx, node_idx)
+    }
+
+    pub(crate) fn nodes_mut(&mut self) -> Vec<&mut Node> {
+        self.datacenters
+            .iter_mut()
+            .flat_map(|dc| dc.racks_mut())
+            .flat_map(|rack| rack.nodes_mut())
+            .collect()
+    }
+
+    // This function will be used during testing load balancing when starting proxy on each node.
+    // It will make drivers requests to go through proxy,
+    // that will be running on the same address as node but different port.
+    pub(crate) fn update_all_nodes_port(&mut self, port: u16) {
+        for node in self.nodes_mut() {
+            node.alternator_port = port;
+        }
+    }
+
+    pub(crate) fn datacenters(&self) -> &[Datacenter] {
+        &self.datacenters
+    }
+
+    pub(crate) fn datacenters_mut(&mut self) -> &mut [Datacenter] {
+        &mut self.datacenters
+    }
+}

--- a/tests/ccm_wrapper/mod.rs
+++ b/tests/ccm_wrapper/mod.rs
@@ -1,0 +1,4 @@
+#![allow(dead_code)]
+pub(crate) mod ccm;
+pub(crate) mod cluster;
+pub(crate) mod topology_spec;

--- a/tests/ccm_wrapper/topology_spec.rs
+++ b/tests/ccm_wrapper/topology_spec.rs
@@ -1,0 +1,84 @@
+//! Tools for creating topology passed to cluster creation.
+//!
+//! ```no_run
+//! let topology = TopologySpecBuilder::new()
+//!     .datacenter(DatacenterSpec::new().rack(1).rack(1))
+//!     .datacenter(DatacenterSpec::new().rack(1).rack(2).rack(3))
+//!     .datacenter(DatacenterSpec::new().rack(1))
+//!     .build();
+//! ```
+
+pub(crate) struct TopologySpec {
+    pub(crate) datacenters: Vec<DatacenterSpec>,
+}
+
+pub(crate) struct DatacenterSpec {
+    pub(crate) racks: Vec<usize>,
+}
+
+impl DatacenterSpec {
+    pub(crate) fn new() -> Self {
+        Self { racks: Vec::new() }
+    }
+
+    pub(crate) fn rack(mut self, node_count: usize) -> Self {
+        self.racks.push(node_count);
+        self
+    }
+}
+
+pub(crate) struct TopologySpecBuilder {
+    datacenters: Vec<DatacenterSpec>,
+}
+
+impl TopologySpecBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            datacenters: Vec::new(),
+        }
+    }
+
+    pub(crate) fn datacenter(mut self, dc: DatacenterSpec) -> Self {
+        self.datacenters.push(dc);
+        self
+    }
+
+    pub(crate) fn build(self) -> anyhow::Result<TopologySpec> {
+        Self::validate(&self.datacenters)?;
+        Ok(TopologySpec {
+            datacenters: self.datacenters,
+        })
+    }
+
+    fn validate(datacenters: &[DatacenterSpec]) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !datacenters.is_empty(),
+            "Topology must have at least one datacenter"
+        );
+        let mut total_nodes_count: usize = 0;
+        for (dc_idx, dc) in datacenters.iter().enumerate() {
+            anyhow::ensure!(
+                !dc.racks.is_empty(),
+                "Datacenter dc{} must have at least one rack",
+                dc_idx + 1
+            );
+            for (rack_idx, &node_count) in dc.racks.iter().enumerate() {
+                anyhow::ensure!(
+                    node_count >= 1,
+                    "Rack RAC{} in dc{} must have at least one node",
+                    rack_idx + 1,
+                    dc_idx + 1
+                );
+                total_nodes_count += node_count;
+            }
+        }
+
+        // Every node needs its own ip, so the limit is max value of the last octet.
+        anyhow::ensure!(
+            total_nodes_count <= usize::from(u8::MAX),
+            "Too many nodes in cluster"
+        );
+
+        Ok(())
+    }
+}

--- a/tests/ccm_wrapper_tests.rs
+++ b/tests/ccm_wrapper_tests.rs
@@ -1,0 +1,1 @@
+mod ccm_wrapper;

--- a/tests/ccm_wrapper_tests.rs
+++ b/tests/ccm_wrapper_tests.rs
@@ -1,1 +1,212 @@
 mod ccm_wrapper;
+
+use crate::ccm_wrapper::ccm::*;
+use crate::ccm_wrapper::cluster::*;
+use crate::ccm_wrapper::topology_spec::*;
+
+// GET request on node with alternator can only return "healthy".
+// Therefore if it did not refuse the connection - it is up.
+async fn is_node_up(node: &Node) -> Result<bool, reqwest::Error> {
+    Ok(reqwest::get(node.address()).await.is_ok())
+}
+
+async fn get_localnodes(url: &str) -> Result<Vec<String>, reqwest::Error> {
+    let response = reqwest::get(url).await?;
+    let nodes = response.json::<Vec<String>>().await?;
+    Ok(nodes)
+}
+
+// Test to verify if cluster matches the given topology.
+fn verify_correctness_with_topology(
+    cluster: &Cluster,
+    topology_spec: &TopologySpec,
+) -> Result<(), String> {
+    if cluster.datacenters().len() != topology_spec.datacenters.len() {
+        return Err(format!(
+            "Datacenter count mismatch. cluster: {}, topology: {}",
+            cluster.datacenters().len(),
+            topology_spec.datacenters.len()
+        ));
+    }
+
+    for (datacenter_idx, datacenter) in cluster.datacenters().iter().enumerate() {
+        if datacenter.racks().len() != topology_spec.datacenters[datacenter_idx].racks.len() {
+            return Err(format!(
+                "Rack count mismatch in {}. cluster: {}, topology: {}",
+                datacenter.name,
+                datacenter.racks().len(),
+                topology_spec.datacenters[datacenter_idx].racks.len()
+            ));
+        }
+        for (rack_idx, rack) in datacenter.racks().iter().enumerate() {
+            if rack.nodes().len() != topology_spec.datacenters[datacenter_idx].racks[rack_idx] {
+                return Err(format!(
+                    "Node count mismatch in {}/{}. cluster: {}, topology: {}",
+                    datacenter.name,
+                    rack.name,
+                    rack.nodes().len(),
+                    topology_spec.datacenters[datacenter_idx].racks[rack_idx]
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+// Test to see if real cluster matches the cluster struct, using localnodes API.
+async fn verify_correctness_with_localnodes(
+    cluster: &Cluster,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for datacenter in cluster.datacenters().iter() {
+        let dc_localnodes_url = format!(
+            "{}/localnodes?dc={}",
+            // Take the first node address for the localnodes url.
+            datacenter.racks()[0].nodes()[0].address(),
+            datacenter.name
+        );
+
+        let localnodes: Vec<String> = get_localnodes(&dc_localnodes_url).await?;
+
+        let mut localnodes: Vec<&str> = localnodes.iter().map(|s| s.as_str()).collect();
+        let mut dc_node_ips: Vec<&str> = datacenter.node_ips();
+
+        dc_node_ips.sort();
+        localnodes.sort();
+
+        if dc_node_ips != localnodes {
+            return Err(format!(
+                "mismatch in {}.\n Nodes in the cluster structure: {:?},\n list returned by localnodes: {:?}",
+                datacenter.name, dc_node_ips, localnodes
+            ).into());
+        }
+
+        for rack in datacenter.racks().iter() {
+            let rack_localnodes_url = format!(
+                "{}/localnodes?dc={}&rack={}",
+                rack.nodes()[0].address(),
+                datacenter.name,
+                rack.name
+            );
+
+            let localnodes: Vec<String> = get_localnodes(&rack_localnodes_url).await?;
+
+            let mut localnodes: Vec<&str> = localnodes.iter().map(|s| s.as_str()).collect();
+            let mut rack_node_ips: Vec<&str> = rack.node_ips();
+
+            rack_node_ips.sort();
+            localnodes.sort();
+
+            if rack_node_ips != localnodes {
+                return Err(format!(
+                    "mismatch in {}/{}.\n Nodes in the cluster structure: {:?},\n list returned by localnodes: {:?}",
+                    datacenter.name, rack.name, rack_node_ips, localnodes
+                ).into());
+            }
+        }
+    }
+    Ok(())
+}
+
+// Check if the actual state of nodes corresponds to their node.is_up value.
+async fn check_if_correct_nodes_are_up(
+    cluster: &Cluster,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for node in cluster.nodes().iter() {
+        let is_really_up = is_node_up(node).await?;
+
+        if node.is_up != is_really_up {
+            return Err(format!(
+                "{} inconsistency found, node.is_up is {}, but should be {}",
+                node.name, node.is_up, is_really_up
+            )
+            .into());
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+// Tests that are using ccm are marked with this attribute.
+// They are ignored by default, and only are run when the ccm_tests flag is set:
+// RUSTFLAGS='--cfg ccm_tests' cargo test
+// It allows running simpler tests, ones that do not need a special cluster setup to be run without involving ccm.
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn ccm_wrapper_test_cluster() -> Result<(), Box<dyn std::error::Error>> {
+    let topology = TopologySpecBuilder::new()
+        .datacenter(DatacenterSpec::new().rack(1))
+        .datacenter(DatacenterSpec::new().rack(1).rack(2))
+        .build()?;
+
+    let ip_prefix = IpPrefix::new("127.0.1.")?;
+    let cluster_name = uuid::Uuid::new_v4().to_string();
+    let scylla_version = String::from("release:2025.1");
+
+    let mut cluster = ClusterGuard(Ccm::create_cluster(
+        cluster_name,
+        &topology,
+        ip_prefix,
+        8000,
+        scylla_version,
+    )?);
+
+    verify_correctness_with_topology(&cluster, &topology)?;
+    check_if_correct_nodes_are_up(&cluster).await?;
+
+    Ccm::start_cluster(&mut cluster)?;
+
+    verify_correctness_with_localnodes(&cluster).await?;
+    check_if_correct_nodes_are_up(&cluster).await?;
+
+    let node1_1_1 = cluster.node_mut(0, 0, 0).unwrap();
+    Ccm::stop_node(node1_1_1)?;
+
+    let node2_2_1 = cluster.node_mut(1, 1, 0).unwrap();
+    Ccm::stop_node(node2_2_1)?;
+
+    check_if_correct_nodes_are_up(&cluster).await?;
+
+    let node1_1_1 = cluster.node_mut(0, 0, 0).unwrap();
+    Ccm::start_node(node1_1_1)?;
+
+    check_if_correct_nodes_are_up(&cluster).await?;
+
+    let node2_2_1 = cluster.node_mut(1, 1, 0).unwrap();
+    Ccm::start_node(node2_2_1)?;
+
+    check_if_correct_nodes_are_up(&cluster).await?;
+
+    Ccm::stop_cluster(&mut cluster)?;
+
+    check_if_correct_nodes_are_up(&cluster).await?;
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(not(ccm_tests), ignore)]
+fn ccm_wrapper_test_invalid_topology() {
+    // Empty cluster.
+    let result = TopologySpecBuilder::new().build();
+    assert!(result.is_err());
+
+    // Empty datacenter.
+    let result = TopologySpecBuilder::new()
+        .datacenter(DatacenterSpec::new())
+        .datacenter(DatacenterSpec::new().rack(1).rack(2))
+        .build();
+    assert!(result.is_err());
+
+    // Empty rack
+    let result = TopologySpecBuilder::new()
+        .datacenter(DatacenterSpec::new().rack(1))
+        .datacenter(DatacenterSpec::new().rack(1).rack(0))
+        .build();
+    assert!(result.is_err());
+
+    // Too many nodes.
+    let result = TopologySpecBuilder::new()
+        .datacenter(DatacenterSpec::new().rack(20000))
+        .datacenter(DatacenterSpec::new().rack(1).rack(2))
+        .build();
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Introduces a CCM wrapper for programmatically creating and managing ScyllaDB Alternator clusters for use in load balancing and integration tests.

Key features:
        - creating a cluster based on a given topology specification,
        - starting, stopping and removing clusters,
        - stopping and starting nodes in order to test Driver's ability to handle failovers,
        - overriding the Alternator port for all nodes allowing traffic redirection through proxy during tests.

