### PR TITLE
Add round-robin load balancing

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v5
     - name: Install scylla-ccm
       run: pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
-    - name: CCM wrapper tests
-      run: make ccm-wrapper-tests
+    - name: CCM tests
+      run: make ccm-tests
     - name: Tests
       run: make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ aws-smithy-runtime = "1.9.8"
 aws-smithy-runtime-api = "1.10.0"
 aws-types = "1.3.11"
 aws-runtime = "1.5.18"
+tokio = { version = "1", features = ["full"] }
 aws-smithy-types = "1.3.6"
 flate2 = "1.1.5"
 http-body-util = "0.1"
@@ -17,12 +18,13 @@ anyhow = "1.0.102"
 itertools = "0.14.0"
 reqwest = { version = "0.11", features = ["json"] }
 url = "2.5.8"
+arc-swap = "1.9.1"
+rand = "0.10.1"
 
 [dev-dependencies]
 aws-sdk-dynamodb = { version = "1.103.0", features = ["test-util"] }
 aws-smithy-types = { version = "1.3.6", features = ["http-body-1-x"] }
 aws-smithy-http-client = "1.1.5"
-tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.22.0", features = ["v4"] }
 hyper = { version = "1.8", features = ["client", "server", "http1"] }
 http = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ http-body-util = "0.1"
 anyhow = "1.0.102"
 itertools = "0.14.0"
 reqwest = { version = "0.11", features = ["json"] }
+url = "2.5.8"
 
 [dev-dependencies]
 aws-sdk-dynamodb = { version = "1.103.0", features = ["test-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ futures = "0.3.31"
 test-context = "0.5.5"
 rustdoc-types = "0.56.0"
 serde_json = "1.0"
+ctor = "0.8.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,14 @@ clippy:
 test: up
 	cargo test
 
-.PHONY: ccm-wrapper-tests
+.PHONY: ccm-wrapper-tests load-balancing-tests ccm-tests
 ccm-wrapper-tests:
 	RUSTFLAGS="--cfg ccm_tests" cargo test --test ccm_wrapper_tests -- --nocapture
+
+load-balancing-tests:
+	RUSTFLAGS="--cfg ccm_tests" cargo test --test load_balancing_tests -- --nocapture
+
+ccm-tests: ccm-wrapper-tests load-balancing-tests
 
 .PHONY: up
 up:

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,6 @@ impl AlternatorClient {
 
         let request_compression = extensions.request_compression.unwrap_or_default();
         let enforce_header_whitelist = extensions.enforce_header_whitelist.unwrap_or(true);
-
         let has_region = dynamodb_config.region().is_some();
 
         let mut dynamodb_config =
@@ -39,6 +38,12 @@ impl AlternatorClient {
                     enforce_header_whitelist,
                 ));
 
+        let live_nodes = LiveNodes::new(&config);
+        if let Some(nodes) = &live_nodes {
+            dynamodb_config =
+                dynamodb_config.interceptor(RoundRobinQueryPlanInterceptor::new(nodes.clone()));
+        }
+
         if !has_region {
             dynamodb_config.set_region(Some(aws_sdk_dynamodb::config::Region::from_static(
                 "us-east-1",
@@ -47,6 +52,10 @@ impl AlternatorClient {
 
         let dynamodb_config = dynamodb_config.build();
         let dynamodb_client = aws_sdk_dynamodb::Client::from_conf(dynamodb_config);
+
+        if let Some(nodes) = live_nodes {
+            nodes.start();
+        }
 
         Self {
             dynamodb_client,

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,6 @@ impl AlternatorClient {
 
         let request_compression = extensions.request_compression.unwrap_or_default();
         let enforce_header_whitelist = extensions.enforce_header_whitelist.unwrap_or(true);
-
         let has_region = dynamodb_config.region().is_some();
 
         let mut dynamodb_config =
@@ -39,6 +38,12 @@ impl AlternatorClient {
                     enforce_header_whitelist,
                 ));
 
+        let live_nodes = LiveNodes::new(&config);
+        if let Some(nodes) = &live_nodes {
+            dynamodb_config =
+                dynamodb_config.interceptor(RoundRobinQueryPlanInterceptor::new(nodes.clone()));
+        }
+
         if !has_region {
             dynamodb_config.set_region(Some(aws_sdk_dynamodb::config::Region::from_static(
                 "us-east-1",
@@ -47,6 +52,10 @@ impl AlternatorClient {
 
         let dynamodb_config = dynamodb_config.build();
         let dynamodb_client = aws_sdk_dynamodb::Client::from_conf(dynamodb_config);
+
+        if let Some(nodes) = live_nodes {
+            nodes.ensure_discovery_started();
+        }
 
         Self {
             dynamodb_client,

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,8 +4,8 @@ use crate::*;
 ///
 /// A simple wrapper around [aws_sdk_dynamodb::Client], that adds hooks with alternator-specific optimizations.
 ///
-/// By default, enables gzip request compression, strips requests from headers that are not used by alternator,
-/// and chooses an arbitrary aws region, as alternator doesn't require one.
+/// By default, enables round-robin load balancing, gzip request compression, strips requests from headers
+/// that are not used by alternator, and chooses an arbitrary aws region, as alternator doesn't require one.
 ///
 /// Can be build using [AlternatorConfig] like so:
 /// ```ignore
@@ -38,7 +38,16 @@ impl AlternatorClient {
                     enforce_header_whitelist,
                 ));
 
-        let live_nodes = LiveNodes::new(&config);
+        // If live nodes are not in config - create new config with live nodes.
+        let (config, live_nodes) = if let Some(nodes) = config.live_nodes() {
+            (config, Some(nodes))
+        } else if let Some(nodes) = LiveNodes::new(&config) {
+            let config = config.to_builder().live_nodes(nodes.clone()).build();
+            (config, Some(nodes))
+        } else {
+            (config, None)
+        };
+
         if let Some(nodes) = &live_nodes {
             dynamodb_config =
                 dynamodb_config.interceptor(RoundRobinQueryPlanInterceptor::new(nodes.clone()));
@@ -61,6 +70,13 @@ impl AlternatorClient {
             dynamodb_client,
             config,
         }
+    }
+
+    pub fn from_conf_with_live_nodes(
+        config: AlternatorConfig,
+        live_nodes: std::sync::Arc<LiveNodes>,
+    ) -> Self {
+        Self::from_conf(config.to_builder().live_nodes(live_nodes).build())
     }
 
     pub fn new(sdk_config: &aws_types::sdk_config::SdkConfig) -> Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use crate::*;
 pub(crate) struct AlternatorExtensions {
     pub(crate) request_compression: Option<RequestCompression>,
     pub(crate) enforce_header_whitelist: Option<bool>,
+    pub(crate) routing_scope: Option<RoutingScope>,
 }
 
 /// [AlternatorClient]'s config
@@ -72,6 +73,26 @@ impl AlternatorConfig {
     /// By default, Gzip compression is used, with 1024 threshold and level 6 of compression.
     pub fn request_compression(&self) -> Option<RequestCompression> {
         self.alternator_ext.request_compression.clone()
+    }
+
+    /// Get the client's routing scope.
+    ///
+    /// This is used by the client to route requests to a chosen subset of nodes in the cluster,
+    /// based on the routing scope parameters set - datacenter and rack, see [RoutingScope].
+    ///
+    /// A routing scope can have a fallback scope set by [RoutingScope::with_fallback], which is used if no nodes are available in the preferred scope.
+    /// This function can be used multiple times to create a chain of fallback scopes.
+    /// Requests will always be routed to the most preferred scope in the chain with available nodes.
+    ///
+    /// If this is not provided, the client will use the cluster scope, meaning load balancing will happen across nodes in the datacenter of the seed host.
+    /// If multiple seed hosts are provided, it will use the datacenter of one of the seed hosts, falling back to a different one if needed.
+    ///
+    /// Keep in mind that subsequent fallback scope should ideally be broader than or equal to the
+    /// previous one, e.g., (rack -> datacenter -> cluster) or (rack -> another rack -> datacenter -> cluster).
+    /// Making a fallback narrower, e.g., (datacenter -> rack) or (cluster -> datacenter),
+    /// may be redundant if the set of nodes in the next scope is a subset of the previous one.
+    pub fn routing_scope(&self) -> Option<RoutingScope> {
+        self.alternator_ext.routing_scope.clone()
     }
 }
 
@@ -160,6 +181,48 @@ impl AlternatorBuilder {
         request_compression: RequestCompression,
     ) -> &mut Self {
         self.alternator_ext.request_compression = Some(request_compression);
+        self
+    }
+
+    /// Set the routing scope for the client.
+    ///
+    /// This is used by the client to route requests to a chosen subset of nodes in the cluster,
+    /// based on the routing scope parameters set - datacenter and rack, see [RoutingScope].
+    ///
+    /// A routing scope can have a fallback scope set by [RoutingScope::with_fallback], which is used if no nodes are available in the preferred scope.
+    /// This function can be used multiple times to create a chain of fallback scopes.
+    /// Requests will always be routed to the most preferred scope in the chain with available nodes.
+    ///
+    /// If this is not provided, the client will use the cluster scope, meaning load balancing will happen across nodes in the datacenter of the seed host.
+    /// If multiple seed hosts are provided, it will use the datacenter of one of the seed hosts, falling back to a different one if needed.
+    ///
+    /// Keep in mind that subsequent fallback scope should ideally be broader than or equal to the
+    /// previous one, e.g., (rack -> datacenter -> cluster) or (rack -> another rack -> datacenter -> cluster).
+    /// Making a fallback narrower, e.g., (datacenter -> rack) or (cluster -> datacenter),
+    /// may be redundant if the set of nodes in the next scope is a subset of the previous one.
+    pub fn routing_scope(mut self, routing_scope: RoutingScope) -> Self {
+        self.set_routing_scope(routing_scope);
+        self
+    }
+
+    /// Set the routing scope for the client.
+    ///
+    /// This is used by the client to route requests to a chosen subset of nodes in the cluster,
+    /// based on the routing scope parameters set - datacenter and rack, see [RoutingScope].
+    ///
+    /// A routing scope can have a fallback scope set by [RoutingScope::with_fallback], which is used if no nodes are available in the preferred scope.
+    /// This function can be used multiple times to create a chain of fallback scopes.
+    /// Requests will always be routed to the most preferred scope in the chain with available nodes.
+    ///
+    /// If this is not provided, the client will use the cluster scope, meaning load balancing will happen across nodes in the datacenter of the seed host.
+    /// If multiple seed hosts are provided, it will use the datacenter of one of the seed hosts, falling back to a different one if needed.
+    ///
+    /// Keep in mind that subsequent fallback scope should ideally be broader than or equal to the
+    /// previous one, e.g., (rack -> datacenter -> cluster) or (rack -> another rack -> datacenter -> cluster).
+    /// Making a fallback narrower, e.g., (datacenter -> rack) or (cluster -> datacenter),
+    /// may be redundant if the set of nodes in the next scope is a subset of the previous one.
+    pub fn set_routing_scope(&mut self, routing_scope: RoutingScope) -> &mut Self {
+        self.alternator_ext.routing_scope = Some(routing_scope);
         self
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,12 @@ use crate::*;
 pub(crate) struct AlternatorExtensions {
     pub(crate) request_compression: Option<RequestCompression>,
     pub(crate) enforce_header_whitelist: Option<bool>,
+    pub(crate) active_interval: Option<u64>,
+    pub(crate) idle_interval: Option<u64>,
     pub(crate) routing_scope: Option<RoutingScope>,
+    pub(crate) scheme: Option<String>,
+    pub(crate) port: Option<u16>,
+    pub(crate) seed_hosts: Option<Vec<String>>,
 }
 
 /// [AlternatorClient]'s config
@@ -75,6 +80,14 @@ impl AlternatorConfig {
         self.alternator_ext.request_compression.clone()
     }
 
+    pub fn active_interval(&self) -> Option<u64> {
+        self.alternator_ext.active_interval
+    }
+
+    pub fn idle_interval(&self) -> Option<u64> {
+        self.alternator_ext.idle_interval
+    }
+
     /// Get the client's routing scope.
     ///
     /// This is used by the client to route requests to a chosen subset of nodes in the cluster,
@@ -94,6 +107,18 @@ impl AlternatorConfig {
     pub fn routing_scope(&self) -> Option<RoutingScope> {
         self.alternator_ext.routing_scope.clone()
     }
+
+    pub fn scheme(&self) -> Option<String> {
+        self.alternator_ext.scheme.clone()
+    }
+
+    pub fn port(&self) -> Option<u16> {
+        self.alternator_ext.port
+    }
+
+    pub fn seed_hosts(&self) -> Option<Vec<String>> {
+        self.alternator_ext.seed_hosts.clone()
+    }
 }
 
 /// Builder for [AlternatorConfig]
@@ -109,7 +134,6 @@ impl AlternatorConfig {
 ///     .build();
 ///
 /// let client = AlternatorClient::from_conf(config);
-/// ```
 #[derive(Clone, Debug, Default)]
 pub struct AlternatorBuilder {
     pub(crate) dynamodb_builder: aws_sdk_dynamodb::config::Builder,
@@ -184,6 +208,26 @@ impl AlternatorBuilder {
         self
     }
 
+    pub fn active_interval(mut self, active_interval: u64) -> Self {
+        self.set_active_interval(active_interval);
+        self
+    }
+
+    pub fn set_active_interval(&mut self, active_interval: u64) -> &mut Self {
+        self.alternator_ext.active_interval = Some(active_interval);
+        self
+    }
+
+    pub fn idle_interval(mut self, idle_interval: u64) -> Self {
+        self.set_idle_interval(idle_interval);
+        self
+    }
+
+    pub fn set_idle_interval(&mut self, idle_interval: u64) -> &mut Self {
+        self.alternator_ext.idle_interval = Some(idle_interval);
+        self
+    }
+
     /// Set the routing scope for the client.
     ///
     /// This is used by the client to route requests to a chosen subset of nodes in the cluster,
@@ -223,6 +267,40 @@ impl AlternatorBuilder {
     /// may be redundant if the set of nodes in the next scope is a subset of the previous one.
     pub fn set_routing_scope(&mut self, routing_scope: RoutingScope) -> &mut Self {
         self.alternator_ext.routing_scope = Some(routing_scope);
+        self
+    }
+
+    pub fn scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.set_scheme(scheme);
+        self
+    }
+
+    pub fn set_scheme(&mut self, scheme: impl Into<String>) -> &mut Self {
+        self.alternator_ext.scheme = Some(scheme.into());
+        self
+    }
+
+    pub fn port(mut self, port: u16) -> Self {
+        self.set_port(port);
+        self
+    }
+
+    pub fn set_port(&mut self, port: u16) -> &mut Self {
+        self.alternator_ext.port = Some(port);
+        self
+    }
+
+    pub fn seed_hosts<I, S>(mut self, seed_hosts: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.set_seed_hosts(seed_hosts.into_iter().map(Into::into).collect());
+        self
+    }
+
+    pub fn set_seed_hosts(&mut self, seed_hosts: Vec<String>) -> &mut Self {
+        self.alternator_ext.seed_hosts = Some(seed_hosts);
         self
     }
 }
@@ -633,15 +711,24 @@ impl AlternatorBuilder {
     }
 
     pub fn endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
-        self.dynamodb_builder = self.dynamodb_builder.endpoint_url(endpoint_url);
+        self.set_endpoint_url(Some(endpoint_url.into()));
         self
     }
 
     pub fn set_endpoint_url(&mut self, endpoint_url: Option<String>) -> &mut Self {
+        if let Some(url_str) = endpoint_url.as_deref()
+            && let Ok(url) = url::Url::parse(url_str)
+            && let Some(host) = url.host_str()
+        {
+            self.set_seed_hosts(vec![host.to_string()]);
+            self.set_scheme(format!("{}://", url.scheme()));
+            if let Some(port) = url.port() {
+                self.set_port(port);
+            }
+        }
         self.dynamodb_builder.set_endpoint_url(endpoint_url);
         self
     }
-
     pub fn use_dual_stack(mut self, use_dual_stack: impl Into<bool>) -> Self {
         self.dynamodb_builder = self.dynamodb_builder.use_dual_stack(use_dual_stack);
         self

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,7 +12,12 @@ use crate::*;
 pub(crate) struct AlternatorExtensions {
     pub(crate) request_compression: Option<RequestCompression>,
     pub(crate) enforce_header_whitelist: Option<bool>,
+    pub(crate) active_interval: Option<u64>,
+    pub(crate) idle_interval: Option<u64>,
     pub(crate) routing_scope: Option<RoutingScope>,
+    pub(crate) scheme: Option<String>,
+    pub(crate) port: Option<u16>,
+    pub(crate) seed_hosts: Option<Vec<String>>,
 }
 
 /// [AlternatorClient]'s config
@@ -75,6 +80,35 @@ impl AlternatorConfig {
         self.alternator_ext.request_compression.clone()
     }
 
+    /// Gets the active interval (in milliseconds) for refreshing the list of known nodes
+    /// when the client is active.
+    ///
+    /// While the client is sending requests to the cluster, the node list is refreshed at
+    /// this interval to quickly detect topology changes.
+    ///
+    /// The client is considered active when it has sent a request within the last
+    /// `idle_interval` milliseconds.
+    ///
+    /// The default value is 1000 ms (1 second).
+    pub fn active_interval(&self) -> Option<u64> {
+        self.alternator_ext.active_interval
+    }
+
+    /// Gets the idle interval (in milliseconds) for refreshing the list of known nodes
+    /// when the client is idle.
+    ///
+    /// While no requests are being made to the cluster, the node list is refreshed at this
+    /// longer interval to reduce unnecessary network traffic while still keeping the list
+    /// reasonably up-to-date.
+    ///
+    /// The client is considered idle when it hasn't sent a request within the last
+    /// `idle_interval` milliseconds.
+    ///
+    /// The default value is 60000 ms (1 minute).
+    pub fn idle_interval(&self) -> Option<u64> {
+        self.alternator_ext.idle_interval
+    }
+
     /// Get the client's routing scope.
     ///
     /// This is used by the client to route requests to a chosen subset of nodes in the cluster,
@@ -94,6 +128,24 @@ impl AlternatorConfig {
     pub fn routing_scope(&self) -> Option<RoutingScope> {
         self.alternator_ext.routing_scope.clone()
     }
+
+    /// Gets the URI scheme (http or https).
+    pub fn scheme(&self) -> Option<String> {
+        self.alternator_ext.scheme.clone()
+    }
+
+    /// Port number for alternator connections.
+    pub fn port(&self) -> Option<u16> {
+        self.alternator_ext.port
+    }
+
+    /// Get the list of seed hosts for cluster discovery.
+    ///
+    /// The seed hosts are the initial endpoints (IP addresses or hostnames) used to discover the full cluster topology.
+    /// Use with [`AlternatorBuilder::scheme`] and [`AlternatorBuilder::port`] to construct the endpoint URIs.
+    pub fn seed_hosts(&self) -> Option<Vec<String>> {
+        self.alternator_ext.seed_hosts.clone()
+    }
 }
 
 /// Builder for [AlternatorConfig]
@@ -109,7 +161,6 @@ impl AlternatorConfig {
 ///     .build();
 ///
 /// let client = AlternatorClient::from_conf(config);
-/// ```
 #[derive(Clone, Debug, Default)]
 pub struct AlternatorBuilder {
     pub(crate) dynamodb_builder: aws_sdk_dynamodb::config::Builder,
@@ -184,6 +235,68 @@ impl AlternatorBuilder {
         self
     }
 
+    /// Sets the active interval (in milliseconds) for refreshing the list of known nodes
+    /// when the client is active.
+    ///
+    /// While the client is sending requests to the cluster, the node list is refreshed at
+    /// this interval to quickly detect topology changes.
+    ///
+    /// The client is considered active when it has sent a request within the last
+    /// `idle_interval` milliseconds.
+    ///
+    /// The default value is 1000 ms (1 second).
+    pub fn active_interval(mut self, active_interval: u64) -> Self {
+        self.set_active_interval(active_interval);
+        self
+    }
+
+    /// Sets the active interval (in milliseconds) for refreshing the list of known nodes
+    /// when the client is active.
+    ///
+    /// While the client is sending requests to the cluster, the node list is refreshed at
+    /// this interval to quickly detect topology changes.
+    ///
+    /// The client is considered active when it has sent a request within the last
+    /// `idle_interval` milliseconds.
+    ///
+    /// The default value is 1000 ms (1 second).
+    pub fn set_active_interval(&mut self, active_interval: u64) -> &mut Self {
+        self.alternator_ext.active_interval = Some(active_interval);
+        self
+    }
+
+    /// Sets the idle interval (in milliseconds) for refreshing the list of known nodes
+    /// when the client is idle.
+    ///
+    /// While no requests are being made to the cluster, the node list is refreshed at this
+    /// longer interval to reduce unnecessary network traffic while still keeping the list
+    /// reasonably up-to-date.
+    ///
+    /// The client is considered idle when it hasn't sent a request within the last
+    /// `idle_interval` milliseconds.
+    ///
+    /// The default value is 60000 ms (1 minute).
+    pub fn idle_interval(mut self, idle_interval: u64) -> Self {
+        self.set_idle_interval(idle_interval);
+        self
+    }
+
+    /// Sets the idle interval (in milliseconds) for refreshing the list of known nodes
+    /// when the client is idle.
+    ///
+    /// While no requests are being made to the cluster, the node list is refreshed at this
+    /// longer interval to reduce unnecessary network traffic while still keeping the list
+    /// reasonably up-to-date.
+    ///
+    /// The client is considered idle when it hasn't sent a request within the last
+    /// `idle_interval` milliseconds.
+    ///
+    /// The default value is 60000 ms (1 minute).
+    pub fn set_idle_interval(&mut self, idle_interval: u64) -> &mut Self {
+        self.alternator_ext.idle_interval = Some(idle_interval);
+        self
+    }
+
     /// Set the routing scope for the client.
     ///
     /// This is used by the client to route requests to a chosen subset of nodes in the cluster,
@@ -223,6 +336,59 @@ impl AlternatorBuilder {
     /// may be redundant if the set of nodes in the next scope is a subset of the previous one.
     pub fn set_routing_scope(&mut self, routing_scope: RoutingScope) -> &mut Self {
         self.alternator_ext.routing_scope = Some(routing_scope);
+        self
+    }
+
+    /// Sets the URI scheme (http or https).
+    ///
+    /// Accepts for example "http", "http:", "http://" — stores just "http", same with "https".
+    pub fn scheme(mut self, scheme: impl Into<String>) -> Self {
+        self.set_scheme(scheme);
+        self
+    }
+
+    /// Sets the URI scheme (http or https).
+    ///
+    /// Accepts for example "http", "http:", "http://" — stores just "http", same with "https".
+    pub fn set_scheme(&mut self, scheme: impl Into<String>) -> &mut Self {
+        let s = scheme.into();
+
+        let normalized = s.trim_end_matches('/').trim_end_matches(':').to_string();
+        self.alternator_ext.scheme = Some(normalized);
+        self
+    }
+
+    /// Port number for alternator connections
+    pub fn port(mut self, port: u16) -> Self {
+        self.set_port(port);
+        self
+    }
+
+    /// Port number for alternator connections
+    pub fn set_port(&mut self, port: u16) -> &mut Self {
+        self.alternator_ext.port = Some(port);
+        self
+    }
+
+    /// Set the list of seed hosts for cluster discovery.
+    ///
+    /// The seed hosts are the initial endpoints (IP addresses or hostnames) used to discover the full cluster topology.
+    /// Use with [`AlternatorBuilder::scheme`] and [`AlternatorBuilder::port`] to construct the endpoint URIs.
+    pub fn seed_hosts<I, S>(mut self, seed_hosts: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.set_seed_hosts(seed_hosts.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Set the list of seed hosts for cluster discovery.
+    ///
+    /// The seed hosts are the initial endpoints (IP addresses or hostnames) used to discover the full cluster topology.
+    /// Use with [`AlternatorBuilder::scheme`] and [`AlternatorBuilder::port`] to construct the endpoint URIs.
+    pub fn set_seed_hosts(&mut self, seed_hosts: Vec<String>) -> &mut Self {
+        self.alternator_ext.seed_hosts = Some(seed_hosts);
         self
     }
 }
@@ -633,11 +799,26 @@ impl AlternatorBuilder {
     }
 
     pub fn endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
-        self.dynamodb_builder = self.dynamodb_builder.endpoint_url(endpoint_url);
+        self.set_endpoint_url(Some(endpoint_url.into()));
         self
     }
 
     pub fn set_endpoint_url(&mut self, endpoint_url: Option<String>) -> &mut Self {
+        // Reset everything upfront to avoid stale fields.
+        self.alternator_ext.seed_hosts = None;
+        self.alternator_ext.scheme = None;
+        self.alternator_ext.port = None;
+
+        if let Some(url_str) = endpoint_url.as_deref()
+            && let Ok(url) = url::Url::parse(url_str)
+            && let Some(host) = url.host_str()
+        {
+            self.set_seed_hosts(vec![host.to_string()]);
+            self.set_scheme(url.scheme());
+            if let Some(port) = url.port() {
+                self.set_port(port);
+            }
+        }
         self.dynamodb_builder.set_endpoint_url(endpoint_url);
         self
     }
@@ -766,5 +947,56 @@ mod test {
                 .expect("does not have length")
                 == 0
         );
+    }
+
+    #[test]
+    fn from_conf_does_not_panic_without_runtime() {
+        let config = AlternatorConfig::builder()
+            .behavior_version_latest()
+            .build();
+        let _ = AlternatorClient::from_conf(config);
+    }
+
+    #[test]
+    fn endpoint_url_sets_and_clears_correctly() {
+        let config = AlternatorConfig::builder()
+            .endpoint_url("http://127.0.0.1:8000")
+            .behavior_version_latest()
+            .build();
+        assert_eq!(config.seed_hosts(), Some(vec!["127.0.0.1".to_string()]));
+        assert_eq!(config.scheme(), Some("http".to_string()));
+        assert_eq!(config.port(), Some(8000));
+
+        let mut new_builder = config.to_builder();
+        new_builder.set_endpoint_url(None);
+        let new_config = new_builder.build();
+
+        assert_eq!(new_config.seed_hosts(), None);
+        assert_eq!(new_config.scheme(), None);
+        assert_eq!(new_config.port(), None);
+    }
+
+    #[test]
+    fn setting_scheme_test() {
+        let config = AlternatorConfig::builder()
+            .scheme("https://")
+            .behavior_version_latest()
+            .build();
+
+        assert_eq!(config.scheme(), Some("https".to_string()));
+
+        let config = AlternatorConfig::builder()
+            .scheme("http:")
+            .behavior_version_latest()
+            .build();
+
+        assert_eq!(config.scheme(), Some("http".to_string()));
+
+        let config = AlternatorConfig::builder()
+            .scheme("http")
+            .behavior_version_latest()
+            .build();
+
+        assert_eq!(config.scheme(), Some("http".to_string()));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ pub(crate) struct AlternatorExtensions {
     pub(crate) scheme: Option<String>,
     pub(crate) port: Option<u16>,
     pub(crate) seed_hosts: Option<Vec<String>>,
+    pub(crate) live_nodes: Option<std::sync::Arc<LiveNodes>>,
 }
 
 /// [AlternatorClient]'s config
@@ -146,6 +147,21 @@ impl AlternatorConfig {
     pub fn seed_hosts(&self) -> Option<Vec<String>> {
         self.alternator_ext.seed_hosts.clone()
     }
+
+    /// The [`LiveNodes`] instance shared into this config, if any.
+    ///
+    /// On a config you have built but not yet used, this is [`None`] unless you
+    /// set it via [`live_nodes`], and [`None`] means a client built from it will
+    /// construct its own. On the config a client stores ([`config()`]), this is
+    /// populated: the constructor sets the instance it created so the stored config
+    /// reflects what the client actually uses. It is [`None`] there only if
+    /// constructing [`LiveNodes`] failed.
+    ///
+    /// [`live_nodes`]: Self::live_nodes
+    /// [`config()`]: AlternatorClient::config
+    pub fn live_nodes(&self) -> Option<std::sync::Arc<LiveNodes>> {
+        self.alternator_ext.live_nodes.clone()
+    }
 }
 
 /// Builder for [AlternatorConfig]
@@ -161,6 +177,7 @@ impl AlternatorConfig {
 ///     .build();
 ///
 /// let client = AlternatorClient::from_conf(config);
+/// ```
 #[derive(Clone, Debug, Default)]
 pub struct AlternatorBuilder {
     pub(crate) dynamodb_builder: aws_sdk_dynamodb::config::Builder,
@@ -389,6 +406,80 @@ impl AlternatorBuilder {
     /// Use with [`AlternatorBuilder::scheme`] and [`AlternatorBuilder::port`] to construct the endpoint URIs.
     pub fn set_seed_hosts(&mut self, seed_hosts: Vec<String>) -> &mut Self {
         self.alternator_ext.seed_hosts = Some(seed_hosts);
+        self
+    }
+
+    /// Share an existing [`LiveNodes`] instance across clients (optional).
+    ///
+    /// By default you never need to call this. Every client built from a config
+    /// constructs its own [`LiveNodes`] and spawns a background task that discovers
+    /// and periodically refreshes the set of live cluster nodes. If you run several
+    /// clients with the same load-balancing settings, each one spawns its own task,
+    /// and they all do identical work.
+    ///
+    /// Setting this lets those clients share a single [`LiveNodes`], and therefore
+    /// a single discovery task instead of each running their own.
+    ///
+    /// The discovery task is owned by the [`LiveNodes`] instance: it lives as long
+    /// as the instance does and stops once the last [`Arc`] to it is dropped. The
+    /// instance is shared through an [`Arc`], so handing the same one to several
+    /// clients is exactly how they come to share that one task.
+    ///
+    /// When you pass a shared instance, these settings on this config are
+    /// ignored - the shared [`LiveNodes`] already has its own, fixed at the
+    /// time it was constructed:
+    /// - active and idle refresh intervals
+    /// - routing scope
+    /// - seed hosts
+    /// - scheme and port
+    ///
+    /// Construct the instance to share with [`LiveNodes::new`], then pass it here.
+    /// If you already have a built [`AlternatorConfig`],
+    /// [`AlternatorClient::from_conf_with_live_nodes`] takes both at once, so you
+    /// don't have to rebuild the config yourself to inject the instance.
+    ///
+    /// For more information, see [`LiveNodes`].
+    ///
+    /// [`Arc`]: std::sync::Arc
+    pub fn live_nodes(mut self, live_nodes: std::sync::Arc<LiveNodes>) -> Self {
+        self.set_live_nodes(live_nodes);
+        self
+    }
+
+    /// Share an existing [`LiveNodes`] instance across clients (optional).
+    ///
+    /// By default you never need to call this. Every client built from a config
+    /// constructs its own [`LiveNodes`] and spawns a background task that discovers
+    /// and periodically refreshes the set of live cluster nodes. If you run several
+    /// clients with the same load-balancing settings, each one spawns its own task,
+    /// and they all do identical work.
+    ///
+    /// Setting this lets those clients share a single [`LiveNodes`], and therefore
+    /// a single discovery task instead of each running their own.
+    ///
+    /// The discovery task is owned by the [`LiveNodes`] instance: it lives as long
+    /// as the instance does and stops once the last [`Arc`] to it is dropped. The
+    /// instance is shared through an [`Arc`], so handing the same one to several
+    /// clients is exactly how they come to share that one task.
+    ///
+    /// When you pass a shared instance, these settings on this config are
+    /// ignored - the shared [`LiveNodes`] already has its own, fixed at the
+    /// time it was constructed:
+    /// - active and idle refresh intervals
+    /// - routing scope
+    /// - seed hosts
+    /// - scheme and port
+    ///
+    /// Construct the instance to share with [`LiveNodes::new`], then pass it here.
+    /// If you already have a built [`AlternatorConfig`],
+    /// [`AlternatorClient::from_conf_with_live_nodes`] takes both at once, so you
+    /// don't have to rebuild the config yourself to inject the instance.
+    ///
+    /// For more information, see [`LiveNodes`].
+    ///
+    /// [`Arc`]: std::sync::Arc
+    pub fn set_live_nodes(&mut self, live_nodes: std::sync::Arc<LiveNodes>) -> &mut Self {
+        self.alternator_ext.live_nodes = Some(live_nodes);
         self
     }
 }
@@ -998,5 +1089,32 @@ mod test {
             .build();
 
         assert_eq!(config.scheme(), Some("http".to_string()));
+    }
+
+    #[test]
+    fn test_live_nodes_sharing() {
+        let config = AlternatorConfig::builder()
+            .behavior_version_latest()
+            .endpoint_url("http://127.0.0.1:8000")
+            .build();
+
+        let live_nodes = LiveNodes::new(&config).unwrap();
+
+        // The client can be built with the provided live_nodes instance.
+        let client1 = AlternatorClient::from_conf_with_live_nodes(config, live_nodes.clone());
+
+        // live_nodes can also be insterted into a new config.
+        let config2 = AlternatorConfig::builder()
+            .live_nodes(live_nodes.clone())
+            .behavior_version_latest()
+            .build();
+
+        let client2 = AlternatorClient::from_conf(config2);
+
+        // Assert that they point to the exact same Arc.
+        assert!(std::sync::Arc::ptr_eq(
+            &client1.config().live_nodes().unwrap(),
+            &client2.config().live_nodes().unwrap()
+        ));
     }
 }

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -8,6 +8,7 @@ use aws_smithy_runtime_api::client::interceptors::context::{
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
+use std::sync::Arc;
 
 /// Driver's main interceptor
 ///
@@ -73,6 +74,13 @@ impl Intercept for AlternatorInterceptor {
             strip_headers(context.request_mut());
         }
 
+        // Take the next node from the query plan and override the request URI.
+        if let Some(query_plan) = cfg.interceptor_state().load::<QueryPlan>()
+            && let Some(next_node) = query_plan.next_node()
+        {
+            let _ = context.request_mut().set_uri(next_node.to_string());
+        }
+
         Ok(())
     }
 }
@@ -135,5 +143,36 @@ impl AlternatorOverrideInterceptor<EnforceHeaderWhitelistStore> {
                 enforce_header_whitelist,
             },
         }
+    }
+}
+
+/// An interceptor that adds a round-robin [QueryPlan] to the config bag before request serialization,
+/// so that [AlternatorInterceptor] can later use it to determine which node to send the request to.
+#[derive(Debug)]
+pub(crate) struct RoundRobinQueryPlanInterceptor {
+    live_nodes: Arc<LiveNodes>,
+}
+
+impl RoundRobinQueryPlanInterceptor {
+    pub fn new(live_nodes: Arc<LiveNodes>) -> Self {
+        Self { live_nodes }
+    }
+}
+
+impl Intercept for RoundRobinQueryPlanInterceptor {
+    fn name(&self) -> &'static str {
+        "RoundRobinQueryPlanInterceptor"
+    }
+
+    fn modify_before_serialization(
+        &self,
+        _: &mut BeforeSerializationInterceptorContextMut,
+        _: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let query_plan = QueryPlan::new(self.live_nodes.clone());
+        cfg.interceptor_state().store_put(query_plan);
+
+        Ok(())
     }
 }

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -8,6 +8,7 @@ use aws_smithy_runtime_api::client::interceptors::context::{
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
+use std::sync::Arc;
 
 /// Driver's main interceptor
 ///
@@ -75,6 +76,34 @@ impl Intercept for AlternatorInterceptor {
 
         Ok(())
     }
+
+    fn modify_before_signing(
+        &self,
+        context: &mut BeforeTransmitInterceptorContextMut<'_>,
+        _: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        // Take the next node from the query plan and override the request URI.
+        if let Some(query_plan) = cfg.interceptor_state().load::<QueryPlan>()
+            && let Some(next_node) = query_plan.next_node()
+        {
+            let request = context.request_mut();
+            let mut current = url::Url::parse(request.uri())?;
+            current
+                .set_scheme(next_node.scheme())
+                .map_err(|_| "cannot set scheme")?;
+            current
+                .set_host(next_node.host_str())
+                .map_err(|_| "cannot set host")?;
+            current
+                .set_port(next_node.port())
+                .map_err(|_| "cannot set port")?;
+
+            request.set_uri(current.as_str())?;
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -135,5 +164,40 @@ impl AlternatorOverrideInterceptor<EnforceHeaderWhitelistStore> {
                 enforce_header_whitelist,
             },
         }
+    }
+}
+
+/// An interceptor that adds a round-robin [QueryPlan] to the config bag before request serialization,
+/// so that [AlternatorInterceptor] can later use it to determine which node to send the request to.
+#[derive(Debug)]
+pub(crate) struct RoundRobinQueryPlanInterceptor {
+    live_nodes: Arc<LiveNodes>,
+}
+
+impl RoundRobinQueryPlanInterceptor {
+    pub fn new(live_nodes: Arc<LiveNodes>) -> Self {
+        Self { live_nodes }
+    }
+}
+
+impl Intercept for RoundRobinQueryPlanInterceptor {
+    fn name(&self) -> &'static str {
+        "RoundRobinQueryPlanInterceptor"
+    }
+
+    /// This hook is triggered exactly once per request, before the first attempt is serialized.
+    /// Query plan, put here, is then used before every attempt by [`AlternatorInterceptor`] in `modify_before_signing`
+    /// hook to determine which node the request should be sent to.
+    /// This allows for tracking which nodes have already been tried in the current request and implementing a round-robin strategy.
+    fn modify_before_serialization(
+        &self,
+        _: &mut BeforeSerializationInterceptorContextMut,
+        _: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let query_plan = QueryPlan::new(self.live_nodes.clone());
+        cfg.interceptor_state().store_put(query_plan);
+
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod config;
 mod customize;
 mod header_whitelist;
 mod interceptors;
+mod routing_scope;
 
 pub use crate::client::*;
 pub use crate::compression::*;
@@ -11,3 +12,4 @@ pub use crate::config::*;
 pub use crate::customize::*;
 pub(crate) use crate::header_whitelist::*;
 pub(crate) use crate::interceptors::*;
+pub use crate::routing_scope::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ mod config;
 mod customize;
 mod header_whitelist;
 mod interceptors;
+mod live_nodes;
+mod query_plan;
 mod routing_scope;
 
 pub use crate::client::*;
@@ -12,4 +14,6 @@ pub use crate::config::*;
 pub use crate::customize::*;
 pub(crate) use crate::header_whitelist::*;
 pub(crate) use crate::interceptors::*;
+pub(crate) use crate::live_nodes::*;
+pub(crate) use crate::query_plan::*;
 pub use crate::routing_scope::*;

--- a/src/live_nodes.rs
+++ b/src/live_nodes.rs
@@ -1,0 +1,267 @@
+//! Maintains and updates a list of known live Alternator nodes using the `/localnodes` endpoint.
+//!
+//! # Overview
+//!
+//! [`LiveNodes`] is constructed from an [`AlternatorConfig`] and seeded with a list of hosts.
+//! Once [`start`] is called, a background Tokio task
+//! periodically calls the [`update_live_nodes`] function which requests the known
+//! nodes in a random order to get an updated list of live nodes. After starting, the list is
+//! guaranteed to always contain nodes in the highest available scope in the fallback chain provided by the user.
+//! Underneath it uses a basic [`reqwest::Client`] with timeouts.
+//!
+//! # Polling cadence
+//!
+//! The refresh loop has two cadences:
+//!
+//! - **Active** ([`active_interval`]): used while the client is being called
+//!   regularly. Polls run frequently to keep the view fresh under load.
+//! - **Idle** ([`idle_interval`]): used when no caller has touched
+//!   [`LiveNodes`] recently. An incoming request wakes the loop early via a [`Notify`].
+//!
+//! Activity is tracked through [`mark_activity`], which every read path calls.
+//!
+//! # Discovery mechanism
+//!
+//! Each refresh starts from the highest scope in fallback chain, it shuffles
+//! the current node list and walks it as a candidate queue:
+//! - If a node responds with a non-empty list, the list is used as the new live nodes list,
+//!   and the refresh ends.
+//! - If a node responds with an empty list, it is put back at the end of the queue,
+//!   and the next node is tried, with the next fallback scope.
+//! - A network error causes the node to be dropped from the queue, but the next nodes are
+//!   tried with the same scope.
+//! - If the queue is exhausted without a successful response, it is populated with
+//!   the seed nodes, and the process repeats. If the seeds are exhausted without success, the refresh ends with no changes.
+//!
+//! Once it successfully gets a non-empty response, atomically updates the [`live_nodes`] list using ['ArcSwap].
+//!
+//!  # Lifetime
+//!
+//! The background task holds a [`Weak`] reference to its [`LiveNodes`], so it
+//! terminates on its own once the last external [`Arc`] is dropped. [`Drop`]
+//! additionally aborts the task to avoid waiting out the current sleep.
+//!
+//! [`AlternatorConfig`]: crate::config::AlternatorConfig
+//! [`RoutingScope`]: crate::routing_scope::RoutingScope
+//! [`ArcSwap`]: arc_swap::ArcSwap
+//! [`Notify`]: tokio::sync::Notify
+//! [`Weak`]: std::sync::Weak
+//! [`Arc`]: std::sync::Arc
+//! [`active_interval`]: LiveNodes::active_interval
+//! [`idle_interval`]: LiveNodes::idle_interval
+//! [`mark_activity`]: LiveNodes::mark_activity
+//! [`start`]: LiveNodes::start
+//! [`update_live_nodes`]: LiveNodes::update_live_nodes
+//! [`live_nodes`]: LiveNodes::live_nodes
+
+use crate::routing_scope::RoutingScope;
+use arc_swap::ArcSwap;
+use rand::seq::SliceRandom;
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use url::Url;
+
+const DEFAULT_ACTIVE_REFRESH_INTERVAL_MS: u64 = 1000;
+const DEFAULT_IDLE_REFRESH_INTERVAL_MS: u64 = 60000;
+#[derive(Debug)]
+pub struct LiveNodes {
+    routing_scope: RoutingScope,
+    active_interval: Duration,
+    idle_interval: Duration,
+    counter: Arc<AtomicUsize>,
+    live_nodes: ArcSwap<Vec<Url>>,
+    seed_urls: Vec<Url>,
+    alternator_scheme: String,
+    port: Option<u16>,
+    client: reqwest::Client,
+    last_activity: Arc<Mutex<Instant>>,
+    notify: Arc<tokio::sync::Notify>,
+    bg_task: std::sync::Mutex<Option<tokio::task::AbortHandle>>,
+}
+
+impl LiveNodes {
+    pub fn new(config: &crate::config::AlternatorConfig) -> Option<Arc<Self>> {
+        let active_interval = config
+            .active_interval()
+            .unwrap_or(DEFAULT_ACTIVE_REFRESH_INTERVAL_MS);
+        let idle_interval = config
+            .idle_interval()
+            .unwrap_or(DEFAULT_IDLE_REFRESH_INTERVAL_MS);
+        let routing_scope = config
+            .routing_scope()
+            .unwrap_or(RoutingScope::from_cluster());
+        let alternator_scheme = config.scheme().unwrap_or("http://".to_string());
+        let port = config.port();
+        let seed_nodes = config.seed_hosts().unwrap_or_default();
+
+        let seed_urls = seed_nodes
+            .iter()
+            .filter_map(|addr| {
+                let mut url = Url::parse(&format!("{}{}", alternator_scheme, addr)).ok()?;
+                url.set_port(port).ok()?;
+                Some(url)
+            })
+            .collect::<Vec<_>>();
+        if seed_urls.is_empty() {
+            return None;
+        }
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .connect_timeout(Duration::from_secs(2))
+            .build()
+            .ok()?;
+
+        Some(Arc::new(Self {
+            routing_scope,
+            active_interval: Duration::from_millis(active_interval),
+            idle_interval: Duration::from_millis(idle_interval),
+            counter: Arc::new(AtomicUsize::new(0)),
+            live_nodes: ArcSwap::from_pointee(seed_urls.clone()),
+            seed_urls,
+            alternator_scheme,
+            port,
+            client,
+            last_activity: Arc::new(Mutex::new(Instant::now())),
+            notify: Arc::new(tokio::sync::Notify::new()),
+            bg_task: std::sync::Mutex::new(None),
+        }))
+    }
+
+    fn host_to_uri(&self, addr: &str) -> Result<Url, url::ParseError> {
+        let mut url = Url::parse(&format!("{}{}", self.alternator_scheme, addr))?;
+        url.set_port(self.port)
+            .map_err(|()| url::ParseError::InvalidPort)?;
+        Ok(url)
+    }
+
+    pub fn start(self: Arc<Self>) {
+        let weak_self = Arc::downgrade(&self);
+        let notify = self.notify.clone();
+
+        self.mark_activity();
+        let handle = tokio::spawn(async move {
+            loop {
+                let (idle_interval, active_interval, is_idle) = {
+                    let Some(strong_self) = weak_self.upgrade() else {
+                        break;
+                    };
+
+                    strong_self.update_live_nodes().await;
+
+                    let last = *strong_self.last_activity.lock().unwrap();
+                    (
+                        strong_self.idle_interval,
+                        strong_self.active_interval,
+                        last.elapsed() >= strong_self.idle_interval,
+                    )
+                };
+
+                if !is_idle {
+                    tokio::time::sleep(active_interval).await;
+                } else {
+                    tokio::select! {
+                        _ = tokio::time::sleep(idle_interval) => {}
+                        _ = notify.notified() => {}
+                    }
+                }
+            }
+        });
+
+        if let Ok(mut guard) = self.bg_task.lock() {
+            *guard = Some(handle.abort_handle());
+        }
+    }
+
+    fn mark_activity(&self) {
+        let now = Instant::now();
+        let mut last = self.last_activity.lock().unwrap();
+        let was_idle = now.duration_since(*last) > self.idle_interval;
+        *last = now;
+        if was_idle {
+            self.notify.notify_one();
+        }
+    }
+
+    /// Returns the current list of live nodes starting with the next node in round-robin order.
+    /// Used by [`crate::QueryPlan`] round-robin strategy.
+    pub fn get_live_nodes_round_robin(&self) -> Vec<Url> {
+        self.mark_activity();
+        let live_nodes = self.live_nodes.load();
+
+        let len = live_nodes.len();
+        if len == 0 {
+            return Vec::new();
+        }
+
+        let counter = self.counter.fetch_add(1, Ordering::Relaxed) % len;
+        let (left, right) = live_nodes.split_at(counter);
+        [right, left].concat()
+    }
+
+    pub async fn update_live_nodes(&self) {
+        let mut scope = &self.routing_scope;
+        // Live nodes in a random order.
+        let mut nodes = self.live_nodes.load().as_ref().clone();
+        nodes.shuffle(&mut rand::rng());
+        let mut candidates: VecDeque<Url> = nodes.into();
+        let mut using_seeds = false;
+
+        while let Some(node_addr) = candidates.pop_front() {
+            let url = scope.build_localnodes_url(node_addr.clone());
+            let result = async {
+                self.client
+                    .get(url)
+                    .send()
+                    .await
+                    .ok()?
+                    .json::<Vec<String>>()
+                    .await
+                    .ok()
+            }
+            .await;
+
+            // Request failed: try the next candidate, or fall back to seeds.
+            let Some(mut nodes) = result else {
+                if candidates.is_empty() && !using_seeds {
+                    using_seeds = true;
+                    candidates = self.seed_urls.clone().into();
+                }
+                continue;
+            };
+
+            nodes.sort();
+            let new_nodes: Vec<Url> = nodes
+                .into_iter()
+                .filter_map(|addr| self.host_to_uri(&addr).ok())
+                .collect();
+
+            // Empty result: retry under a fallback scope if one exists.
+            if new_nodes.is_empty() {
+                let Some(fallback) = scope.fallback() else {
+                    return;
+                };
+                scope = fallback;
+                candidates.push_back(node_addr);
+                continue;
+            }
+
+            if **self.live_nodes.load() != new_nodes {
+                self.live_nodes.store(Arc::new(new_nodes));
+            }
+            return;
+        }
+    }
+}
+
+impl Drop for LiveNodes {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.bg_task.lock()
+            && let Some(task) = guard.take()
+        {
+            task.abort();
+        }
+    }
+}

--- a/src/live_nodes.rs
+++ b/src/live_nodes.rs
@@ -1,0 +1,373 @@
+//! Maintains and updates a list of known live Alternator nodes using the `/localnodes` endpoint.
+//!
+//! # Overview
+//!
+//! [`LiveNodes`] is constructed from an [`AlternatorConfig`] and seeded with a list of hosts.
+//! Once [`start`] is called, a background Tokio task
+//! periodically calls the [`update_live_nodes`] function which requests the known
+//! nodes in a random order to get an updated list of live nodes. After starting, the list is
+//! guaranteed to always contain nodes in the highest available scope in the fallback chain provided by the user.
+//! Underneath it uses a basic [`reqwest::Client`] with timeouts.
+//!
+//! # Polling cadence
+//!
+//! The refresh loop has two cadences:
+//!
+//! - **Active** ([`active_interval`]): used while the client is being called
+//!   regularly. Polls run frequently to keep the view fresh under load.
+//! - **Idle** ([`idle_interval`]): used when no caller has touched
+//!   [`LiveNodes`] recently. An incoming request wakes the loop early via a [`Notify`].
+//!
+//! Activity is tracked through [`mark_activity`], which every read path calls.
+//!
+//! # Discovery mechanism
+//!
+//! Each refresh starts from the highest scope in fallback chain, it shuffles
+//! the current node list and walks it as a candidate queue:
+//! - If a node responds with a non-empty list, the list is used as the new live nodes list,
+//!   and the refresh ends.
+//! - If a node responds with an empty list, it is put back at the end of the queue,
+//!   and the next node is tried, with the next fallback scope.
+//! - A network error causes the node to be dropped from the queue, but the next nodes are
+//!   tried with the same scope.
+//! - If the queue is exhausted without a successful response, it is populated with
+//!   the seed nodes, and the process repeats. If the seeds are exhausted without success, the refresh ends with no changes.
+//!
+//! Once it successfully gets a non-empty response, atomically updates the [`live_nodes`] list using ['ArcSwap].
+//!
+//!  # Lifetime
+//!
+//! The background task holds a [`Weak`] reference to its [`LiveNodes`], so it
+//! terminates on its own once the last external [`Arc`] is dropped. [`Drop`]
+//! additionally aborts the task to avoid waiting out the current sleep.
+//!
+//! # Start-up
+//!
+//! The task is launched via [`tokio::spawn`], which requires an active Tokio runtime on the calling thread or else it panics.
+//! The client's [`from_conf`] constructor, however, is synchronous and can be called from anywhere.
+//! It is handled by funneling start-up through a single idempotent entry point:
+//! [`ensure_discovery_started`]. It does three things, in order:
+//!
+//! 1. If discovery is already running, return immediately (a relaxed atomic load, essentially free).
+//! 2. Runtime check: if no Tokio runtime is available on the current thread, return without spawning.
+//!    The task will be started lazily on the first [`get_next_node_round_robin`] call,
+//!    which is always invoked from within the request pipeline and therefore always inside a runtime.
+//! 3. A `compare_exchange` on `discovery_started` ensures that
+//!    exactly one caller wins the right to spawn the task, even under
+//!    concurrent first-access from multiple threads.
+//!
+//! [`AlternatorConfig`]: crate::config::AlternatorConfig
+//! [`RoutingScope`]: crate::routing_scope::RoutingScope
+//! [`ArcSwap`]: arc_swap::ArcSwap
+//! [`Notify`]: tokio::sync::Notify
+//! [`Weak`]: std::sync::Weak
+//! [`Arc`]: std::sync::Arc
+//! [`active_interval`]: LiveNodes::active_interval
+//! [`idle_interval`]: LiveNodes::idle_interval
+//! [`mark_activity`]: LiveNodes::mark_activity
+//! [`ensure_discovery_started`]: LiveNodes::ensure_discovery_started
+//! [`start`]: LiveNodes::start
+//! [`update_live_nodes`]: LiveNodes::update_live_nodes
+//! [`get_next_node_round_robin`]: LiveNodes::get_next_node_round_robin
+//! [`live_nodes`]: LiveNodes::live_nodes
+//! [`from_conf`]: crate::client::AlternatorClient::from_conf
+
+use crate::routing_scope::RoutingScope;
+use arc_swap::ArcSwap;
+use rand::seq::SliceRandom;
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::runtime::Handle;
+use url::Url;
+
+const DEFAULT_ACTIVE_REFRESH_INTERVAL_MS: u64 = 1000;
+const DEFAULT_IDLE_REFRESH_INTERVAL_MS: u64 = 60000;
+#[derive(Debug)]
+pub struct LiveNodes {
+    routing_scope: RoutingScope,
+    active_interval: Duration,
+    idle_interval: Duration,
+    counter: Arc<AtomicUsize>,
+    live_nodes: ArcSwap<Vec<Arc<Url>>>,
+    seed_urls: Vec<Arc<Url>>,
+    alternator_scheme: String,
+    port: Option<u16>,
+    client: reqwest::Client,
+    last_activity: Arc<Mutex<Instant>>,
+    notify: Arc<tokio::sync::Notify>,
+    bg_task: std::sync::Mutex<Option<tokio::task::AbortHandle>>,
+    discovery_started: AtomicBool,
+}
+
+impl LiveNodes {
+    pub fn new(config: &crate::config::AlternatorConfig) -> Option<Arc<Self>> {
+        let active_interval = config
+            .active_interval()
+            .unwrap_or(DEFAULT_ACTIVE_REFRESH_INTERVAL_MS);
+        let idle_interval = config
+            .idle_interval()
+            .unwrap_or(DEFAULT_IDLE_REFRESH_INTERVAL_MS);
+        let routing_scope = config
+            .routing_scope()
+            .unwrap_or(RoutingScope::from_cluster());
+        let alternator_scheme = config.scheme().unwrap_or("http".to_string());
+        let port = config.port();
+        let seed_nodes = config.seed_hosts().unwrap_or_default();
+
+        let seed_urls = seed_nodes
+            .iter()
+            .filter_map(|addr| {
+                let mut url = Url::parse(&format!("{}://{}", alternator_scheme, addr)).ok()?;
+                url.set_port(port).ok()?;
+                Some(Arc::new(url))
+            })
+            .collect::<Vec<_>>();
+        if seed_urls.is_empty() {
+            return None;
+        }
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .connect_timeout(Duration::from_secs(2))
+            .build()
+            .ok()?;
+
+        Some(Arc::new(Self {
+            routing_scope,
+            active_interval: Duration::from_millis(active_interval),
+            idle_interval: Duration::from_millis(idle_interval),
+            counter: Arc::new(AtomicUsize::new(0)),
+            live_nodes: ArcSwap::from_pointee(seed_urls.clone()),
+            seed_urls,
+            alternator_scheme,
+            port,
+            client,
+            last_activity: Arc::new(Mutex::new(Instant::now())),
+            notify: Arc::new(tokio::sync::Notify::new()),
+            bg_task: std::sync::Mutex::new(None),
+            discovery_started: AtomicBool::new(false),
+        }))
+    }
+
+    fn host_to_uri(&self, addr: &str) -> Result<Url, url::ParseError> {
+        let mut url = Url::parse(&format!("{}://{}", self.alternator_scheme, addr))?;
+        url.set_port(self.port)
+            .map_err(|()| url::ParseError::InvalidPort)?;
+        Ok(url)
+    }
+
+    /// Ensures the background discovery task is running.
+    ///
+    /// Idempotent and safe to call from any context: returns immediately if
+    /// discovery is already started, or if no Tokio runtime is available.
+    pub fn ensure_discovery_started(self: &Arc<Self>) {
+        if self.discovery_started.load(Ordering::Acquire) {
+            return;
+        }
+
+        if Handle::try_current().is_err() {
+            return;
+        }
+
+        if self
+            .discovery_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            Arc::clone(self).start();
+        }
+    }
+
+    fn start(self: Arc<Self>) {
+        let weak_self = Arc::downgrade(&self);
+        let notify = self.notify.clone();
+
+        self.mark_activity();
+        let handle = tokio::spawn(async move {
+            loop {
+                let (idle_interval, active_interval, is_idle) = {
+                    let Some(strong_self) = weak_self.upgrade() else {
+                        break;
+                    };
+
+                    strong_self.update_live_nodes().await;
+
+                    let last = *strong_self.last_activity.lock().unwrap();
+                    (
+                        strong_self.idle_interval,
+                        strong_self.active_interval,
+                        last.elapsed() >= strong_self.idle_interval,
+                    )
+                };
+
+                if !is_idle {
+                    tokio::time::sleep(active_interval).await;
+                } else {
+                    tokio::select! {
+                        _ = tokio::time::sleep(idle_interval) => {}
+                        _ = notify.notified() => {}
+                    }
+                }
+            }
+        });
+
+        if let Ok(mut guard) = self.bg_task.lock() {
+            *guard = Some(handle.abort_handle());
+        }
+    }
+
+    fn mark_activity(&self) {
+        let now = Instant::now();
+        let mut last = self.last_activity.lock().unwrap();
+        let was_idle = now.duration_since(*last) > self.idle_interval;
+        *last = now;
+        if was_idle {
+            self.notify.notify_one();
+        }
+    }
+
+    /// Returns the first live node not in `used_nodes` starting with the next node in round-robin order.
+    /// Used by [`crate::QueryPlan`] round-robin strategy.
+    pub fn get_next_node_round_robin(
+        self: &Arc<Self>,
+        used_nodes: &std::collections::HashSet<Arc<Url>>,
+    ) -> Option<Arc<Url>> {
+        self.ensure_discovery_started();
+        self.mark_activity();
+        let live_nodes = self.live_nodes.load();
+
+        let len = live_nodes.len();
+        if len == 0 {
+            return None;
+        }
+
+        let start = self.counter.fetch_add(1, Ordering::Relaxed) % len;
+        for i in 0..len {
+            let idx = (start + i) % len;
+            let node = &live_nodes[idx];
+            if !used_nodes.contains(node) {
+                return Some(node.clone());
+            }
+        }
+        None
+    }
+
+    pub async fn update_live_nodes(&self) {
+        let mut scope = &self.routing_scope;
+        // Live nodes in a random order.
+        let mut nodes = self.live_nodes.load().as_ref().clone();
+        nodes.shuffle(&mut rand::rng());
+        let mut candidates: VecDeque<Arc<Url>> = nodes.into();
+        let mut using_seeds = false;
+
+        while let Some(node_addr) = candidates.pop_front() {
+            let url = scope.build_localnodes_url((*node_addr).clone());
+            let result = async {
+                self.client
+                    .get(url)
+                    .send()
+                    .await
+                    .ok()?
+                    .json::<Vec<String>>()
+                    .await
+                    .ok()
+            }
+            .await;
+
+            // Request failed: try the next candidate, or fall back to seeds.
+            let Some(mut nodes) = result else {
+                if candidates.is_empty() && !using_seeds {
+                    using_seeds = true;
+                    candidates = self.seed_urls.clone().into();
+                }
+                continue;
+            };
+
+            nodes.sort();
+            let new_nodes: Vec<Arc<Url>> = nodes
+                .into_iter()
+                .filter_map(|addr| self.host_to_uri(&addr).ok().map(Arc::new))
+                .collect();
+
+            // Empty result: retry under a fallback scope if one exists.
+            if new_nodes.is_empty() {
+                let Some(fallback) = scope.fallback() else {
+                    return;
+                };
+                scope = fallback;
+                candidates.push_back(node_addr);
+                continue;
+            }
+
+            if **self.live_nodes.load() != new_nodes {
+                self.live_nodes.store(Arc::new(new_nodes));
+            }
+            return;
+        }
+    }
+}
+
+impl Drop for LiveNodes {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.bg_task.lock()
+            && let Some(task) = guard.take()
+        {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AlternatorConfig;
+
+    fn test_config() -> AlternatorConfig {
+        AlternatorConfig::builder()
+            .behavior_version_latest()
+            .endpoint_url("http://127.0.0.1:1".to_string())
+            .build()
+    }
+
+    #[test]
+    fn start_without_runtime_does_not_panic() {
+        let nodes = LiveNodes::new(&test_config()).unwrap();
+        LiveNodes::ensure_discovery_started(&nodes);
+        assert!(!nodes.discovery_started.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn start_with_runtime_starts_correctly() {
+        let nodes = LiveNodes::new(&test_config()).unwrap();
+        LiveNodes::ensure_discovery_started(&nodes);
+        assert!(nodes.discovery_started.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn start_on_first_access() {
+        let nodes = LiveNodes::new(&test_config()).unwrap();
+        LiveNodes::ensure_discovery_started(&nodes);
+        assert!(!nodes.discovery_started.load(Ordering::Acquire));
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let _ = nodes.get_next_node_round_robin(&std::collections::HashSet::new());
+        });
+        assert!(nodes.discovery_started.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn ipv6_address_parsing() {
+        let config = AlternatorConfig::builder()
+            .behavior_version_latest()
+            .endpoint_url("http://[::1]:8000".to_string())
+            .build();
+        let nodes = LiveNodes::new(&config).unwrap();
+        assert_eq!(nodes.seed_urls[0].scheme(), "http");
+        assert_eq!(nodes.seed_urls[0].host_str(), Some("[::1]"));
+        assert_eq!(nodes.seed_urls[0].port(), Some(8000));
+        assert_eq!(nodes.seed_urls[0].to_string(), "http://[::1]:8000/");
+    }
+}

--- a/src/live_nodes.rs
+++ b/src/live_nodes.rs
@@ -50,7 +50,7 @@
 //!
 //! 1. If discovery is already running, return immediately (a relaxed atomic load, essentially free).
 //! 2. Runtime check: if no Tokio runtime is available on the current thread, return without spawning.
-//!    The task will be started lazily on the first [`get_next_node_round_robin`] call,
+//!    The task will be started lazily on the first [`get_next_node_round_robin`] or [`get_live_nodes`] call,
 //!    which is always invoked from within the request pipeline and therefore always inside a runtime.
 //! 3. A `compare_exchange` on `discovery_started` ensures that
 //!    exactly one caller wins the right to spawn the task, even under
@@ -69,6 +69,7 @@
 //! [`start`]: LiveNodes::start
 //! [`update_live_nodes`]: LiveNodes::update_live_nodes
 //! [`get_next_node_round_robin`]: LiveNodes::get_next_node_round_robin
+//! [`get_live_nodes`]: LiveNodes::get_live_nodes
 //! [`live_nodes`]: LiveNodes::live_nodes
 //! [`from_conf`]: crate::client::AlternatorClient::from_conf
 
@@ -226,6 +227,12 @@ impl LiveNodes {
         if was_idle {
             self.notify.notify_one();
         }
+    }
+
+    /// Returns a list of all current live nodes and updates the last activity timestamp.
+    pub fn get_live_nodes(self: &Arc<Self>) -> Vec<Arc<Url>> {
+        self.mark_activity();
+        self.live_nodes.load().as_ref().clone()
     }
 
     /// Returns the first live node not in `used_nodes` starting with the next node in round-robin order.

--- a/src/query_plan.rs
+++ b/src/query_plan.rs
@@ -1,0 +1,40 @@
+//! Query plan for Alternator requests.
+//!
+//! The object is put in the config and on each requests is used to determine which node to send the request to.
+
+use crate::live_nodes::LiveNodes;
+use aws_smithy_types::config_bag::{Storable, StoreReplace};
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+use url::Url;
+#[derive(Debug)]
+pub(crate) struct QueryPlan {
+    live_nodes: Arc<LiveNodes>,
+    used_nodes: Mutex<HashSet<Url>>,
+}
+
+impl Storable for QueryPlan {
+    type Storer = StoreReplace<Self>;
+}
+
+impl QueryPlan {
+    pub fn new(live_nodes: Arc<LiveNodes>) -> Self {
+        Self {
+            live_nodes,
+            used_nodes: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// On every attempt, the first node that hasn't been used yet in this request is returned.
+    /// Search begins from the last used node in the live nodes list, so that requests are distributed evenly across the cluster.
+    pub fn next_node(&self) -> Option<Url> {
+        let mut used_nodes = self.used_nodes.lock().unwrap();
+        let node = self
+            .live_nodes
+            .get_live_nodes_round_robin()
+            .into_iter()
+            .find(|n| !used_nodes.contains(n))?;
+        used_nodes.insert(node.clone());
+        Some(node)
+    }
+}

--- a/src/query_plan.rs
+++ b/src/query_plan.rs
@@ -1,0 +1,36 @@
+//! Query plan for Alternator requests.
+//!
+//! The object is put in the config and on each requests is used to determine which node to send the request to.
+
+use crate::live_nodes::LiveNodes;
+use aws_smithy_types::config_bag::{Storable, StoreReplace};
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex};
+use url::Url;
+#[derive(Debug)]
+pub(crate) struct QueryPlan {
+    live_nodes: Arc<LiveNodes>,
+    used_nodes: Mutex<HashSet<Arc<Url>>>,
+}
+
+impl Storable for QueryPlan {
+    type Storer = StoreReplace<Self>;
+}
+
+impl QueryPlan {
+    pub fn new(live_nodes: Arc<LiveNodes>) -> Self {
+        Self {
+            live_nodes,
+            used_nodes: Mutex::new(HashSet::new()),
+        }
+    }
+
+    /// On every attempt, the first node that hasn't been used yet in this request is returned.
+    /// Search begins from the last used node in the live nodes list, so that requests are distributed evenly across the cluster.
+    pub fn next_node(&self) -> Option<Arc<Url>> {
+        let mut used_nodes = self.used_nodes.lock().unwrap();
+        let node = self.live_nodes.get_next_node_round_robin(&used_nodes)?;
+        used_nodes.insert(node.clone());
+        Some(node)
+    }
+}

--- a/src/routing_scope.rs
+++ b/src/routing_scope.rs
@@ -1,0 +1,239 @@
+//! Routing scope for directing requests to specific subsets of nodes in a cluster.
+//!
+//! Routing scopes allow user to specify which nodes should be used for load balancing,
+//! with optional fallback to a wider scope if no nodes are available in the preferred one.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoutingScope {
+    dc: Option<String>,
+    rack: Option<String>,
+    fallback: Option<Box<RoutingScope>>,
+}
+
+impl RoutingScope {
+    /// Note that the cluster scope does not actually mean that client will use the whole cluster, but rather that it
+    /// won't specify any datacenter or rack. This means that load balancing will happen across nodes in the datacenter of
+    /// the node that it queried for local nodes, so one of the seed hosts or the nodes that it knew at the moment of fallback.
+    pub fn from_cluster() -> Self {
+        Self {
+            dc: None,
+            rack: None,
+            fallback: None,
+        }
+    }
+
+    pub fn from_datacenter(dc: String) -> Self {
+        if dc.is_empty() {
+            Self::from_cluster()
+        } else {
+            Self {
+                dc: Some(dc),
+                ..Self::from_cluster()
+            }
+        }
+    }
+
+    pub fn from_rack(dc: String, rack: String) -> Self {
+        if dc.is_empty() {
+            Self::from_cluster()
+        } else if rack.is_empty() {
+            Self::from_datacenter(dc)
+        } else {
+            Self {
+                dc: Some(dc),
+                rack: Some(rack),
+                ..Self::from_cluster()
+            }
+        }
+    }
+
+    /// Sets a fallback for the routing scope that is used if no nodes are available in the preferred scope.
+    ///
+    /// This function can be called multiple times to create a chain of fallback scopes.
+    /// Each call of this function adds the new fallback scope at the end of the existing fallback chain.
+    /// Requests are always routed to the most preferred scope in the chain that has available nodes.
+    ///
+    /// Keep in mind that subsequent fallback scope should ideally be broader than or equal to the
+    /// previous one, e.g., (rack -> datacenter -> cluster) or (rack -> another rack -> datacenter -> cluster).
+    /// Making a fallback narrower, e.g., (datacenter -> rack) or (cluster -> datacenter),
+    /// may be redundant if the set of nodes in the next scope is a subset of the previous one.
+    pub fn with_fallback(mut self, new_fallback: RoutingScope) -> Self {
+        let mut tail = &mut self.fallback;
+        while let Some(boxed) = tail {
+            tail = &mut boxed.fallback;
+        }
+        *tail = Some(Box::new(new_fallback));
+        self
+    }
+
+    /// Appends the datacenter and rack parameters to the given URL as query parameters, if they are set in the scope.
+    /// append_pair performs URL encoding.
+    pub fn build_localnodes_url(&self, mut base_url: url::Url) -> url::Url {
+        base_url.set_path("/localnodes");
+        if self.dc.is_some() {
+            let mut query = base_url.query_pairs_mut();
+            if let Some(dc) = &self.dc {
+                query.append_pair("dc", dc);
+            }
+            if let Some(rack) = &self.rack {
+                query.append_pair("rack", rack);
+            }
+        }
+        base_url
+    }
+
+    pub fn fallback(&self) -> Option<&RoutingScope> {
+        self.fallback.as_deref()
+    }
+
+    pub fn dc(&self) -> Option<&str> {
+        self.dc.as_deref()
+    }
+
+    pub fn rack(&self) -> Option<&str> {
+        self.rack.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cluster_scope() {
+        let scope = RoutingScope::from_cluster();
+        assert_eq!(scope.dc(), None);
+        assert_eq!(scope.rack(), None);
+        assert!(scope.fallback().is_none());
+        let url = url::Url::parse("http://localhost/").unwrap();
+        assert_eq!(
+            scope.build_localnodes_url(url).as_str(),
+            "http://localhost/localnodes"
+        );
+    }
+
+    #[test]
+    fn test_datacenter_scope() {
+        let scope = RoutingScope::from_datacenter("dc1".to_string());
+        assert_eq!(scope.dc(), Some("dc1"));
+        assert_eq!(scope.rack(), None);
+        assert!(scope.fallback().is_none());
+        let url = url::Url::parse("http://localhost/").unwrap();
+        assert_eq!(
+            scope.build_localnodes_url(url).as_str(),
+            "http://localhost/localnodes?dc=dc1"
+        );
+    }
+
+    #[test]
+    fn test_rack_scope() {
+        let scope = RoutingScope::from_rack("dc1".to_string(), "rack1".to_string());
+        assert_eq!(scope.dc(), Some("dc1"));
+        assert_eq!(scope.rack(), Some("rack1"));
+        assert!(scope.fallback().is_none());
+        let url = url::Url::parse("http://localhost/").unwrap();
+        assert_eq!(
+            scope.build_localnodes_url(url).as_str(),
+            "http://localhost/localnodes?dc=dc1&rack=rack1"
+        );
+    }
+
+    #[test]
+    fn test_with_fallback() {
+        let scope = RoutingScope::from_rack("dc1".to_string(), "rack1".to_string())
+            .with_fallback(RoutingScope::from_datacenter("dc1".to_string()))
+            .with_fallback(RoutingScope::from_cluster());
+
+        assert_eq!(scope.dc(), Some("dc1"));
+        assert_eq!(scope.rack(), Some("rack1"));
+
+        let first_fallback = scope.fallback().expect("Should have a fallback");
+        assert_eq!(first_fallback.dc(), Some("dc1"));
+        assert_eq!(first_fallback.rack(), None);
+
+        let second_fallback = first_fallback
+            .fallback()
+            .expect("Should have a second fallback");
+        assert_eq!(second_fallback.dc(), None);
+        assert_eq!(second_fallback.rack(), None);
+        assert!(second_fallback.fallback().is_none());
+    }
+
+    #[test]
+    fn test_localnodes_query_encoding() {
+        let scope = RoutingScope::from_rack("dc 1".to_string(), "rack&1".to_string());
+        let url = url::Url::parse("http://localhost/").unwrap();
+        assert_eq!(
+            scope.build_localnodes_url(url).as_str(),
+            "http://localhost/localnodes?dc=dc+1&rack=rack%261"
+        );
+    }
+
+    #[test]
+    fn test_impossible_to_create_cyclic_fallback() {
+        // Because `RoutingScope` uses `Box` which has exclusive ownership, it is impossible to create a self-referential cycle.
+        // Even if a user attempts to create a "cycle" by cloning the scope and passing it
+        // to itself, it creates a finite, linear chain of completely separate allocations.
+
+        let base = RoutingScope::from_rack("dc1".to_string(), "rack1".to_string());
+
+        let scope = base.clone().with_fallback(base);
+
+        // We can prove it's a finite chain because if we walk down the fallbacks, we eventually reach `None` and the traversal stops.
+        let mut count = 0;
+        let mut current = Some(&scope);
+
+        while let Some(node) = current {
+            count += 1;
+            current = node.fallback();
+        }
+
+        // If there were a cycle, the loop above would never terminate.
+        // But since it's just two distinct nodes in a straight line, it safely stops at 2.
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_fallback_associativity() {
+        let rs1 = RoutingScope::from_rack("dc1".to_string(), "rack1".to_string());
+        let rs2 = RoutingScope::from_datacenter("dc1".to_string());
+        let rs3 = RoutingScope::from_rack("dc2".to_string(), "rack2".to_string());
+        let rs4 = RoutingScope::from_datacenter("dc2".to_string());
+        let rs5 = RoutingScope::from_cluster();
+
+        // Chain 1: rs1.with_fallback(rs2.with_fallback(rs3)).with_fallback(rs4.with_fallback(rs5))
+        let chain1 = rs1
+            .clone()
+            .with_fallback(rs2.clone().with_fallback(rs3.clone()))
+            .with_fallback(rs4.clone().with_fallback(rs5.clone()));
+
+        // Chain 2: rs1.with_fallback(rs2).with_fallback(rs3).with_fallback(rs4).with_fallback(rs5)
+        let chain2 = rs1
+            .clone()
+            .with_fallback(rs2.clone())
+            .with_fallback(rs3.clone())
+            .with_fallback(rs4.clone())
+            .with_fallback(rs5.clone());
+
+        // Chain 3: rs1.with_fallback(rs2.with_fallback(rs3.with_fallback(rs4.with_fallback(rs5))))
+        let chain3 = rs1.clone().with_fallback(
+            rs2.clone().with_fallback(
+                rs3.clone()
+                    .with_fallback(rs4.clone().with_fallback(rs5.clone())),
+            ),
+        );
+
+        // Chain 4: rs1.with_fallback(rs2).with_fallback(rs3.with_fallback(rs4)).with_fallback(rs5)
+        let chain4 = rs1
+            .clone()
+            .with_fallback(
+                rs2.clone()
+                    .with_fallback(rs3.clone().with_fallback(rs4.clone())),
+            )
+            .with_fallback(rs5.clone());
+
+        assert_eq!(chain1, chain2);
+        assert_eq!(chain2, chain3);
+        assert_eq!(chain3, chain4);
+    }
+}

--- a/tests/common/proxy.rs
+++ b/tests/common/proxy.rs
@@ -4,7 +4,7 @@
 //!
 //! The proxy is expected to live no longer than the server.
 //! When the server is closed, the future finishes.
-//! The proxy can accept many clients during its lifetime, but only one at a time.
+//! The proxy can accept many clients during its lifetime, up to 2 at a time.
 //!
 //! It comes with three hooks:
 //! - `on_request`
@@ -42,7 +42,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore, watch};
 
 pub struct Proxy<'a> {
     task: Pin<Box<dyn Future<Output = ()> + Send + 'a>>,
@@ -58,29 +58,83 @@ impl<'a> Proxy<'a> {
         on_client_disconnect: Option<Box<dyn Fn() + Send + Sync>>,
     ) -> Proxy<'a>
     where
-        F: Fn(Request<Incoming>, Arc<Mutex<SendRequest<Full<Bytes>>>>) -> Fut + Send + Sync + 'a,
-        Fut: Future<Output = Response<Full<Bytes>>> + Send,
+        F: Fn(Request<Incoming>, Arc<Mutex<SendRequest<Full<Bytes>>>>) -> Fut
+            + Send
+            + Sync
+            + 'static,
+        Fut: Future<Output = Response<Full<Bytes>>> + Send + 'static,
     {
         let on_request = Arc::new(on_request);
+        let on_client_connect: Option<Arc<dyn Fn(SocketAddr) + Send + Sync>> =
+            on_client_connect.map(Arc::from);
+        let on_client_disconnect: Option<Arc<dyn Fn() + Send + Sync>> =
+            on_client_disconnect.map(Arc::from);
         let (listener, listen_address) = Proxy::bind_listener(listen_address.clone()).await;
-        let (sender, mut server_connection) = Proxy::connect_server(connect_address.clone()).await;
+        let (sender, server_connection) = Proxy::connect_server(connect_address.clone()).await;
 
         let task = async move {
-            let mut running = true;
-            while running {
-                let mut client_connection = Proxy::accept_client(
-                    &listener,
-                    sender.clone(),
-                    on_request.clone(),
-                    &on_client_connect,
-                )
-                .await;
-                running = Proxy::handle_connections(
-                    &mut client_connection,
-                    &mut server_connection,
-                    &on_client_disconnect,
-                )
-                .await;
+            let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
+
+            tokio::spawn(async move {
+                let result = server_connection.await;
+                let _ = shutdown_tx.send(true);
+                result.expect("Server finished with an error");
+            });
+
+            let connection_limit = Arc::new(Semaphore::new(2));
+
+            loop {
+                tokio::select! {
+                    changed = shutdown_rx.changed() => {
+                        if changed.is_ok() && *shutdown_rx.borrow() {
+                            break;
+                        }
+                    }
+                    permit = connection_limit.clone().acquire_owned() => {
+                        let permit = permit.unwrap();
+
+                        tokio::select! {
+                            changed = shutdown_rx.changed() => {
+                                if changed.is_ok() && *shutdown_rx.borrow() {
+                                    break;
+                                }
+                            }
+                            accepted = listener.accept() => {
+                                let (stream, client_address) = accepted.unwrap();
+                                let stream = TokioIo::new(stream);
+
+                                if let Some(on_client_connect) = &on_client_connect {
+                                    on_client_connect(client_address);
+                                }
+
+                                let server_sender = sender.clone();
+                                let on_request = on_request.clone();
+                                let on_client_disconnect = on_client_disconnect.clone();
+
+                                tokio::spawn(async move {
+                                    let service = service_fn(move |request| {
+                                        let server_sender = server_sender.clone();
+                                        let on_request = on_request.clone();
+                                        async move {
+                                            let response = on_request(request, server_sender).await;
+                                            Ok::<_, hyper::Error>(response)
+                                        }
+                                    });
+
+                                    let handler = hyper_server::Builder::new();
+                                    let connection = handler.serve_connection(stream, service);
+                                    let result = connection.await;
+                                    drop(permit);
+                                    result.expect("Client finished with an error");
+
+                                    if let Some(on_client_disconnect) = on_client_disconnect {
+                                        on_client_disconnect();
+                                    }
+                                });
+                            }
+                        }
+                    }
+                }
             }
         };
 
@@ -117,60 +171,6 @@ impl<'a> Proxy<'a> {
         let sender = Arc::new(Mutex::new(sender));
 
         (sender, Box::pin(connection.fuse()))
-    }
-
-    async fn accept_client<F, Fut>(
-        listener: &TcpListener,
-        server_sender: Arc<Mutex<SendRequest<Full<Bytes>>>>,
-        on_request: Arc<F>,
-        on_client_connect: &Option<Box<dyn Fn(SocketAddr) + Send + Sync>>,
-    ) -> Pin<Box<Fuse<impl Future<Output = Result<(), hyper::Error>>>>>
-    where
-        F: Fn(Request<Incoming>, Arc<Mutex<SendRequest<Full<Bytes>>>>) -> Fut,
-        Fut: Future<Output = Response<Full<Bytes>>>,
-    {
-        let (stream, client_address) = listener.accept().await.unwrap();
-        let stream = TokioIo::new(stream);
-
-        if let Some(on_client_connect) = on_client_connect {
-            on_client_connect(client_address);
-        }
-
-        let service = service_fn(move |request| {
-            let server_sender = server_sender.clone();
-            let on_request = on_request.clone();
-            async move {
-                let response = on_request(request, server_sender).await;
-                Ok::<_, hyper::Error>(response)
-            }
-        });
-
-        let handler = hyper_server::Builder::new();
-        let connection = handler.serve_connection(stream, service);
-        Box::pin(connection.fuse())
-    }
-
-    async fn handle_connections(
-        client_connection: &mut Pin<Box<Fuse<impl Future<Output = Result<(), hyper::Error>>>>>,
-        server_connection: &mut Pin<Box<Fuse<impl Future<Output = Result<(), hyper::Error>>>>>,
-        on_client_disconnect: &Option<Box<dyn Fn() + Send + Sync>>,
-    ) -> bool {
-        let (client_finished, result) = tokio::select! {
-            client_result = client_connection => (true, client_result),
-            server_result = server_connection => (false, server_result),
-        };
-
-        if client_finished {
-            result.expect("Client finished with an error");
-
-            if let Some(on_client_disconnect) = on_client_disconnect {
-                on_client_disconnect();
-            }
-        } else {
-            result.expect("Server finished with an error");
-        }
-
-        client_finished
     }
 }
 

--- a/tests/http_content/body_compression.rs
+++ b/tests/http_content/body_compression.rs
@@ -144,6 +144,7 @@ pub async fn test_request_compression_gzip(ctx: &mut HttpTestContext<Config>) {
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .credentials_provider(
                 aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
@@ -193,6 +194,7 @@ pub async fn test_request_compression_zlib(ctx: &mut HttpTestContext<Config>) {
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .credentials_provider(
                 aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
@@ -271,6 +273,7 @@ pub async fn test_enabled_by_per_request_customization(ctx: &mut HttpTestContext
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .credentials_provider(
                 aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
@@ -380,6 +383,7 @@ pub async fn test_disabled_by_per_request_customization(ctx: &mut HttpTestContex
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .credentials_provider(
                 aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),

--- a/tests/http_content/common/http_test.rs
+++ b/tests/http_content/common/http_test.rs
@@ -22,6 +22,11 @@
 //!    register it with HttpTestContext::register_resource()
 //!
 //! 5. You can override the initial on_request with HttpTestContext::set_on_request().
+//!
+//! **Note:** since load balancing is automatically enabled,
+//! the GETs from the discovery may interfere with the test logic.
+//! To work around this, you can disable load balancing by setting an empty list
+//! of seed hosts in the client configuration, using `.seed_hosts(Vec::<String>::new())`.
 
 use crate::http_content::proxy::*;
 

--- a/tests/http_content/correct_line.rs
+++ b/tests/http_content/correct_line.rs
@@ -74,6 +74,7 @@ pub async fn test(ctx: &mut HttpTestContext<ContextConfig>) {
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .credentials_provider(
                 aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),

--- a/tests/http_content/header_whitelist.rs
+++ b/tests/http_content/header_whitelist.rs
@@ -200,6 +200,7 @@ pub async fn test_without_credentials(ctx: &mut HttpTestContext<WithoutCredentia
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .enforce_header_whitelist(true)
             .allow_no_auth()
@@ -259,6 +260,7 @@ pub async fn test_with_credentials(ctx: &mut HttpTestContext<WithCredentialsConf
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .enforce_header_whitelist(true)
             .credentials_provider(
@@ -319,6 +321,7 @@ pub async fn test_whitelist_needed(ctx: &mut HttpTestContext<WhitelistNeededConf
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .enforce_header_whitelist(false)
             .credentials_provider(
@@ -429,6 +432,7 @@ pub async fn test_enabled_by_per_request_customization(
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .credentials_provider(
                 aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
@@ -456,6 +460,7 @@ pub async fn test_disabled_by_per_request_customization(
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .credentials_provider(
                 aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),

--- a/tests/load_balancing/common/scope_utils.rs
+++ b/tests/load_balancing/common/scope_utils.rs
@@ -1,0 +1,119 @@
+//! Utility functions for working with RoutingScope in tests.
+
+use alternator_driver::RoutingScope;
+
+use crate::ccm_wrapper::ccm::Ccm;
+use crate::ccm_wrapper::cluster::{Cluster, Node};
+
+pub(crate) fn nodes_in_scope<'a>(cluster: &'a Cluster, scope: &RoutingScope) -> Vec<&'a Node> {
+    match (scope.dc(), scope.rack()) {
+        (None, None) => cluster.nodes(),
+        (Some(dc), None) => cluster
+            .datacenters()
+            .iter()
+            .find(|datacenter| datacenter.name == dc)
+            .map_or_else(Vec::new, |datacenter| {
+                datacenter
+                    .racks()
+                    .iter()
+                    .flat_map(|rack| rack.nodes().iter())
+                    .collect()
+            }),
+        (Some(dc), Some(rack)) => cluster
+            .datacenters()
+            .iter()
+            .find(|datacenter| datacenter.name == dc)
+            .and_then(|datacenter| {
+                datacenter
+                    .racks()
+                    .iter()
+                    .find(|rack_struct| rack_struct.name == rack)
+            })
+            .map_or_else(Vec::new, |rack_struct| rack_struct.nodes().iter().collect()),
+        (None, Some(_)) => unreachable!("rack without dc — invariant violated"),
+    }
+}
+
+pub(crate) fn nodes_in_scope_mut<'a>(
+    cluster: &'a mut Cluster,
+    scope: &RoutingScope,
+) -> Vec<&'a mut Node> {
+    match (scope.dc(), scope.rack()) {
+        (None, None) => cluster.nodes_mut(),
+        (Some(dc), None) => cluster
+            .datacenters_mut()
+            .iter_mut()
+            .find(|datacenter| datacenter.name == dc)
+            .map_or_else(Vec::new, |datacenter| {
+                datacenter
+                    .racks_mut()
+                    .iter_mut()
+                    .flat_map(|rack| rack.nodes_mut().iter_mut())
+                    .collect()
+            }),
+        (Some(dc), Some(rack)) => cluster
+            .datacenters_mut()
+            .iter_mut()
+            .find(|datacenter| datacenter.name == dc)
+            .and_then(|datacenter| {
+                datacenter
+                    .racks_mut()
+                    .iter_mut()
+                    .find(|rack_struct| rack_struct.name == rack)
+            })
+            .map_or_else(Vec::new, |rack_struct| {
+                rack_struct.nodes_mut().iter_mut().collect()
+            }),
+        (None, Some(_)) => unreachable!("rack without dc — invariant violated"),
+    }
+}
+
+pub(crate) fn ips_in_scope<'a>(cluster: &'a Cluster, scope: &RoutingScope) -> Vec<&'a str> {
+    nodes_in_scope(cluster, scope)
+        .iter()
+        .map(|node| node.ip.as_str())
+        .collect()
+}
+
+pub(crate) fn working_nodes_ips_in_scope<'a>(
+    cluster: &'a Cluster,
+    scope: &RoutingScope,
+) -> Vec<&'a str> {
+    nodes_in_scope(cluster, scope)
+        .iter()
+        .filter(|node| node.is_up)
+        .map(|node| node.ip.as_str())
+        .collect()
+}
+
+pub(crate) fn scope_first_working_node_mut<'a>(
+    cluster: &'a mut Cluster,
+    scope: &RoutingScope,
+) -> Option<&'a mut Node> {
+    nodes_in_scope_mut(cluster, scope)
+        .into_iter()
+        .find(|node| node.is_up)
+}
+
+pub(crate) fn shut_down_scope(cluster: &mut Cluster, scope: &RoutingScope) {
+    for node in nodes_in_scope_mut(cluster, scope) {
+        Ccm::stop_node(node).unwrap();
+    }
+}
+
+pub(crate) fn datacenter_scope_from_index(cluster: &Cluster, index: usize) -> RoutingScope {
+    RoutingScope::from_datacenter(cluster.datacenters()[index].name.to_string())
+}
+
+pub(crate) fn rack_scope_from_index(
+    cluster: &Cluster,
+    datacenter_index: usize,
+    rack_index: usize,
+) -> RoutingScope {
+    RoutingScope::from_rack(
+        cluster.datacenters()[datacenter_index].name.to_string(),
+        cluster.datacenters()[datacenter_index].racks()[rack_index]
+            .name
+            .to_string(),
+    )
+}

--- a/tests/load_balancing/load_balancing_tests.rs
+++ b/tests/load_balancing/load_balancing_tests.rs
@@ -1,0 +1,528 @@
+use crate::ccm_wrapper::ccm::*;
+use crate::ccm_wrapper::cluster::*;
+use crate::ccm_wrapper::topology_spec::*;
+use crate::load_balancing::proxy;
+use crate::load_balancing::scope_utils;
+
+use alternator_driver::AlternatorClient;
+use alternator_driver::AlternatorConfig;
+use alternator_driver::RoutingScope;
+use hyper::Method;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use ctor::dtor;
+use tokio::sync::{Mutex, MutexGuard};
+
+const PROXY_PORT: u16 = 7999;
+const ALTERNATOR_PORT: u16 = 8000;
+
+// The client will use different refresh intervals for idle mode (when nothing happened for a while)
+// and active mode, when calls are being made. Exact value might change later.
+const ACTIVE_INTERVAL: Duration = Duration::from_secs(1);
+
+// Since cluster creation is expensive, we create it once and reuse it for every test.
+// Before a test gets access to the cluster, we make sure that all nodes are up and their ports are set to default.
+// Datacenter 1 is a single node which is meant to never be shut down. Its address will be used as a seed address
+// for clients and as a redirect target for requests directed to shut down nodes.
+static CLUSTER: OnceLock<Mutex<Cluster>> = OnceLock::new();
+async fn get_cluster() -> MutexGuard<'static, Cluster> {
+    let mut cluster = CLUSTER
+        .get_or_init(|| {
+            let topology = TopologySpecBuilder::new()
+                .datacenter(DatacenterSpec::new().rack(1))
+                .datacenter(DatacenterSpec::new().rack(1).rack(2))
+                .datacenter(DatacenterSpec::new().rack(2).rack(1))
+                .build()
+                .unwrap();
+            let ip_prefix = IpPrefix::new("127.0.1.").unwrap();
+            let cluster_name = format!("test_cluster_{}", uuid::Uuid::new_v4());
+            let scylla_version = String::from("release:2025.1");
+            let cluster = Ccm::create_cluster(
+                cluster_name,
+                &topology,
+                ip_prefix,
+                ALTERNATOR_PORT,
+                scylla_version,
+            )
+            .unwrap();
+            Mutex::new(cluster)
+        })
+        .lock()
+        .await;
+
+    Ccm::start_cluster(&mut cluster).unwrap();
+    cluster.update_all_nodes_port(ALTERNATOR_PORT);
+    cluster
+}
+
+// Since the cluster is static, it never drops, so we use a destructor.
+#[dtor]
+fn clean_up_cluster() {
+    if let Some(cluster_mutex) = CLUSTER.get() {
+        let mut cluster = cluster_mutex.blocking_lock();
+        Ccm::remove_cluster(&mut cluster);
+    }
+}
+
+fn default_endpoint_url(cluster: &Cluster) -> String {
+    cluster.datacenters()[0].racks()[0].nodes()[0].address()
+}
+
+fn redirect_target_node(cluster: &Cluster) -> Node {
+    cluster.datacenters()[0].racks()[0].nodes()[0].clone()
+}
+
+// Struct for counting requests made to the proxy. GETs and POSTs are counted separately.
+// GETs are service discovery calls, and POSTs are the actual calls to DB.
+#[derive(Debug)]
+pub(crate) struct NodeCounter {
+    posts: AtomicUsize,
+    gets: AtomicUsize,
+}
+
+impl NodeCounter {
+    fn new() -> Self {
+        Self {
+            posts: AtomicUsize::new(0),
+            gets: AtomicUsize::new(0),
+        }
+    }
+
+    pub(crate) fn posts(&self) -> usize {
+        self.posts.load(Ordering::Relaxed)
+    }
+
+    fn reset(&self) {
+        self.posts.store(0, Ordering::Relaxed);
+        self.gets.store(0, Ordering::Relaxed);
+    }
+}
+
+pub(crate) async fn start_counting_proxy(
+    listen_addr: String,
+    connect_addr: String,
+    request_counter: Arc<NodeCounter>,
+) {
+    let proxy = proxy::Proxy::start(
+        listen_addr,
+        connect_addr,
+        move |req, send| {
+            let node_counter = Arc::clone(&request_counter);
+
+            async move {
+                {
+                    match *req.method() {
+                        Method::POST => node_counter.posts.fetch_add(1, Ordering::Relaxed),
+                        Method::GET => node_counter.gets.fetch_add(1, Ordering::Relaxed),
+                        _ => 0,
+                    };
+                }
+                proxy::forward_on_request(req, send).await
+            }
+        },
+        None,
+        None,
+    )
+    .await;
+
+    // Avoid a dead-code warning.
+    let _ = proxy.address();
+
+    // We deliberately detach the proxy task here.
+    // Each test has its own Tokio runtime, so dropping the runtime will abort
+    // this task and cleanly release the listener and connection resources.
+    // Only one test at a time can use the cluster, so old proxies will be dropped before new ones are created.
+    tokio::spawn(async move {
+        proxy.run().await;
+    });
+}
+
+// This proxy is used in tests where we check if calls are made to a node that is down.
+// Redirecting calls to a different node allows us to count calls to the stopped node,
+// while also allowing the client to use it for discovery without connection errors.
+pub(crate) async fn start_redirecting_proxy(
+    from: &Node,
+    to: &Node,
+    request_counter: Arc<NodeCounter>,
+) {
+    let listen_addr = format!("{}:{}", from.ip.clone(), from.alternator_port);
+    let connect_addr = format!("{}:{}", to.ip.clone(), ALTERNATOR_PORT);
+    start_counting_proxy(listen_addr, connect_addr, request_counter).await;
+}
+
+// This is the proxy that calls to the node go through. Used to count calls and ensure that client calls the correct nodes.
+pub(crate) async fn start_proxy_on_node(
+    node: Node,
+    proxy_port: u16,
+    request_counter: Arc<NodeCounter>,
+) {
+    let listen_addr = format!("{}:{}", node.ip, proxy_port);
+    let connect_addr = format!("{}:{}", node.ip, ALTERNATOR_PORT);
+    start_counting_proxy(listen_addr, connect_addr, request_counter).await;
+}
+
+pub(crate) async fn start_proxies(
+    cluster: &mut Cluster,
+    proxy_port: u16,
+    request_counter: &RequestCounter,
+) {
+    cluster.update_all_nodes_port(proxy_port);
+    let counter = &request_counter.counter;
+    for node in cluster.nodes() {
+        if node.is_up {
+            let node_counter = Arc::clone(counter.get(&node.ip).unwrap());
+            start_proxy_on_node(node.clone(), proxy_port, node_counter).await;
+        }
+    }
+}
+
+pub(crate) async fn start_redirecting_proxies(
+    cluster: &mut Cluster,
+    proxy_port: u16,
+    request_counter: &RequestCounter,
+) {
+    cluster.update_all_nodes_port(proxy_port);
+    let to = &redirect_target_node(cluster);
+    let counter = &request_counter.counter;
+    for node in cluster.nodes() {
+        let node_counter = Arc::clone(counter.get(&node.ip).unwrap());
+        start_redirecting_proxy(node, to, node_counter).await;
+    }
+}
+
+// Struct with a hashmap underneath for holding and monitoring the counters for multiple nodes.
+#[derive(Debug)]
+pub(crate) struct RequestCounter {
+    counter: HashMap<String, Arc<NodeCounter>>,
+}
+
+impl RequestCounter {
+    pub(crate) fn new() -> Self {
+        Self {
+            counter: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn from_cluster(cluster: &Cluster) -> Self {
+        let counter = cluster
+            .nodes()
+            .iter()
+            .map(|node| (node.ip.clone(), Arc::new(NodeCounter::new())))
+            .collect();
+        Self { counter }
+    }
+
+    pub(crate) fn get(&self, ip: &str) -> Arc<NodeCounter> {
+        Arc::clone(self.counter.get(ip).unwrap())
+    }
+
+    pub(crate) fn add(&mut self, ip: String) {
+        self.counter.insert(ip, Arc::new(NodeCounter::new()));
+    }
+
+    pub(crate) fn reset(&self) {
+        for c in self.counter.values() {
+            c.reset();
+        }
+    }
+
+    pub(crate) fn total_posts(&self) -> usize {
+        self.counter
+            .values()
+            .map(|c| c.posts.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    pub(crate) fn get_posts_to_ips(&self, ips: &[&str]) -> usize {
+        ips.iter()
+            .map(|ip| self.counter.get(*ip).unwrap().posts.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    pub(crate) fn get_posts_to_other_ips(&self, ips: &[&str]) -> usize {
+        self.counter
+            .iter()
+            .filter(|(ip, _)| !ips.contains(&ip.as_str()))
+            .map(|(_, c)| c.posts.load(Ordering::Relaxed))
+            .sum()
+    }
+}
+
+// Make calls without caring about the result, used to count where calls are directed.
+async fn make_n_calls(client: &AlternatorClient, n: usize) {
+    for _ in 0..n {
+        let _ = client.list_tables().send().await;
+    }
+}
+
+// Create a basic client with scope.
+fn create_client_with_scope(cluster: &Cluster, scope: RoutingScope) -> AlternatorClient {
+    AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .region(aws_sdk_dynamodb::config::Region::new("eu-central-1"))
+            .behavior_version_latest()
+            .endpoint_url(default_endpoint_url(cluster))
+            .routing_scope(scope)
+            .build(),
+    )
+}
+
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn calls_correct_datacenter_scope_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let scope = scope_utils::datacenter_scope_from_index(cluster, 1);
+    let client = create_client_with_scope(cluster, scope.clone());
+
+    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    let n = 20;
+    make_n_calls(&client, n).await;
+
+    // Check if it called its scope, and only its scope.
+    assert!(
+        request_counter.get_posts_to_ips(scope_utils::ips_in_scope(cluster, &scope).as_slice())
+            >= n
+    );
+    assert_eq!(
+        request_counter
+            .get_posts_to_other_ips(scope_utils::ips_in_scope(cluster, &scope).as_slice()),
+        0
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn calls_correct_rack_scope_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let scope = scope_utils::rack_scope_from_index(cluster, 1, 1);
+    let client = create_client_with_scope(cluster, scope.clone());
+
+    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    let n = 20;
+    make_n_calls(&client, n).await;
+
+    assert!(
+        request_counter.get_posts_to_ips(scope_utils::ips_in_scope(cluster, &scope).as_slice())
+            >= n
+    );
+    assert_eq!(
+        request_counter
+            .get_posts_to_other_ips(scope_utils::ips_in_scope(cluster, &scope).as_slice()),
+        0
+    );
+}
+
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn node_shut_down_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let scope = scope_utils::datacenter_scope_from_index(cluster, 1);
+    let redirect_node = redirect_target_node(cluster);
+
+    let client = create_client_with_scope(cluster, scope.clone());
+
+    // This counter holds all nodes that were shut down, sum of its counters should always be 0.
+    let mut request_counter = RequestCounter::new();
+    while let Some(node) = scope_utils::scope_first_working_node_mut(cluster, &scope) {
+        tokio::time::sleep(ACTIVE_INTERVAL).await;
+        make_n_calls(&client, 10).await;
+        assert_eq!(request_counter.total_posts(), 0);
+        Ccm::stop_node(node).unwrap();
+        request_counter.add(node.ip.clone());
+        start_redirecting_proxy(node, &redirect_node, request_counter.get(&node.ip)).await;
+    }
+}
+
+// In this test we check that when the scope fails during client work,
+// the client starts using only the fallback scope.
+// This tests fallback behavior when localnodes returns an empty list.
+// Here every call to every node is redirected to the redirect node, because we want to monitor both calls to
+// working and not working nodes.
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn scope_fallback_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+
+    start_redirecting_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let fallback_scope = scope_utils::datacenter_scope_from_index(cluster, 1);
+    let scope =
+        scope_utils::rack_scope_from_index(cluster, 1, 1).with_fallback(fallback_scope.clone());
+
+    let client = create_client_with_scope(cluster, scope.clone());
+    make_n_calls(&client, 5).await;
+
+    scope_utils::shut_down_scope(cluster, &scope);
+    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    request_counter.reset();
+
+    let n = 20;
+    make_n_calls(&client, n).await;
+    let ips = scope_utils::working_nodes_ips_in_scope(cluster, &fallback_scope);
+    assert!(request_counter.get_posts_to_ips(ips.as_slice()) >= n);
+    assert_eq!(request_counter.get_posts_to_other_ips(ips.as_slice()), 0);
+}
+
+// Test if client switches to higher priority fallback once it starts working.
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn primary_scope_recover_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let fallback_scope = scope_utils::datacenter_scope_from_index(cluster, 1);
+    let scope =
+        scope_utils::rack_scope_from_index(cluster, 1, 1).with_fallback(fallback_scope.clone());
+
+    scope_utils::shut_down_scope(cluster, &scope);
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_redirecting_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let client = create_client_with_scope(cluster, scope.clone());
+    tokio::time::sleep(ACTIVE_INTERVAL).await;
+
+    let n = 20;
+    make_n_calls(&client, n).await;
+
+    let ips = scope_utils::ips_in_scope(cluster, &fallback_scope);
+    assert!(request_counter.get_posts_to_ips(ips.as_slice()) >= n);
+    assert_eq!(request_counter.get_posts_to_other_ips(ips.as_slice()), 0);
+
+    // Start one node in main scope.
+    let mut nodes = scope_utils::nodes_in_scope_mut(cluster, &scope);
+    let node_to_start = &mut nodes[0];
+    Ccm::start_node(node_to_start).unwrap();
+    tokio::time::sleep(ACTIVE_INTERVAL).await;
+
+    request_counter.reset();
+    make_n_calls(&client, n).await;
+
+    let ip = node_to_start.ip.as_str();
+    assert!(request_counter.get_posts_to_ips(&[ip]) >= n);
+    assert_eq!(request_counter.get_posts_to_other_ips(&[ip]), 0);
+}
+
+// If a bad scope is given, the client should call only the seed node.
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn bad_scope_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let scope = RoutingScope::from_datacenter("fake_dc".to_string());
+    let client = create_client_with_scope(cluster, scope.clone());
+    let n = 20;
+    make_n_calls(&client, n).await;
+    // With a bad scope, the client should call only the seed.
+    let seed_url = default_endpoint_url(cluster);
+    let seed_ip = seed_url
+        .strip_prefix("http://")
+        .unwrap()
+        .split(':')
+        .next()
+        .unwrap();
+
+    assert!(request_counter.get_posts_to_ips(&[seed_ip]) >= n);
+    assert_eq!(request_counter.get_posts_to_other_ips(&[seed_ip]), 0);
+}
+
+// Check only if the restarted node gets requests from client.
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn node_restart_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let scope = scope_utils::datacenter_scope_from_index(cluster, 1);
+
+    // Store only its IP, so the borrow checker doesn't complain.
+    let stopped_node_ip = {
+        let node_to_stop = scope_utils::scope_first_working_node_mut(cluster, &scope).unwrap();
+        let ip = node_to_stop.ip.clone();
+        Ccm::stop_node(node_to_stop).unwrap();
+        ip
+    };
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let client = create_client_with_scope(cluster, scope.clone());
+    make_n_calls(&client, 5).await;
+
+    // Start the node and its proxy.
+    let restarted_node = {
+        let nodes = cluster.nodes_mut();
+        let restarted_node = nodes
+            .into_iter()
+            .find(|node| node.ip == stopped_node_ip)
+            .unwrap();
+        Ccm::start_node(restarted_node).unwrap();
+        restarted_node
+    };
+    let counter = request_counter.get(&stopped_node_ip);
+    start_proxy_on_node(restarted_node.clone(), PROXY_PORT, counter.clone()).await;
+
+    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    make_n_calls(&client, 20).await;
+    assert!(counter.posts() > 0);
+}
+
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn round_robin_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let scope = scope_utils::datacenter_scope_from_index(cluster, 1);
+    let client = create_client_with_scope(cluster, scope.clone());
+    tokio::time::sleep(ACTIVE_INTERVAL).await;
+
+    let n = 10;
+
+    let node_ips: Vec<&str> = scope_utils::nodes_in_scope(cluster, &scope)
+        .iter()
+        .map(|node| node.ip.as_str())
+        .collect();
+
+    let nodes_count = node_ips.len();
+
+    for _ in 0..n {
+        // Make one request per node in the scope
+        make_n_calls(&client, nodes_count).await;
+
+        // Verify each node was called exactly once
+        for ip in &node_ips {
+            assert_eq!(request_counter.get(ip).posts(), 1);
+        }
+
+        request_counter.reset();
+    }
+}

--- a/tests/load_balancing/load_balancing_tests.rs
+++ b/tests/load_balancing/load_balancing_tests.rs
@@ -19,9 +19,8 @@ use tokio::sync::{Mutex, MutexGuard};
 const PROXY_PORT: u16 = 7999;
 const ALTERNATOR_PORT: u16 = 8000;
 
-// The client will use different refresh intervals for idle mode (when nothing happened for a while)
-// and active mode, when calls are being made. Exact value might change later.
-const ACTIVE_INTERVAL: Duration = Duration::from_secs(1);
+const POLLING_TIMEOUT: Duration = Duration::from_secs(5);
+const POLLING_INTERVAL: Duration = Duration::from_millis(50);
 
 // Since cluster creation is expensive, we create it once and reuse it for every test.
 // Before a test gets access to the cluster, we make sure that all nodes are up and their ports are set to default.
@@ -273,6 +272,28 @@ fn create_client_with_scope(cluster: &Cluster, scope: RoutingScope) -> Alternato
     )
 }
 
+// Poll until the client's live nodes match the given IPs, or timeout.
+async fn wait_until_live_nodes_match(client: &AlternatorClient, ips: Vec<&str>) {
+    let live_nodes = client.config().live_nodes().unwrap().clone();
+    tokio::time::timeout(POLLING_TIMEOUT, async {
+        loop {
+            let nodes = live_nodes.get_live_nodes();
+            let node_ips: Vec<&str> = nodes.iter().map(|url| url.host_str().unwrap()).collect();
+            if node_ips.len() == ips.len() && node_ips.iter().all(|ip| ips.contains(ip)) {
+                break;
+            }
+            tokio::time::sleep(POLLING_INTERVAL).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "failed to update nodes\nexpected nodes {:?}, timed out after {:?}",
+            ips, POLLING_TIMEOUT
+        )
+    });
+}
+
 #[tokio::test]
 #[cfg_attr(not(ccm_tests), ignore)]
 async fn calls_correct_datacenter_scope_test() {
@@ -285,7 +306,11 @@ async fn calls_correct_datacenter_scope_test() {
     let scope = scope_utils::datacenter_scope_from_index(cluster, 1);
     let client = create_client_with_scope(cluster, scope.clone());
 
-    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    wait_until_live_nodes_match(
+        &client,
+        scope_utils::working_nodes_ips_in_scope(cluster, &scope),
+    )
+    .await;
     let n = 20;
     make_n_calls(&client, n).await;
 
@@ -313,7 +338,11 @@ async fn calls_correct_rack_scope_test() {
     let scope = scope_utils::rack_scope_from_index(cluster, 1, 1);
     let client = create_client_with_scope(cluster, scope.clone());
 
-    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    wait_until_live_nodes_match(
+        &client,
+        scope_utils::working_nodes_ips_in_scope(cluster, &scope),
+    )
+    .await;
     let n = 20;
     make_n_calls(&client, n).await;
 
@@ -341,8 +370,16 @@ async fn node_shut_down_test() {
 
     // This counter holds all nodes that were shut down, sum of its counters should always be 0.
     let mut request_counter = RequestCounter::new();
-    while let Some(node) = scope_utils::scope_first_working_node_mut(cluster, &scope) {
-        tokio::time::sleep(ACTIVE_INTERVAL).await;
+    loop {
+        let ips_owned: Vec<String> = scope_utils::working_nodes_ips_in_scope(cluster, &scope)
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+        let Some(node) = scope_utils::scope_first_working_node_mut(cluster, &scope) else {
+            break;
+        };
+        let ips: Vec<&str> = ips_owned.iter().map(String::as_str).collect();
+        wait_until_live_nodes_match(&client, ips).await;
         make_n_calls(&client, 10).await;
         assert_eq!(request_counter.total_posts(), 0);
         Ccm::stop_node(node).unwrap();
@@ -374,7 +411,12 @@ async fn scope_fallback_test() {
     make_n_calls(&client, 5).await;
 
     scope_utils::shut_down_scope(cluster, &scope);
-    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    wait_until_live_nodes_match(
+        &client,
+        scope_utils::working_nodes_ips_in_scope(cluster, &fallback_scope),
+    )
+    .await;
+
     request_counter.reset();
 
     let n = 20;
@@ -401,7 +443,11 @@ async fn primary_scope_recover_test() {
     start_redirecting_proxies(cluster, PROXY_PORT, &request_counter).await;
 
     let client = create_client_with_scope(cluster, scope.clone());
-    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    wait_until_live_nodes_match(
+        &client,
+        scope_utils::working_nodes_ips_in_scope(cluster, &fallback_scope),
+    )
+    .await;
 
     let n = 20;
     make_n_calls(&client, n).await;
@@ -414,7 +460,7 @@ async fn primary_scope_recover_test() {
     let mut nodes = scope_utils::nodes_in_scope_mut(cluster, &scope);
     let node_to_start = &mut nodes[0];
     Ccm::start_node(node_to_start).unwrap();
-    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    wait_until_live_nodes_match(&client, vec![node_to_start.ip.as_str()]).await;
 
     request_counter.reset();
     make_n_calls(&client, n).await;
@@ -487,7 +533,11 @@ async fn node_restart_test() {
     let counter = request_counter.get(&stopped_node_ip);
     start_proxy_on_node(restarted_node.clone(), PROXY_PORT, counter.clone()).await;
 
-    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    wait_until_live_nodes_match(
+        &client,
+        scope_utils::working_nodes_ips_in_scope(cluster, &scope),
+    )
+    .await;
     make_n_calls(&client, 20).await;
     assert!(counter.posts() > 0);
 }
@@ -503,7 +553,11 @@ async fn round_robin_test() {
 
     let scope = scope_utils::datacenter_scope_from_index(cluster, 1);
     let client = create_client_with_scope(cluster, scope.clone());
-    tokio::time::sleep(ACTIVE_INTERVAL).await;
+    wait_until_live_nodes_match(
+        &client,
+        scope_utils::working_nodes_ips_in_scope(cluster, &scope),
+    )
+    .await;
 
     let n = 10;
 

--- a/tests/load_balancing/mod.rs
+++ b/tests/load_balancing/mod.rs
@@ -1,0 +1,7 @@
+#[path = "../common/proxy.rs"]
+pub mod proxy;
+
+#[path = "common/scope_utils.rs"]
+pub mod scope_utils;
+
+pub mod load_balancing_tests;

--- a/tests/load_balancing_tests.rs
+++ b/tests/load_balancing_tests.rs
@@ -1,0 +1,2 @@
+mod ccm_wrapper;
+mod load_balancing;


### PR DESCRIPTION
Introduces load balancing with round-robin strategy. 

`live_nodes.rs` - a background task for service discovery that refreshes known nodes list and falls back to further scopes if needed,
`query_plan.rs` - object put in a config bag before request is made, chooses which node will the request be sent to.

Closes #18 