### PR TITLE
Change active_interval and idle_interval to std::time::Duration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,8 +12,8 @@ use crate::*;
 pub(crate) struct AlternatorExtensions {
     pub(crate) request_compression: Option<RequestCompression>,
     pub(crate) enforce_header_whitelist: Option<bool>,
-    pub(crate) active_interval: Option<u64>,
-    pub(crate) idle_interval: Option<u64>,
+    pub(crate) active_interval: Option<std::time::Duration>,
+    pub(crate) idle_interval: Option<std::time::Duration>,
     pub(crate) routing_scope: Option<RoutingScope>,
     pub(crate) scheme: Option<String>,
     pub(crate) port: Option<u16>,
@@ -82,32 +82,28 @@ impl AlternatorConfig {
         self.alternator_ext.request_compression.clone()
     }
 
-    /// Gets the active interval (in milliseconds) for refreshing the list of known nodes
-    /// when the client is active.
+    /// Gets the active interval for refreshing the list of known nodes when the client is active.
     ///
     /// While the client is sending requests to the cluster, the node list is refreshed at
     /// this interval to quickly detect topology changes.
     ///
-    /// The client is considered active when it has sent a request within the last
-    /// `idle_interval` milliseconds.
+    /// The client is considered active when it has sent a request within the last `idle_interval`.
     ///
-    /// The default value is 1000 ms (1 second).
-    pub fn active_interval(&self) -> Option<u64> {
+    /// The default value is 1 second.
+    pub fn active_interval(&self) -> Option<std::time::Duration> {
         self.alternator_ext.active_interval
     }
 
-    /// Gets the idle interval (in milliseconds) for refreshing the list of known nodes
-    /// when the client is idle.
+    /// Gets the idle interval for refreshing the list of known nodes when the client is idle.
     ///
     /// While no requests are being made to the cluster, the node list is refreshed at this
     /// longer interval to reduce unnecessary network traffic while still keeping the list
     /// reasonably up-to-date.
     ///
-    /// The client is considered idle when it hasn't sent a request within the last
-    /// `idle_interval` milliseconds.
+    /// The client is considered idle when it hasn't sent a request within the last `idle_interval`.
     ///
-    /// The default value is 60000 ms (1 minute).
-    pub fn idle_interval(&self) -> Option<u64> {
+    /// The default value is 1 minute.
+    pub fn idle_interval(&self) -> Option<std::time::Duration> {
         self.alternator_ext.idle_interval
     }
 
@@ -262,64 +258,56 @@ impl AlternatorBuilder {
         self
     }
 
-    /// Sets the active interval (in milliseconds) for refreshing the list of known nodes
-    /// when the client is active.
+    /// Sets the active interval for refreshing the list of known nodes when the client is active.
     ///
     /// While the client is sending requests to the cluster, the node list is refreshed at
     /// this interval to quickly detect topology changes.
     ///
-    /// The client is considered active when it has sent a request within the last
-    /// `idle_interval` milliseconds.
+    /// The client is considered active when it has sent a request within the last `idle_interval`.
     ///
-    /// The default value is 1000 ms (1 second).
-    pub fn active_interval(mut self, active_interval: u64) -> Self {
+    /// The default value is 1 second.
+    pub fn active_interval(mut self, active_interval: std::time::Duration) -> Self {
         self.set_active_interval(active_interval);
         self
     }
 
-    /// Sets the active interval (in milliseconds) for refreshing the list of known nodes
-    /// when the client is active.
+    /// Sets the active interval for refreshing the list of known nodes when the client is active.
     ///
     /// While the client is sending requests to the cluster, the node list is refreshed at
     /// this interval to quickly detect topology changes.
     ///
-    /// The client is considered active when it has sent a request within the last
-    /// `idle_interval` milliseconds.
+    /// The client is considered active when it has sent a request within the last `idle_interval`.
     ///
-    /// The default value is 1000 ms (1 second).
-    pub fn set_active_interval(&mut self, active_interval: u64) -> &mut Self {
+    /// The default value is 1 second.
+    pub fn set_active_interval(&mut self, active_interval: std::time::Duration) -> &mut Self {
         self.alternator_ext.active_interval = Some(active_interval);
         self
     }
 
-    /// Sets the idle interval (in milliseconds) for refreshing the list of known nodes
-    /// when the client is idle.
+    /// Sets the idle interval for refreshing the list of known nodes when the client is idle.
     ///
     /// While no requests are being made to the cluster, the node list is refreshed at this
     /// longer interval to reduce unnecessary network traffic while still keeping the list
     /// reasonably up-to-date.
     ///
-    /// The client is considered idle when it hasn't sent a request within the last
-    /// `idle_interval` milliseconds.
+    /// The client is considered idle when it hasn't sent a request within the last `idle_interval`.
     ///
-    /// The default value is 60000 ms (1 minute).
-    pub fn idle_interval(mut self, idle_interval: u64) -> Self {
+    /// The default value is 1 minute.
+    pub fn idle_interval(mut self, idle_interval: std::time::Duration) -> Self {
         self.set_idle_interval(idle_interval);
         self
     }
 
-    /// Sets the idle interval (in milliseconds) for refreshing the list of known nodes
-    /// when the client is idle.
+    /// Sets the idle interval for refreshing the list of known nodes when the client is idle.
     ///
     /// While no requests are being made to the cluster, the node list is refreshed at this
     /// longer interval to reduce unnecessary network traffic while still keeping the list
     /// reasonably up-to-date.
     ///
-    /// The client is considered idle when it hasn't sent a request within the last
-    /// `idle_interval` milliseconds.
+    /// The client is considered idle when it hasn't sent a request within the last `idle_interval`.
     ///
-    /// The default value is 60000 ms (1 minute).
-    pub fn set_idle_interval(&mut self, idle_interval: u64) -> &mut Self {
+    /// The default value is 1 minute.
+    pub fn set_idle_interval(&mut self, idle_interval: std::time::Duration) -> &mut Self {
         self.alternator_ext.idle_interval = Some(idle_interval);
         self
     }

--- a/src/live_nodes.rs
+++ b/src/live_nodes.rs
@@ -83,8 +83,9 @@ use std::time::{Duration, Instant};
 use tokio::runtime::Handle;
 use url::Url;
 
-const DEFAULT_ACTIVE_REFRESH_INTERVAL_MS: u64 = 1000;
-const DEFAULT_IDLE_REFRESH_INTERVAL_MS: u64 = 60000;
+const DEFAULT_ACTIVE_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const DEFAULT_IDLE_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+
 #[derive(Debug)]
 pub struct LiveNodes {
     routing_scope: RoutingScope,
@@ -106,10 +107,10 @@ impl LiveNodes {
     pub fn new(config: &crate::config::AlternatorConfig) -> Option<Arc<Self>> {
         let active_interval = config
             .active_interval()
-            .unwrap_or(DEFAULT_ACTIVE_REFRESH_INTERVAL_MS);
+            .unwrap_or(DEFAULT_ACTIVE_REFRESH_INTERVAL);
         let idle_interval = config
             .idle_interval()
-            .unwrap_or(DEFAULT_IDLE_REFRESH_INTERVAL_MS);
+            .unwrap_or(DEFAULT_IDLE_REFRESH_INTERVAL);
         let routing_scope = config
             .routing_scope()
             .unwrap_or(RoutingScope::from_cluster());
@@ -137,8 +138,8 @@ impl LiveNodes {
 
         Some(Arc::new(Self {
             routing_scope,
-            active_interval: Duration::from_millis(active_interval),
-            idle_interval: Duration::from_millis(idle_interval),
+            active_interval,
+            idle_interval,
             counter: Arc::new(AtomicUsize::new(0)),
             live_nodes: ArcSwap::from_pointee(seed_urls.clone()),
             seed_urls,


### PR DESCRIPTION
As decided in #33, changed `active_interval` and `idle_interval` fields from `u64` (milliseconds) to std::time::Duration.
The new way is more idiomatic, user-friendly, and follows the AWS SDK API.