### PR TITLE
Simplify docker setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ccm-wrapper-tests:
 up:
 	$(COMPOSE) up -d --wait
 	@echo
-	@echo "A 2-node cluster is running in the background. Use 'make down' to stop it and remove all the volumes."
+	@echo "1 scylla node is running in the background. Use 'make down' to stop it and remove its volume."
 	@echo
 
 .PHONY: down
@@ -47,11 +47,11 @@ logs:
 
 .PHONY: cqlsh
 cqlsh:
-	$(COMPOSE) exec scylla1 cqlsh -u cassandra -p cassandra
+	$(COMPOSE) exec scylla_node cqlsh -u cassandra -p cassandra
 
 .PHONY: shell
 shell:
-	$(COMPOSE) exec scylla1 bash
+	$(COMPOSE) exec scylla_node bash
 
 .PHONY: volumes
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,49 +1,25 @@
 networks:
   default:
-    name: scylla_2_nodes
+    name: scylla_network
 services:
-  scylla1:
+  scylla_node:
     image: scylladb/scylla
-    container_name: scylla1
+    container_name: scylla_node
     command: |
       --smp 1
       --memory 1G
       --developer-mode 1
       --overprovisioned 1
       --alternator-write-isolation always
-      --listen-address scylla1
-      --rpc-address scylla1
+      --listen-address scylla_node
+      --rpc-address scylla_node
       --alternator-port 8000
-      --seeds scylla1
+      --seeds scylla_node
     ports:
       - "9042:9042"
       - "8000:8000"
     healthcheck:
-      test: [ "CMD", "cqlsh", "scylla1", "-e", "select * from system.local WHERE key='local'" ]
-      interval: 5s
-      timeout: 5s
-      retries: 60
-  scylla2:
-    image: scylladb/scylla
-    container_name: scylla2
-    command: |
-      --smp 1
-      --memory 1G
-      --developer-mode 1
-      --overprovisioned 1
-      --alternator-write-isolation always
-      --listen-address scylla2
-      --rpc-address scylla2
-      --alternator-port 8000
-      --seeds scylla1
-    ports:
-      - "9043:9042"
-      - "8001:8000"
-    depends_on:
-      scylla1:
-        condition: service_healthy
-    healthcheck:
-      test: [ "CMD", "cqlsh", "scylla2", "-e", "select * from system.local WHERE key='local'" ]
+      test: [ "CMD", "cqlsh", "scylla_node", "-e", "select * from system.local WHERE key='local'" ]
       interval: 5s
       timeout: 5s
       retries: 60


### PR DESCRIPTION
Currently, we set up 2 scylla nodes using docker.
This is too much, we need only one.

Closes #13