### PR TITLE
Align HTTPS discovery trust with API requests and add HTTPS integration coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ flate2 = "1.1.5"
 http-body-util = "0.1"
 anyhow = "1.0.102"
 itertools = "0.14.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 url = "2.5.8"
 arc-swap = "1.9.1"
 rand = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ dashmap = "6.1.0"
 [dev-dependencies]
 aws-sdk-dynamodb = { version = "1.103.0", features = ["test-util"] }
 aws-smithy-types = { version = "1.3.6", features = ["http-body-1-x"] }
-aws-smithy-http-client = "1.1.5"
+aws-smithy-http-client = { version = "1.1.5", features = ["rustls-aws-lc"] }
 uuid = { version = "1.22.0", features = ["v4"] }
 hyper = { version = "1.8", features = ["client", "server", "http1"] }
 http = "1.0"
@@ -36,6 +36,10 @@ futures = "0.3.31"
 test-context = "0.5.5"
 rustdoc-types = "0.56.0"
 serde_json = "1.0"
+rcgen = "0.13"
+rustls = "0.23"
+tokio-rustls = "0.26"
+rustls-pki-types = "1"
 ctor = "0.8.0"
 
 [lints.rust]

--- a/tests/common/proxy.rs
+++ b/tests/common/proxy.rs
@@ -50,6 +50,9 @@ pub struct Proxy<'a> {
 }
 
 impl<'a> Proxy<'a> {
+    // This file is compiled separately into multiple integration-test crates.
+    // Some crates only use the plain entrypoint, others only the TLS one.
+    #[allow(dead_code)]
     pub async fn start<F, Fut>(
         listen_address: String,
         connect_address: String,
@@ -64,7 +67,99 @@ impl<'a> Proxy<'a> {
             + 'static,
         Fut: Future<Output = Response<Full<Bytes>>> + Send + 'static,
     {
+        Self::start_with_accept(
+            listen_address,
+            connect_address,
+            on_request,
+            on_client_connect,
+            on_client_disconnect,
+            |stream| async move { TokioIo::new(stream) },
+        )
+        .await
+    }
+
+    pub async fn run(self) {
+        self.task.await;
+    }
+
+    pub fn address(&self) -> SocketAddr {
+        self.listen_address
+    }
+
+    async fn bind_listener(address: String) -> (TcpListener, SocketAddr) {
+        let listener = TcpListener::bind(address).await.unwrap();
+        let listen_address = listener.local_addr().unwrap();
+        (listener, listen_address)
+    }
+
+    async fn connect_server(
+        address: String,
+    ) -> (
+        Arc<Mutex<SendRequest<Full<Bytes>>>>,
+        Pin<Box<Fuse<impl Future<Output = Result<(), hyper::Error>>>>>,
+    ) {
+        let stream = TcpStream::connect(address).await.unwrap();
+        let stream = TokioIo::new(stream);
+        let client = hyper_client::Builder::new();
+        let (sender, connection) = client.handshake::<_, Full<Bytes>>(stream).await.unwrap();
+        let sender = Arc::new(Mutex::new(sender));
+
+        (sender, Box::pin(connection.fuse()))
+    }
+
+    /// Like [`start`], but wraps connections with TLS using the provided acceptor.
+    // This file is compiled separately into multiple integration-test crates.
+    // Some crates only use the TLS entrypoint, others only the plain one.
+    #[allow(dead_code)]
+    pub async fn start_tls<F, Fut>(
+        listen_address: String,
+        connect_address: String,
+        on_request: F,
+        on_client_connect: Option<Box<dyn Fn(SocketAddr) + Send + Sync>>,
+        on_client_disconnect: Option<Box<dyn Fn() + Send + Sync>>,
+        acceptor: tokio_rustls::TlsAcceptor,
+    ) -> Proxy<'a>
+    where
+        F: Fn(Request<Incoming>, Arc<Mutex<SendRequest<Full<Bytes>>>>) -> Fut
+            + Send
+            + Sync
+            + 'static,
+        Fut: Future<Output = Response<Full<Bytes>>> + Send + 'static,
+    {
+        Self::start_with_accept(
+            listen_address,
+            connect_address,
+            on_request,
+            on_client_connect,
+            on_client_disconnect,
+            move |stream| {
+                let acceptor = acceptor.clone();
+                async move { TokioIo::new(acceptor.accept(stream).await.unwrap()) }
+            },
+        )
+        .await
+    }
+
+    async fn start_with_accept<F, Fut, A, AFut, IO>(
+        listen_address: String,
+        connect_address: String,
+        on_request: F,
+        on_client_connect: Option<Box<dyn Fn(SocketAddr) + Send + Sync>>,
+        on_client_disconnect: Option<Box<dyn Fn() + Send + Sync>>,
+        accept_stream: A,
+    ) -> Proxy<'a>
+    where
+        F: Fn(Request<Incoming>, Arc<Mutex<SendRequest<Full<Bytes>>>>) -> Fut
+            + Send
+            + Sync
+            + 'static,
+        Fut: Future<Output = Response<Full<Bytes>>> + Send + 'static,
+        A: Fn(TcpStream) -> AFut + Send + Sync + 'static,
+        AFut: Future<Output = IO> + Send + 'static,
+        IO: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
+    {
         let on_request = Arc::new(on_request);
+        let accept_stream = Arc::new(accept_stream);
         let on_client_connect: Option<Arc<dyn Fn(SocketAddr) + Send + Sync>> =
             on_client_connect.map(Arc::from);
         let on_client_disconnect: Option<Arc<dyn Fn() + Send + Sync>> =
@@ -101,7 +196,7 @@ impl<'a> Proxy<'a> {
                             }
                             accepted = listener.accept() => {
                                 let (stream, client_address) = accepted.unwrap();
-                                let stream = TokioIo::new(stream);
+                                let stream = accept_stream(stream).await;
 
                                 if let Some(on_client_connect) = &on_client_connect {
                                     on_client_connect(client_address);
@@ -142,35 +237,6 @@ impl<'a> Proxy<'a> {
             task: Box::pin(task),
             listen_address,
         }
-    }
-
-    pub async fn run(self) {
-        self.task.await;
-    }
-
-    pub fn address(&self) -> SocketAddr {
-        self.listen_address
-    }
-
-    async fn bind_listener(address: String) -> (TcpListener, SocketAddr) {
-        let listener = TcpListener::bind(address).await.unwrap();
-        let listen_address = listener.local_addr().unwrap();
-        (listener, listen_address)
-    }
-
-    async fn connect_server(
-        address: String,
-    ) -> (
-        Arc<Mutex<SendRequest<Full<Bytes>>>>,
-        Pin<Box<Fuse<impl Future<Output = Result<(), hyper::Error>>>>>,
-    ) {
-        let stream = TcpStream::connect(address).await.unwrap();
-        let stream = TokioIo::new(stream);
-        let client = hyper_client::Builder::new();
-        let (sender, connection) = client.handshake::<_, Full<Bytes>>(stream).await.unwrap();
-        let sender = Arc::new(Mutex::new(sender));
-
-        (sender, Box::pin(connection.fuse()))
     }
 }
 

--- a/tests/https_test/common/https_test_context.rs
+++ b/tests/https_test/common/https_test_context.rs
@@ -1,0 +1,152 @@
+//! Shared HTTPS test context.
+//!
+//! Each test gets a TLS-terminating proxy in front of the real Alternator HTTP port.
+//! The generated CA is published through `SSL_CERT_FILE` so both the SDK path and
+//! the reqwest-based discovery path trust the proxy certificate.
+
+use crate::https_test::proxy::forward_on_request;
+use crate::https_test::proxy::*;
+
+use test_context::AsyncTestContext;
+
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
+use hyper::client::conn::http1::SendRequest;
+use hyper::{Request, Response};
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+use futures::FutureExt;
+use futures::future::BoxFuture;
+
+use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio_rustls::TlsAcceptor;
+use uuid::Uuid;
+
+const ALTERNATOR_ADDRESS: &str = "localhost:8000";
+
+struct Fixture {
+    ca_pem: String,
+    acceptor: TlsAcceptor,
+}
+
+static FIXTURE: std::sync::LazyLock<Fixture> = std::sync::LazyLock::new(|| {
+    let ca_key = KeyPair::generate().unwrap();
+    let mut ca_params = CertificateParams::new(vec!["Test CA".to_string()]).unwrap();
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![rcgen::KeyUsagePurpose::KeyCertSign];
+    let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+
+    let server_key = KeyPair::generate().unwrap();
+    let server_params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+    let server_cert = server_params
+        .signed_by(&server_key, &ca_cert, &ca_key)
+        .unwrap();
+
+    let certs_chain = vec![CertificateDer::from(server_cert.der().to_vec())];
+    let priv_key = PrivateKeyDer::try_from(server_key.serialize_der()).unwrap();
+    let server_config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs_chain, priv_key)
+        .unwrap();
+
+    Fixture {
+        ca_pem: ca_cert.pem(),
+        acceptor: TlsAcceptor::from(Arc::new(server_config)),
+    }
+});
+
+fn write_ca_and_set_env(ca_pem: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!("https_test_ca_{}.pem", Uuid::new_v4()));
+    std::fs::write(&path, ca_pem).unwrap();
+    // SAFETY: These HTTPS tests are marked `#[serial]` and use Tokio's
+    // `current_thread` runtime, so this test process runs only one of these
+    // env-mutating test contexts at a time during setup/teardown.
+    unsafe { std::env::set_var("SSL_CERT_FILE", &path) };
+    path
+}
+
+type OnRequest = Box<
+    dyn Fn(
+            Request<Incoming>,
+            Arc<Mutex<SendRequest<Full<Bytes>>>>,
+        ) -> BoxFuture<'static, Response<Full<Bytes>>>
+        + Send
+        + Sync,
+>;
+
+pub struct HttpsTestContext {
+    on_request: Arc<Mutex<OnRequest>>,
+    proxy_handle: JoinHandle<()>,
+    proxy_address: String,
+    cert_path: PathBuf,
+}
+
+impl AsyncTestContext for HttpsTestContext {
+    async fn setup() -> Self {
+        let cert_path = write_ca_and_set_env(&FIXTURE.ca_pem);
+
+        let initial: OnRequest =
+            Box::new(|request, sender| forward_on_request(request, sender).boxed());
+        let inner = Arc::new(Mutex::new(initial));
+        let on_request = {
+            let inner = inner.clone();
+            move |request, sender| {
+                let inner = inner.clone();
+                async move { inner.lock().await(request, sender).await }
+            }
+        };
+
+        let proxy: Proxy = Proxy::start_tls(
+            "localhost:0".to_string(),
+            ALTERNATOR_ADDRESS.to_string(),
+            on_request,
+            None,
+            None,
+            FIXTURE.acceptor.clone(),
+        )
+        .await;
+
+        let proxy_address = format!("localhost:{}", proxy.address().port());
+        let proxy_handle = tokio::spawn(proxy.run());
+
+        HttpsTestContext {
+            on_request: inner,
+            proxy_handle,
+            proxy_address,
+            cert_path,
+        }
+    }
+
+    async fn teardown(self) {
+        self.proxy_handle.abort();
+        std::fs::remove_file(&self.cert_path).ok();
+        // SAFETY: These HTTPS tests are marked `#[serial]` and use Tokio's
+        // `current_thread` runtime, so this test process runs only one of these
+        // env-mutating test contexts at a time during setup/teardown.
+        unsafe { std::env::remove_var("SSL_CERT_FILE") };
+    }
+}
+
+impl HttpsTestContext {
+    pub async fn set_on_request<F, Fut>(&self, new: F)
+    where
+        F: Fn(Request<Incoming>, Arc<Mutex<SendRequest<Full<Bytes>>>>) -> Fut
+            + Send
+            + Sync
+            + 'static,
+        Fut: Future<Output = Response<Full<Bytes>>> + Send + 'static,
+    {
+        *self.on_request.lock().await =
+            Box::new(move |request, sender| new(request, sender).boxed());
+    }
+
+    pub fn get_proxy_address(&self) -> String {
+        self.proxy_address.clone()
+    }
+}

--- a/tests/https_test/discovery.rs
+++ b/tests/https_test/discovery.rs
@@ -1,0 +1,92 @@
+//! HTTPS test for the `/localnodes` discovery path plus a follow-up API call.
+
+use crate::https_test::https_test_context::*;
+use crate::https_test::proxy::forward_on_request;
+
+use alternator_driver::AlternatorClient;
+use alternator_driver::AlternatorConfig;
+use aws_sdk_dynamodb::config::{BehaviorVersion, Credentials};
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
+use hyper::client::conn::http1::SendRequest;
+use hyper::{Method, Request, Response};
+use serial_test::serial;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use test_context::test_context;
+use tokio::sync::Mutex;
+
+const POLLING_TIMEOUT: Duration = Duration::from_secs(5);
+const POLLING_INTERVAL: Duration = Duration::from_millis(50);
+
+#[test_context(HttpsTestContext)]
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_https_discovery(ctx: &mut HttpsTestContext) {
+    let proxy_local = ctx.get_proxy_address();
+    let localnodes_gets = Arc::new(AtomicUsize::new(0));
+    let api_posts = Arc::new(AtomicUsize::new(0));
+    let localnodes_gets_for_proxy = localnodes_gets.clone();
+    let api_posts_for_proxy = api_posts.clone();
+
+    ctx.set_on_request(
+        move |request: Request<Incoming>, sender: Arc<Mutex<SendRequest<Full<Bytes>>>>| {
+            let proxy_local = proxy_local.clone();
+            let localnodes_gets = localnodes_gets_for_proxy.clone();
+            let api_posts = api_posts_for_proxy.clone();
+            async move {
+                if request.method() == Method::GET && request.uri().path() == "/localnodes" {
+                    // Return the proxy itself as the discovered node so both discovery and
+                    // the subsequent API call stay on the HTTPS test path.
+                    localnodes_gets.fetch_add(1, Ordering::Relaxed);
+                    let body = format!("[\"{}\"]", proxy_local);
+                    Response::new(Full::new(Bytes::from(body)))
+                } else {
+                    if request.method() == Method::POST && request.uri().path() == "/" {
+                        api_posts.fetch_add(1, Ordering::Relaxed);
+                    }
+                    forward_on_request(request, sender).await
+                }
+            }
+        },
+    )
+    .await;
+
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("https://{}", ctx.get_proxy_address()))
+            .behavior_version(BehaviorVersion::latest())
+            .credentials_provider(Credentials::for_tests_with_session_token())
+            .build(),
+    );
+
+    // Poll for the discovery request instead of sleeping for an arbitrary interval.
+    tokio::time::timeout(POLLING_TIMEOUT, async {
+        loop {
+            if localnodes_gets.load(Ordering::Relaxed) > 0 {
+                break;
+            }
+            tokio::time::sleep(POLLING_INTERVAL).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "timed out waiting for /localnodes after {:?}",
+            POLLING_TIMEOUT
+        )
+    });
+
+    let result = client.list_tables().send().await;
+    assert!(
+        result.is_ok(),
+        "ListTables after discovery failed: {:?}",
+        result.err()
+    );
+    // Confirm a regular Alternator API request also went through the HTTPS proxy.
+    assert!(
+        api_posts.load(Ordering::Relaxed) > 0,
+        "expected at least one API POST request through the proxy"
+    );
+}

--- a/tests/https_test/main_api.rs
+++ b/tests/https_test/main_api.rs
@@ -1,0 +1,27 @@
+//! Basic HTTPS smoke test for regular Alternator API traffic.
+
+use crate::https_test::https_test_context::*;
+
+use alternator_driver::AlternatorClient;
+use alternator_driver::AlternatorConfig;
+use aws_sdk_dynamodb::config::{BehaviorVersion, Credentials};
+use serial_test::serial;
+use test_context::test_context;
+
+#[test_context(HttpsTestContext)]
+#[tokio::test(flavor = "current_thread")]
+#[serial]
+async fn test_https_main_api(ctx: &mut HttpsTestContext) {
+    // Discovery is disabled here so the request path only exercises the main API.
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("https://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(BehaviorVersion::latest())
+            .credentials_provider(Credentials::for_tests_with_session_token())
+            .build(),
+    );
+
+    let result = client.list_tables().send().await;
+    assert!(result.is_ok(), "ListTables failed: {:?}", result.err());
+}

--- a/tests/https_test/mod.rs
+++ b/tests/https_test/mod.rs
@@ -1,0 +1,8 @@
+#[path = "../common/proxy.rs"]
+mod proxy;
+
+#[path = "common/https_test_context.rs"]
+mod https_test_context;
+
+pub mod discovery;
+pub mod main_api;

--- a/tests/https_test_tests.rs
+++ b/tests/https_test_tests.rs
@@ -1,0 +1,1 @@
+mod https_test;


### PR DESCRIPTION
This PR makes HTTPS behavior consistent across the driver by ensuring discovery uses the same trust path as regular Alternator API requests. That matters both for standard public certificates and for environments that rely on SSL_CERT_FILE, where discovery and API traffic should not behave differently.

It also adds end-to-end HTTPS test coverage for the two paths that matter in practice: regular Alternator requests and /localnodes discovery. The goal is to validate the intended production behavior without introducing library-side TLS configuration changes.

Importantly, this PR does not add a direct way to customize HTTPS trust or TLS settings through the driver API. Regular API requests can already be customized by supplying a custom SDK HTTP client, but that does not cover the reqwest-based discovery path. The change here is intentionally narrower: it aligns discovery with the default API trust behavior so both paths work the same for public CAs and SSL_CERT_FILE, without introducing a new TLS configuration surface.

Together, these changes close the gap that previously existed between discovery and API HTTPS handling and add regression coverage for the expected default client behavior.

Closes https://github.com/scylladb/alternator-client-rust/issues/49  
Related to https://github.com/scylladb/alternator-client-rust/issues/50