### PR TITLE
Improve code comments and rustdoc

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,14 +6,16 @@ use crate::*;
 ///
 /// By default:
 /// - enables round-robin load balancing
-/// - strips headers that are not used by the alternator from all requests
-/// - chooses an arbitrary aws region, as alternator doesn't require one
+/// - strips headers that Alternator does not use from all requests
+/// - sets a default AWS region, as Alternator does not require a specific one
 /// - does not use request compression
 ///
-/// Can be build using [AlternatorConfig] like so:
-/// ```ignore
+/// Can be built with [AlternatorConfig] like so:
+/// ```
+/// use alternator_driver::{AlternatorClient, AlternatorConfig};
 /// let config =
 ///     AlternatorConfig::builder()
+///    .behavior_version_latest()
 ///     // ...
 ///     .build();
 ///

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -18,7 +18,8 @@ pub struct RequestCompression {
     compression_with_threshold: Option<(CompressionAlgorithm, CompressionLevel, usize)>,
 }
 impl RequestCompression {
-    /// Represents request compression that is applied when http body size exceeds given threshold.
+    /// Represents request compression that is applied when the HTTP body size is
+    /// at least the given threshold.
     ///
     /// When threshold is zero, compression is always applied.
     pub fn enabled(
@@ -86,7 +87,7 @@ fn decompress_zlib(content: &[u8]) -> Option<Vec<u8>> {
 
 /// To be used in an interceptor
 ///
-/// Checks if size of the body exceeds specified threshold.
+/// Checks whether the body size meets the specified threshold.
 /// If so, tries to compress the body and modify `content-encoding` and `content-length` headers accordingly.
 ///
 /// If compression failed or request already contained the `content-encoding` header, leaves the request untouched.

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,9 +28,11 @@ pub(crate) struct AlternatorExtensions {
 ///
 /// It is used to construct [AlternatorClient] like so:
 ///
-/// ```ignore
+/// ```
+/// use alternator_driver::{AlternatorClient, AlternatorConfig};
 /// let config =
 ///     AlternatorConfig::builder()
+///     .behavior_version_latest()
 ///     // ...
 ///     .build();
 ///
@@ -57,7 +59,8 @@ impl AlternatorConfig {
         AlternatorBuilder::from(config).build()
     }
 
-    /// Before sending each request, strip the headers from them which are not used by the Alternator.
+    /// Before sending each request, strip headers that Alternator does not use
+    /// from the request.
     ///
     /// This is done by an interceptor in `modify_before_transmit` hook.
     ///
@@ -176,9 +179,11 @@ impl AlternatorConfig {
 ///
 /// It is used to construct [AlternatorClient] like so:
 ///
-/// ```ignore
+/// ```
+/// use alternator_driver::{AlternatorClient, AlternatorConfig};
 /// let config =
 ///     AlternatorConfig::builder()
+///    .behavior_version_latest()
 ///     // ...
 ///     .build();
 ///
@@ -484,10 +489,14 @@ impl AlternatorBuilder {
     /// Sets the key route affinity configuration.
     ///
     /// Use it either with a pre-constructed [keyrouting::affinity_config::KeyRouteAffinityConfig]
-    /// or with a [keyrouting::affinity_config::KeyRouteAffinity] for simpler use cases.
-    /// Calling with [keyrouting::affinity_config::KeyRouteAffinityType::None], is equivalent to not setting the affinity at all.
+    /// or with a [keyrouting::affinity_config::KeyRouteAffinityType] for simpler
+    /// use cases. Calling with
+    /// [keyrouting::affinity_config::KeyRouteAffinityType::None] is equivalent
+    /// to not setting the affinity at all.
     ///
-    /// For more information see [keyrouting::affinity_config::KeyRouteAffinityConfig] and [keyrouting::affinity_config::KeyRouteAffinityType].
+    /// For more information, see
+    /// [keyrouting::affinity_config::KeyRouteAffinityConfig] and
+    /// [keyrouting::affinity_config::KeyRouteAffinityType].
     pub fn key_route_affinity(
         mut self,
         key_route_affinity: impl Into<keyrouting::affinity_config::KeyRouteAffinityConfig>,
@@ -499,10 +508,14 @@ impl AlternatorBuilder {
     /// Sets the key route affinity configuration.
     ///
     /// Use it either with a pre-constructed [keyrouting::affinity_config::KeyRouteAffinityConfig]
-    /// or with a [keyrouting::affinity_config::KeyRouteAffinity] for simpler use cases.
-    /// Calling with [keyrouting::affinity_config::KeyRouteAffinityType::None], is equivalent to not setting the affinity at all.
+    /// or with a [keyrouting::affinity_config::KeyRouteAffinityType] for simpler
+    /// use cases. Calling with
+    /// [keyrouting::affinity_config::KeyRouteAffinityType::None] is equivalent
+    /// to not setting the affinity at all.
     ///
-    /// For more information see [keyrouting::affinity_config::KeyRouteAffinityConfig] and [keyrouting::affinity_config::KeyRouteAffinityType].
+    /// For more information, see
+    /// [keyrouting::affinity_config::KeyRouteAffinityConfig] and
+    /// [keyrouting::affinity_config::KeyRouteAffinityType].
     pub fn set_key_route_affinity(
         &mut self,
         key_route_affinity: impl Into<keyrouting::affinity_config::KeyRouteAffinityConfig>,

--- a/src/customize.rs
+++ b/src/customize.rs
@@ -2,24 +2,41 @@ use crate::*;
 
 use aws_sdk_dynamodb::client::customize::CustomizableOperation;
 
-/// Trait to be implemented by Dynamodb's [CustomizableOperation].
+/// Extension trait for DynamoDB's [CustomizableOperation].
 ///
-/// It allows us to override [AlternatorConfig] at per-operation level, like so:
-/// ```ignore
+/// Build the client with a full [`AlternatorConfig`], then use a partial
+/// [`AlternatorConfig::builder()`] value to override Alternator settings for a
+/// single operation:
+/// ```no_run
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// use alternator_driver::{
+///     AlternatorClient,
+///     AlternatorConfig,
+///     AlternatorCustomizableOperation,
+///     RequestCompression,
+/// };
+///
+/// let config = AlternatorConfig::builder()
+///     .behavior_version_latest()
+///     .build();
+///
+/// let client = AlternatorClient::from_conf(config);
+///
 /// client
 ///     .create_table()
 ///     // ...
 ///     .customize()
 ///     .alternator_config_override(
+///         // Per-operation overrides take a builder, not a built config.
 ///         AlternatorConfig::builder()
 ///             .optimize_headers(false)
 ///             .request_compression(RequestCompression::disabled())
-///             .behavior_version_latest()
-///             .build()
+///             .behavior_version_latest(),
 ///     )
 ///     .send()
 ///     .await
 ///     .unwrap();
+/// # });
 /// ```
 pub trait AlternatorCustomizableOperation<T, E, B> {
     fn alternator_config_override(self, config_override: impl Into<AlternatorBuilder>) -> Self;

--- a/src/keyrouting/affinity_config.rs
+++ b/src/keyrouting/affinity_config.rs
@@ -40,21 +40,26 @@ pub enum KeyRouteAffinityType {
 ///
 /// Build directly from a mode for the common case:
 ///
-/// ```ignore
+/// ```
+/// use alternator_driver::{KeyRouteAffinityConfig, KeyRouteAffinityType};
 /// let cfg: KeyRouteAffinityConfig = KeyRouteAffinityType::Rmw.into();
 /// ```
 ///
-/// Or when passing it directly to `AlternatorClientBuilder`:
-/// ```ignore
-/// let client = AlternatorDynamoDbClient::builder()
+/// Or when passing it directly to `AlternatorConfig::builder()`:
+/// ```
+/// use alternator_driver::{AlternatorClient, AlternatorConfig, KeyRouteAffinityType};
+/// let config = AlternatorConfig::builder()
+///     .behavior_version_latest()
 ///     .key_route_affinity(KeyRouteAffinityType::Rmw)
 ///     .build();
+/// let client = AlternatorClient::from_conf(config);
 /// ```
 ///
 /// Or via the builder to pre-configure PK names and skip the
 /// `DescribeTable` lookup:
 ///
-/// ```ignore
+/// ```
+/// use alternator_driver::{KeyRouteAffinityConfig, KeyRouteAffinityType};
 /// let cfg = KeyRouteAffinityConfig::builder()
 ///     .with_type(KeyRouteAffinityType::Rmw)
 ///     .with_pk_info("users", "user_id")

--- a/src/keyrouting/hasher.rs
+++ b/src/keyrouting/hasher.rs
@@ -18,8 +18,10 @@
 //!
 //! Example for a table with composite key (user_id, timestamp):
 //!
-//! ```rust,ignore
+//! ```rust
 //! // Only hash the partition key (user_id)
+//! use alternator_driver::keyrouting::hasher::hash_attribute_value;
+//! use aws_sdk_dynamodb::types::AttributeValue;
 //! let partition_key = AttributeValue::S("user_123".to_string());
 //! let hash = hash_attribute_value(&partition_key);
 //! ```

--- a/src/live_nodes.rs
+++ b/src/live_nodes.rs
@@ -5,8 +5,9 @@
 //! [`LiveNodes`] is constructed from an [`AlternatorConfig`] and seeded with a list of hosts.
 //! Once [`start`] is called, a background Tokio task
 //! periodically calls the [`update_live_nodes`] function which requests the known
-//! nodes in a random order to get an updated list of live nodes. After starting, the list is
-//! guaranteed to always contain nodes in the highest available scope in the fallback chain provided by the user.
+//! nodes in a random order to get an updated list of live nodes. After a
+//! successful refresh, the list is updated to nodes from the highest available
+//! scope in the fallback chain provided by the user.
 //! Underneath it uses a basic [`reqwest::Client`] with timeouts.
 //!
 //! # Polling cadence
@@ -22,8 +23,8 @@
 //!
 //! # Discovery mechanism
 //!
-//! Each refresh starts from the highest scope in fallback chain, it shuffles
-//! the current node list and walks it as a candidate queue:
+//! Each refresh starts from the highest scope in the fallback chain, shuffles
+//! the current node list, and walks it as a candidate queue:
 //! - If a node responds with a non-empty list, the list is used as the new live nodes list,
 //!   and the refresh ends.
 //! - If a node responds with an empty list, it is put back at the end of the queue,
@@ -33,7 +34,7 @@
 //! - If the queue is exhausted without a successful response, it is populated with
 //!   the seed nodes, and the process repeats. If the seeds are exhausted without success, the refresh ends with no changes.
 //!
-//! Once it successfully gets a non-empty response, atomically updates the [`live_nodes`] list using ['ArcSwap].
+//! Once it successfully gets a non-empty response, it atomically updates the [`live_nodes`] list using [`ArcSwap`].
 //!
 //!  # Lifetime
 //!
@@ -48,10 +49,10 @@
 //! It is handled by funneling start-up through a single idempotent entry point:
 //! [`ensure_discovery_started`]. It does three things, in order:
 //!
-//! 1. If discovery is already running, return immediately (a relaxed atomic load, essentially free).
+//! 1. If discovery is already running, return immediately (an atomic load, essentially free).
 //! 2. Runtime check: if no Tokio runtime is available on the current thread, return without spawning.
 //!    The task will be started lazily on the first [`get_next_node_round_robin`] or [`get_live_nodes`] call,
-//!    which is always invoked from within the request pipeline and therefore always inside a runtime.
+//!    which is typically invoked from within the request pipeline and therefore from within a runtime.
 //! 3. A `compare_exchange` on `discovery_started` ensures that
 //!    exactly one caller wins the right to spawn the task, even under
 //!    concurrent first-access from multiple threads.

--- a/src/query_plan.rs
+++ b/src/query_plan.rs
@@ -1,6 +1,7 @@
 //! Query plan for Alternator requests.
 //!
-//! The object is put in the config and on each requests is used to determine which node to send the request to.
+//! The object is stored in the config and is used on each request to determine
+//! which node to send the request to.
 
 use crate::keyrouting::go_rand::GoRand;
 use crate::live_nodes::LiveNodes;

--- a/tests/http_content/body_compression.rs
+++ b/tests/http_content/body_compression.rs
@@ -14,7 +14,7 @@
 //!    then customize a call to enable compression and assert it is correctly compressed,
 //!    then perform an uncustomized call to assert the customization doesn't last
 //!
-//! 4. Disabled by per-request compression
+//! 4. Disabled by per-request customization
 //!    Enable compression in client, then customize a call to disable the compression,
 //!    then assert the request was not compressed
 //!

--- a/tests/http_content/common/http_test.rs
+++ b/tests/http_content/common/http_test.rs
@@ -1,32 +1,34 @@
 //! # HTTP Content Tests Context
 //!
-//! All HTTP content tests perform driver calls to alternator.
-//! In the middle of the traffic, stands a proxy server that reads, validates and
-//! possibly modifies forwarded messages.
+//! All HTTP content tests perform driver calls to Alternator.
+//! A proxy server sits in the middle of the traffic, reads forwarded messages,
+//! validates them, and can optionally modify them.
 //!
-//! HttpTestContext provides a framework for such tests, integrated with test_context crate.
+//! `HttpTestContext` provides a framework for such tests and integrates with
+//! the `test_context` crate.
 //!
 //! ### Making tests
 //! 1. Define a cleanup function for your test and optionally the initial on_request
 //!    function to be called inside the proxy whenever a new request goes through.
 //!
-//!    Do this by writting a custom MyConfig struct that implements HttpTestConfig.
+//!    Do this by writing a custom `MyConfig` struct that implements `HttpTestConfig`.
 //!
 //! 2. Use HttpTestContext<MyConfig> as context for test_context crate, so that the proxy
-//!    sets up and cleanup is performed on finish.
+//!    is set up and cleanup is performed at the end.
 //!
 //! 3. Inside the test function, construct a new driver client with
-//!    endpoint HttpTestContext::get_proxy_address().
+//!    `HttpTestContext::get_proxy_address()` as the endpoint.
 //!
 //! 4. Whenever you create a resource that requires cleanup,
-//!    register it with HttpTestContext::register_resource()
+//!    register it with `HttpTestContext::register_resource()`.
 //!
-//! 5. You can override the initial on_request with HttpTestContext::set_on_request().
+//! 5. You can override the initial `on_request` with
+//!    `HttpTestContext::set_on_request()`.
 //!
-//! **Note:** since load balancing is automatically enabled,
-//! the GETs from the discovery may interfere with the test logic.
-//! To work around this, you can disable load balancing by setting an empty list
-//! of seed hosts in the client configuration, using `.seed_hosts(Vec::<String>::new())`.
+//! **Note:** Since load balancing is enabled automatically, the GET requests
+//! from discovery may interfere with the test logic. To work around this, you
+//! can disable load balancing by setting an empty list of seed hosts in the
+//! client configuration with `.seed_hosts(Vec::<String>::new())`.
 
 use crate::http_content::proxy::*;
 

--- a/tests/http_content/correct_line.rs
+++ b/tests/http_content/correct_line.rs
@@ -1,6 +1,7 @@
 //! Correct Request Line Test
-//! This test asserts driver generates only requests with correct line: Method = POST, URI = "/".
-//! We use a proxy to intercept messages sent between driver and alternator.
+//! This test verifies that the driver generates only requests with the correct
+//! request line: method = POST, URI = "/".
+//! We use a proxy to intercept messages sent between the driver and Alternator.
 use crate::http_content::driver_utils::*;
 use crate::http_content::http_test::*;
 use crate::http_content::proxy::*;

--- a/tests/http_content/optimize_headers.rs
+++ b/tests/http_content/optimize_headers.rs
@@ -1,36 +1,31 @@
-//! Header Whitelist Tests
-//! In this module we assert that the driver strips headers from requests when those headers are not used by alternator.
-//! We use a proxy to intercept messages sent between driver and alternator.
+//! Header whitelist tests.
 //!
-//! There are 5 test cases:
-//! 1. Without Credentials:
-//!    Disable use of credentials, then check if all requests follow specific header whitelist:
+//! This module verifies that the driver strips headers that Alternator does not
+//! use from outgoing requests. A proxy is used to intercept messages exchanged
+//! between the driver and Alternator.
+//!
+//! There are five test cases:
+//! 1. Without credentials:
+//!    Disable credentials and verify that requests follow this whitelist:
 //!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding"]
-//!
-//! 2. With Credentials:
-//!    Enable use of credentials, then check if all requests follow specific header whitelist:
+//! 2. With credentials:
+//!    Enable credentials and verify that requests follow this whitelist:
 //!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding", "authorization", "x-amz-date"]
+//! 3. Whitelist needed:
+//!    Enable credentials, disable header stripping, and verify that
+//!    unnecessary headers are present, confirming that stripping is useful.
+//! 4. Enabled by per-request customization:
+//!    Disable header stripping in the client config, override it for one call,
+//!    and then make another non-customized call to verify that the override
+//!    does not persist.
+//! 5. Disabled by per-request customization:
+//!    Enable header stripping in the client config, override it for one call,
+//!    and then make another non-customized call to verify that the override
+//!    does not persist.
 //!
-//! 3. Whitelist Needed:
-//!    Enable use of credentials, disable header stripping,
-//!    then check if unnecessary headers are used at all (therefore we in fact, need to strip them)
-//!
-//! 4. Enabled by Per Request Customization:
-//!    Disable header stripping in the config,
-//!    then customize a call to override it,
-//!    then make another non-customized call to assert the override doesn't last.
-//!
-//!    We use the same whitelist as in With Credentials test.
-//!     
-//! 5. Disabled by Per Request Customization:
-//!    Enable header stripping in the config,
-//!    then customize a call to override it,
-//!    then make another non-customized call to assert the override doesn't last.
-//!
-//!    We use the same whitelist as in With Credentials test.
-//!
-//! All share the same cleanup function, first 3 use the same set of driver calls,
-//! the last 2 also use the same set of driver calls.
+//! All tests share the same cleanup function. The first three also share the
+//! same set of driver calls, and the last two share another set of driver
+//! calls.
 //!
 use crate::http_content::driver_utils::*;
 use crate::http_content::http_test::*;


### PR DESCRIPTION
Clean up wording, grammar, and clarity across public rustdoc and test-module comments. Align documentation with current behavior and fix inaccurate or outdated references and examples.

Fixes #39.