### PR TITLE
Add HTTP connection reuse tests

### DIFF
--- a/tests/load_balancing/common/cluster_utils.rs
+++ b/tests/load_balancing/common/cluster_utils.rs
@@ -1,0 +1,293 @@
+//! Shared test utils for the multi-node CCM cluster: a once-created cluster
+//! reused across tests, per-node counting proxies, and helpers for building
+//! scoped clients and waiting on discovery.
+
+use crate::ccm_wrapper::ccm::*;
+use crate::ccm_wrapper::cluster::*;
+use crate::ccm_wrapper::topology_spec::*;
+use crate::load_balancing::proxy;
+
+use alternator_driver::RoutingScope;
+use alternator_driver::{AlternatorBuilder, AlternatorClient, AlternatorConfig};
+
+use hyper::Method;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use ctor::dtor;
+use tokio::sync::{Mutex, MutexGuard};
+
+pub(crate) const PROXY_PORT: u16 = 7999;
+pub(crate) const ALTERNATOR_PORT: u16 = 8000;
+
+pub(crate) const POLLING_TIMEOUT: Duration = Duration::from_secs(5);
+pub(crate) const POLLING_INTERVAL: Duration = Duration::from_millis(50);
+
+// Since cluster creation is expensive, we create it once and reuse it for every test.
+// Before a test gets access to the cluster, we make sure that all nodes are up and their ports are set to default.
+// Datacenter 1 is a single node which is meant to never be shut down. Its address will be used as a seed address
+// for clients and as a redirect target for requests directed to shut down nodes.
+static CLUSTER: OnceLock<Mutex<Cluster>> = OnceLock::new();
+pub(crate) async fn get_cluster() -> MutexGuard<'static, Cluster> {
+    let mut cluster = CLUSTER
+        .get_or_init(|| {
+            let topology = TopologySpecBuilder::new()
+                .datacenter(DatacenterSpec::new().rack(1))
+                .datacenter(DatacenterSpec::new().rack(1).rack(2))
+                .datacenter(DatacenterSpec::new().rack(2).rack(1))
+                .build()
+                .unwrap();
+            let ip_prefix = IpPrefix::new("127.0.1.").unwrap();
+            let cluster_name = format!("test_cluster_{}", uuid::Uuid::new_v4());
+            let scylla_version = String::from("release:2025.1");
+            let cluster = Ccm::create_cluster(
+                cluster_name,
+                &topology,
+                ip_prefix,
+                ALTERNATOR_PORT,
+                scylla_version,
+            )
+            .unwrap();
+            Mutex::new(cluster)
+        })
+        .lock()
+        .await;
+
+    Ccm::start_cluster(&mut cluster).unwrap();
+    cluster.update_all_nodes_port(ALTERNATOR_PORT);
+    cluster
+}
+
+// Since the cluster is static, it never drops, so we use a destructor.
+#[dtor]
+fn clean_up_cluster() {
+    if let Some(cluster_mutex) = CLUSTER.get() {
+        let mut cluster = cluster_mutex.blocking_lock();
+        Ccm::remove_cluster(&mut cluster);
+    }
+}
+
+pub(crate) fn default_endpoint_url(cluster: &Cluster) -> String {
+    cluster.datacenters()[0].racks()[0].nodes()[0].address()
+}
+
+// Struct for counting requests made to the proxy. GETs, POSTs, and describe_tables are counted separately.
+// GETs are service discovery calls, POSTs are the actual calls to DB, and describe_table calls
+// are from PartitionKeyResolver.
+#[derive(Debug)]
+pub(crate) struct NodeCounter {
+    posts: AtomicUsize,
+    gets: AtomicUsize,
+    describe_tables: AtomicUsize,
+}
+
+impl NodeCounter {
+    fn new() -> Self {
+        Self {
+            posts: AtomicUsize::new(0),
+            gets: AtomicUsize::new(0),
+            describe_tables: AtomicUsize::new(0),
+        }
+    }
+
+    pub(crate) fn posts(&self) -> usize {
+        self.posts.load(Ordering::Relaxed)
+    }
+
+    fn reset(&self) {
+        self.posts.store(0, Ordering::Relaxed);
+        self.gets.store(0, Ordering::Relaxed);
+        self.describe_tables.store(0, Ordering::Relaxed);
+    }
+}
+
+// Struct with a hashmap underneath for holding and monitoring the counters for multiple nodes.
+#[derive(Debug)]
+pub(crate) struct RequestCounter {
+    counter: HashMap<String, Arc<NodeCounter>>,
+}
+
+impl RequestCounter {
+    pub(crate) fn new() -> Self {
+        Self {
+            counter: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn from_cluster(cluster: &Cluster) -> Self {
+        let counter = cluster
+            .nodes()
+            .iter()
+            .map(|node| (node.ip.clone(), Arc::new(NodeCounter::new())))
+            .collect();
+        Self { counter }
+    }
+
+    pub(crate) fn get(&self, ip: &str) -> Arc<NodeCounter> {
+        Arc::clone(self.counter.get(ip).unwrap())
+    }
+
+    pub(crate) fn add(&mut self, ip: String) {
+        self.counter.insert(ip, Arc::new(NodeCounter::new()));
+    }
+
+    pub(crate) fn reset(&self) {
+        for c in self.counter.values() {
+            c.reset();
+        }
+    }
+
+    pub(crate) fn total_posts(&self) -> usize {
+        self.counter
+            .values()
+            .map(|c| c.posts.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    pub(crate) fn get_posts_to_ips(&self, ips: &[&str]) -> usize {
+        ips.iter()
+            .map(|ip| self.counter.get(*ip).unwrap().posts.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    pub(crate) fn get_posts_to_other_ips(&self, ips: &[&str]) -> usize {
+        self.counter
+            .iter()
+            .filter(|(ip, _)| !ips.contains(&ip.as_str()))
+            .map(|(_, c)| c.posts.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    pub(crate) fn total_describe_tables(&self) -> usize {
+        self.counter
+            .values()
+            .map(|c| c.describe_tables.load(Ordering::Relaxed))
+            .sum()
+    }
+}
+
+pub(crate) async fn start_counting_proxy(
+    listen_addr: String,
+    connect_addr: String,
+    request_counter: Arc<NodeCounter>,
+) {
+    let proxy = proxy::Proxy::start(
+        listen_addr,
+        connect_addr,
+        move |req, send| {
+            let node_counter = Arc::clone(&request_counter);
+            async move {
+                {
+                    let is_describe_table = req
+                        .headers()
+                        .get("x-amz-target")
+                        .is_some_and(|h| h == "DynamoDB_20120810.DescribeTable");
+
+                    match *req.method() {
+                        Method::POST => {
+                            if is_describe_table {
+                                node_counter.describe_tables.fetch_add(1, Ordering::Relaxed);
+                            } else {
+                                node_counter.posts.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                        Method::GET => {
+                            node_counter.gets.fetch_add(1, Ordering::Relaxed);
+                        }
+                        _ => {}
+                    };
+                }
+                proxy::forward_on_request(req, send).await
+            }
+        },
+        None,
+        None,
+    )
+    .await;
+
+    // Avoid a dead-code warning.
+    let _ = proxy.address();
+
+    // We deliberately detach the proxy task here.
+    // Each test has its own Tokio runtime, so dropping the runtime will abort
+    // this task and cleanly release the listener and connection resources.
+    // Only one test at a time can use the cluster, so old proxies will be dropped before new ones are created.
+    tokio::spawn(async move {
+        proxy.run().await;
+    });
+}
+
+// This is the proxy that calls to the node go through. Used to count calls and ensure that client calls the correct nodes.
+pub(crate) async fn start_proxy_on_node(
+    node: Node,
+    proxy_port: u16,
+    request_counter: Arc<NodeCounter>,
+) {
+    let listen_addr = format!("{}:{}", node.ip, proxy_port);
+    let connect_addr = format!("{}:{}", node.ip, ALTERNATOR_PORT);
+    start_counting_proxy(listen_addr, connect_addr, request_counter).await;
+}
+
+pub(crate) async fn start_proxies(
+    cluster: &mut Cluster,
+    proxy_port: u16,
+    request_counter: &RequestCounter,
+) {
+    cluster.update_all_nodes_port(proxy_port);
+    let counter = &request_counter.counter;
+    for node in cluster.nodes() {
+        if node.is_up {
+            let node_counter = Arc::clone(counter.get(&node.ip).unwrap());
+            start_proxy_on_node(node.clone(), proxy_port, node_counter).await;
+        }
+    }
+}
+
+// Make calls without caring about the result, used to count where calls are directed.
+pub(crate) async fn make_n_calls(client: &AlternatorClient, n: usize) {
+    for _ in 0..n {
+        let _ = client.list_tables().send().await;
+    }
+}
+
+// Base builder to avoid same code in different constructors.
+pub(crate) fn minimal_builder() -> AlternatorBuilder {
+    AlternatorConfig::builder()
+        .credentials_provider(aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token())
+        .region(aws_sdk_dynamodb::config::Region::new("eu-central-1"))
+        .behavior_version_latest()
+}
+
+// Create a basic client with scope.
+pub(crate) fn create_client_with_scope(cluster: &Cluster, scope: RoutingScope) -> AlternatorClient {
+    AlternatorClient::from_conf(
+        minimal_builder()
+            .endpoint_url(default_endpoint_url(cluster))
+            .routing_scope(scope)
+            .build(),
+    )
+}
+
+// Poll until the client's live nodes match the given IPs, or timeout.
+pub(crate) async fn wait_until_live_nodes_match(client: &AlternatorClient, ips: Vec<&str>) {
+    let live_nodes = client.config().live_nodes().unwrap().clone();
+    tokio::time::timeout(POLLING_TIMEOUT, async {
+        loop {
+            let nodes = live_nodes.get_live_nodes();
+            let node_ips: Vec<&str> = nodes.iter().map(|url| url.host_str().unwrap()).collect();
+            if node_ips.len() == ips.len() && node_ips.iter().all(|ip| ips.contains(ip)) {
+                break;
+            }
+            tokio::time::sleep(POLLING_INTERVAL).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "failed to update nodes\nexpected nodes {:?}, timed out after {:?}",
+            ips, POLLING_TIMEOUT
+        )
+    });
+}

--- a/tests/load_balancing/common/cluster_utils.rs
+++ b/tests/load_balancing/common/cluster_utils.rs
@@ -73,7 +73,8 @@ pub(crate) fn default_endpoint_url(cluster: &Cluster) -> String {
     cluster.datacenters()[0].racks()[0].nodes()[0].address()
 }
 
-// Struct for counting requests made to the proxy. GETs, POSTs, and describe_tables are counted separately.
+// Struct for counting connections accepted / closed and requests made to the proxy.
+// GETs, POSTs, and describe_tables are counted separately.
 // GETs are service discovery calls, POSTs are the actual calls to DB, and describe_table calls
 // are from PartitionKeyResolver.
 #[derive(Debug)]
@@ -81,6 +82,8 @@ pub(crate) struct NodeCounter {
     posts: AtomicUsize,
     gets: AtomicUsize,
     describe_tables: AtomicUsize,
+    connects: AtomicUsize,
+    disconnects: AtomicUsize,
 }
 
 impl NodeCounter {
@@ -89,6 +92,8 @@ impl NodeCounter {
             posts: AtomicUsize::new(0),
             gets: AtomicUsize::new(0),
             describe_tables: AtomicUsize::new(0),
+            connects: AtomicUsize::new(0),
+            disconnects: AtomicUsize::new(0),
         }
     }
 
@@ -96,10 +101,20 @@ impl NodeCounter {
         self.posts.load(Ordering::Relaxed)
     }
 
+    pub(crate) fn gets(&self) -> usize {
+        self.gets.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn connects(&self) -> usize {
+        self.connects.load(Ordering::Relaxed)
+    }
+
     fn reset(&self) {
         self.posts.store(0, Ordering::Relaxed);
         self.gets.store(0, Ordering::Relaxed);
         self.describe_tables.store(0, Ordering::Relaxed);
+        self.connects.store(0, Ordering::Relaxed);
+        self.disconnects.store(0, Ordering::Relaxed);
     }
 }
 
@@ -139,10 +154,31 @@ impl RequestCounter {
         }
     }
 
+    pub(crate) fn total_gets(&self) -> usize {
+        self.counter
+            .values()
+            .map(|c| c.gets.load(Ordering::Relaxed))
+            .sum()
+    }
+
     pub(crate) fn total_posts(&self) -> usize {
         self.counter
             .values()
             .map(|c| c.posts.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    pub(crate) fn total_connects(&self) -> usize {
+        self.counter
+            .values()
+            .map(|c| c.connects.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    pub(crate) fn total_disconnects(&self) -> usize {
+        self.counter
+            .values()
+            .map(|c| c.disconnects.load(Ordering::Relaxed))
             .sum()
     }
 
@@ -173,6 +209,18 @@ pub(crate) async fn start_counting_proxy(
     connect_addr: String,
     request_counter: Arc<NodeCounter>,
 ) {
+    // Count every accepted / closed TCP connection.
+    let connect_counter = Arc::clone(&request_counter);
+    let on_connect: Box<dyn Fn(std::net::SocketAddr) + Send + Sync> = Box::new(move |_addr| {
+        connect_counter.connects.fetch_add(1, Ordering::Relaxed);
+    });
+    let disconnect_counter = Arc::clone(&request_counter);
+    let on_disconnect: Box<dyn Fn() + Send + Sync> = Box::new(move || {
+        disconnect_counter
+            .disconnects
+            .fetch_add(1, Ordering::Relaxed);
+    });
+
     let proxy = proxy::Proxy::start(
         listen_addr,
         connect_addr,
@@ -202,8 +250,8 @@ pub(crate) async fn start_counting_proxy(
                 proxy::forward_on_request(req, send).await
             }
         },
-        None,
-        None,
+        Some(on_connect),
+        Some(on_disconnect),
     )
     .await;
 
@@ -266,6 +314,21 @@ pub(crate) fn create_client_with_scope(cluster: &Cluster, scope: RoutingScope) -
         minimal_builder()
             .endpoint_url(default_endpoint_url(cluster))
             .routing_scope(scope)
+            .build(),
+    )
+}
+
+// Like `create_client_with_scope`, but with a custom discovery active interval.
+pub(crate) fn create_client_with_scope_and_interval(
+    cluster: &Cluster,
+    scope: RoutingScope,
+    active_interval: Duration,
+) -> AlternatorClient {
+    AlternatorClient::from_conf(
+        minimal_builder()
+            .endpoint_url(default_endpoint_url(cluster))
+            .routing_scope(scope)
+            .active_interval(active_interval)
             .build(),
     )
 }

--- a/tests/load_balancing/connection_reuse.rs
+++ b/tests/load_balancing/connection_reuse.rs
@@ -1,0 +1,250 @@
+//! HTTP keep-alive (connection reuse) tests.
+//!
+//! These verify the client keeps TCP/HTTP connections alive across requests
+//! instead of reopening them. Counting proxies sit between the client and the
+//! cluster nodes and record accepted (`connects`) and closed (`disconnects`)
+//! connections via the proxy's `on_client_connect` / `on_client_disconnect`
+//! hooks, alongside GET/POST request counts.
+//!
+//! Two scenarios:
+//!
+//! - Load balancing **off** (`seed_hosts([])`, as in the http_content tests):
+//!   no discovery, so a single data connection carries everything and the
+//!   assertion can be made directly after the calls.
+//!
+//! - Load balancing **on**: background `/localnodes` discovery runs alongside
+//!   operations. Each node then sees at most one data connection (POSTs) plus
+//!   one discovery connection (GETs).
+//!   Invariant to verify: `(posts > 0) + (gets > 0) == connects`.
+//!   Discovery bumps `connects` at accept-time slightly before its
+//!   GET is counted, so that equality is polled until it settles (within
+//!   `POLLING_TIMEOUT`).
+
+use crate::ccm_wrapper::cluster::*;
+use crate::load_balancing::cluster_utils::*;
+use crate::load_balancing::scope_utils;
+use alternator_driver::AlternatorClient;
+
+use std::time::Duration;
+
+// A client that talks directly to `endpoint_url` with load balancing disabled,
+// using an HTTP connection pool with the given idle timeout.
+fn create_lb_disabled_client(
+    cluster: &Cluster,
+    pool_idle_timeout: Option<Duration>,
+) -> AlternatorClient {
+    // `None` keeps Hyper's default idle timeout (~90s); `Some(d)` pins it to `d`.
+    let mut http_builder = aws_smithy_http_client::Builder::new();
+    if let Some(timeout) = pool_idle_timeout {
+        http_builder = http_builder.pool_idle_timeout(Some(timeout));
+    }
+    let http_client = http_builder.build_http();
+    AlternatorClient::from_conf(
+        minimal_builder()
+            .http_client(http_client)
+            .endpoint_url(default_endpoint_url(cluster))
+            .seed_hosts(Vec::<String>::new())
+            .build(),
+    )
+}
+
+// Enough requests that "one connection per request" would be unmistakable.
+const REQUESTS: usize = 50;
+// A reused connection should yield one connect, allow a tiny margin for any
+// pool churn while staying far below REQUESTS.
+const MAX_CONNECTIONS: usize = 2;
+// A short idle gap: well under Hyper's default pool idle timeout (~90s) so the
+// default keeps the connection, but above POOL_TIMEOUT_SHORT so that expires it.
+const IDLE_PERIOD: Duration = Duration::from_secs(3);
+// Pool idle timeout below IDLE_PERIOD: the connection expires during the idle
+// gap, forcing exactly one reconnect.
+const POOL_TIMEOUT_SHORT: Duration = Duration::from_secs(1);
+
+/// Many sequential requests to a single node should reuse one
+/// connection, not one connection per request.
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn connection_kept_alive_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let client = create_lb_disabled_client(cluster, None);
+
+    make_n_calls(&client, REQUESTS).await;
+
+    assert!(
+        request_counter.total_connects() >= 1,
+        "expected at least one connection to the node"
+    );
+    assert!(
+        request_counter.total_connects() <= MAX_CONNECTIONS,
+        "connections were not reused: {} connects for {} requests",
+        request_counter.total_connects(),
+        REQUESTS,
+    );
+}
+
+/// Verify the connection is reused if the idle period is shorter than pool lifetime.
+/// With a pool idle timeout well above the idle gap, the pooled connection
+/// survives the gap and is reused - no new connect, no disconnect.
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn connection_reused_after_idle_within_pool_lifetime_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let client = create_lb_disabled_client(cluster, None);
+
+    make_n_calls(&client, REQUESTS).await;
+    let connects_before = request_counter.total_connects();
+    assert!(
+        connects_before >= 1,
+        "expected an established connection before idling"
+    );
+
+    tokio::time::sleep(IDLE_PERIOD).await;
+    make_n_calls(&client, REQUESTS).await;
+
+    assert_eq!(
+        request_counter.total_connects(),
+        connects_before,
+        "connection was not reused across an idle gap within pool lifetime"
+    );
+    assert_eq!(
+        request_counter.total_disconnects(),
+        0,
+        "connection was unexpectedly closed across the idle gap"
+    );
+}
+
+/// Verify the connection reconnects only once if pool expiry is expected.
+/// With a pool idle timeout below the idle gap, the pooled connection expires
+/// during the gap, forcing exactly one reconnect.
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn connection_reconnects_once_after_pool_expiry_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let client = create_lb_disabled_client(cluster, Some(POOL_TIMEOUT_SHORT));
+
+    make_n_calls(&client, REQUESTS).await;
+    let connects_before = request_counter.total_connects();
+    assert!(
+        connects_before >= 1,
+        "expected an established connection before idling"
+    );
+
+    tokio::time::sleep(IDLE_PERIOD).await;
+    make_n_calls(&client, REQUESTS).await;
+
+    // Exactly one reconnect across the idle gap.
+    assert_eq!(
+        request_counter.total_connects(),
+        connects_before + 1,
+        "expected exactly one reconnect after pool expiry"
+    );
+
+    tokio::time::timeout(POLLING_TIMEOUT, async {
+        loop {
+            if request_counter.total_disconnects() == connects_before {
+                break;
+            }
+            tokio::time::sleep(POLLING_INTERVAL).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        panic!(
+            "expected {} disconnect(s) after pool expiry, got {}",
+            connects_before,
+            request_counter.total_disconnects()
+        )
+    });
+}
+
+/// With load balancing and discovery enabled, repeated operations should keep
+/// succeeding while background `/localnodes` polling runs, without opening a new
+/// connection per GET or POST: each node ends up with at most one data
+/// connection (POSTs) plus one discovery connection (GETs).
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn connection_reused_across_discovery_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let scope = scope_utils::datacenter_scope_from_index(cluster, 1);
+
+    // Short discovery interval so the GET threshold below is reached quickly.
+    let client =
+        create_client_with_scope_and_interval(cluster, scope.clone(), Duration::from_millis(5));
+    let target_gets_number = 10;
+
+    wait_until_live_nodes_match(
+        &client,
+        scope_utils::working_nodes_ips_in_scope(cluster, &scope),
+    )
+    .await;
+
+    make_n_calls(&client, REQUESTS).await;
+
+    // Each in-scope node should hold at most one data connection (if it got
+    // POSTs) plus one discovery connection (if it was polled).
+    // Discovery bumps `connects` at accept-time a touch
+    // before its GET is counted, so poll until the steady state settles.
+    let in_scope_ips = scope_utils::ips_in_scope(cluster, &scope);
+
+    tokio::time::timeout(POLLING_TIMEOUT, async {
+        loop {
+            let settled = in_scope_ips.iter().all(|ip| {
+                let c = request_counter.get(ip);
+                (c.posts() > 0) as usize + (c.gets() > 0) as usize == c.connects()
+            });
+            if settled && request_counter.total_gets() >= target_gets_number {
+                break;
+            }
+            tokio::time::sleep(POLLING_INTERVAL).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| {
+        let detail: Vec<String> = in_scope_ips
+            .iter()
+            .map(|ip| {
+                let c = request_counter.get(ip);
+                format!(
+                    "{}: posts={} gets={} connects={}",
+                    ip,
+                    c.posts(),
+                    c.gets(),
+                    c.connects()
+                )
+            })
+            .collect();
+        panic!(
+            "connection reuse did not settle within {:?}; per-node state: [{}]",
+            POLLING_TIMEOUT,
+            detail.join(", ")
+        )
+    });
+
+    // Sanity: the operations actually flowed through the proxies.
+    assert!(
+        request_counter.total_posts() >= REQUESTS,
+        "expected at least {} POSTs through the proxies, got {}",
+        REQUESTS,
+        request_counter.total_posts()
+    );
+}

--- a/tests/load_balancing/load_balancing_tests.rs
+++ b/tests/load_balancing/load_balancing_tests.rs
@@ -13,68 +13,8 @@ use aws_sdk_dynamodb::types::{
     AttributeAction, AttributeValue, AttributeValueUpdate, DeleteRequest, KeysAndAttributes,
     PutRequest, ReturnValue, Select, WriteRequest,
 };
-use hyper::Method;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, OnceLock};
-use std::time::Duration;
-
-use ctor::dtor;
-use tokio::sync::{Mutex, MutexGuard};
-
-const PROXY_PORT: u16 = 7999;
-const ALTERNATOR_PORT: u16 = 8000;
-
-const POLLING_TIMEOUT: Duration = Duration::from_secs(5);
-const POLLING_INTERVAL: Duration = Duration::from_millis(50);
-
-// Since cluster creation is expensive, we create it once and reuse it for every test.
-// Before a test gets access to the cluster, we make sure that all nodes are up and their ports are set to default.
-// Datacenter 1 is a single node which is meant to never be shut down. Its address will be used as a seed address
-// for clients and as a redirect target for requests directed to shut down nodes.
-static CLUSTER: OnceLock<Mutex<Cluster>> = OnceLock::new();
-async fn get_cluster() -> MutexGuard<'static, Cluster> {
-    let mut cluster = CLUSTER
-        .get_or_init(|| {
-            let topology = TopologySpecBuilder::new()
-                .datacenter(DatacenterSpec::new().rack(1))
-                .datacenter(DatacenterSpec::new().rack(1).rack(2))
-                .datacenter(DatacenterSpec::new().rack(2).rack(1))
-                .build()
-                .unwrap();
-            let ip_prefix = IpPrefix::new("127.0.1.").unwrap();
-            let cluster_name = format!("test_cluster_{}", uuid::Uuid::new_v4());
-            let scylla_version = String::from("release:2025.1");
-            let cluster = Ccm::create_cluster(
-                cluster_name,
-                &topology,
-                ip_prefix,
-                ALTERNATOR_PORT,
-                scylla_version,
-            )
-            .unwrap();
-            Mutex::new(cluster)
-        })
-        .lock()
-        .await;
-
-    Ccm::start_cluster(&mut cluster).unwrap();
-    cluster.update_all_nodes_port(ALTERNATOR_PORT);
-    cluster
-}
-
-// Since the cluster is static, it never drops, so we use a destructor.
-#[dtor]
-fn clean_up_cluster() {
-    if let Some(cluster_mutex) = CLUSTER.get() {
-        let mut cluster = cluster_mutex.blocking_lock();
-        Ccm::remove_cluster(&mut cluster);
-    }
-}
-
-fn default_endpoint_url(cluster: &Cluster) -> String {
-    cluster.datacenters()[0].racks()[0].nodes()[0].address()
-}
+use std::sync::Arc;
 
 fn redirect_target_node(cluster: &Cluster) -> Node {
     cluster.datacenters()[0].racks()[0].nodes()[0].clone()

--- a/tests/load_balancing/load_balancing_tests.rs
+++ b/tests/load_balancing/load_balancing_tests.rs
@@ -1,11 +1,9 @@
 use crate::ccm_wrapper::ccm::*;
 use crate::ccm_wrapper::cluster::*;
-use crate::ccm_wrapper::topology_spec::*;
-use crate::load_balancing::proxy;
+use crate::load_balancing::cluster_utils::*;
 use crate::load_balancing::scope_utils;
 
 use alternator_driver::AlternatorClient;
-use alternator_driver::AlternatorConfig;
 use alternator_driver::RoutingScope;
 use alternator_driver::keyrouting::affinity_config::{
     KeyRouteAffinityConfig, KeyRouteAffinityType,
@@ -82,213 +80,29 @@ fn redirect_target_node(cluster: &Cluster) -> Node {
     cluster.datacenters()[0].racks()[0].nodes()[0].clone()
 }
 
-// Struct for counting requests made to the proxy. GETs, POSTs, and describe_tables are counted separately.
-// GETs are service discovery calls, POSTs are the actual calls to DB, and describe_table calls
-// are from PartitionKeyResolver.
-#[derive(Debug)]
-pub(crate) struct NodeCounter {
-    posts: AtomicUsize,
-    gets: AtomicUsize,
-    describe_tables: AtomicUsize,
-}
-
-impl NodeCounter {
-    fn new() -> Self {
-        Self {
-            posts: AtomicUsize::new(0),
-            gets: AtomicUsize::new(0),
-            describe_tables: AtomicUsize::new(0),
-        }
-    }
-
-    pub(crate) fn posts(&self) -> usize {
-        self.posts.load(Ordering::Relaxed)
-    }
-
-    fn reset(&self) {
-        self.posts.store(0, Ordering::Relaxed);
-        self.gets.store(0, Ordering::Relaxed);
-        self.describe_tables.store(0, Ordering::Relaxed);
-    }
-}
-
-pub(crate) async fn start_counting_proxy(
-    listen_addr: String,
-    connect_addr: String,
-    request_counter: Arc<NodeCounter>,
-) {
-    let proxy = proxy::Proxy::start(
-        listen_addr,
-        connect_addr,
-        move |req, send| {
-            let node_counter = Arc::clone(&request_counter);
-            async move {
-                {
-                    let is_describe_table = req
-                        .headers()
-                        .get("x-amz-target")
-                        .is_some_and(|h| h == "DynamoDB_20120810.DescribeTable");
-
-                    match *req.method() {
-                        Method::POST => {
-                            if is_describe_table {
-                                node_counter.describe_tables.fetch_add(1, Ordering::Relaxed);
-                            } else {
-                                node_counter.posts.fetch_add(1, Ordering::Relaxed);
-                            }
-                        }
-                        Method::GET => {
-                            node_counter.gets.fetch_add(1, Ordering::Relaxed);
-                        }
-                        _ => {}
-                    };
-                }
-                proxy::forward_on_request(req, send).await
-            }
-        },
-        None,
-        None,
-    )
-    .await;
-
-    // Avoid a dead-code warning.
-    let _ = proxy.address();
-
-    // We deliberately detach the proxy task here.
-    // Each test has its own Tokio runtime, so dropping the runtime will abort
-    // this task and cleanly release the listener and connection resources.
-    // Only one test at a time can use the cluster, so old proxies will be dropped before new ones are created.
-    tokio::spawn(async move {
-        proxy.run().await;
-    });
-}
-
 // This proxy is used in tests where we check if calls are made to a node that is down.
 // Redirecting calls to a different node allows us to count calls to the stopped node,
 // while also allowing the client to use it for discovery without connection errors.
-pub(crate) async fn start_redirecting_proxy(
-    from: &Node,
-    to: &Node,
-    request_counter: Arc<NodeCounter>,
-) {
+async fn start_redirecting_proxy(from: &Node, to: &Node, request_counter: Arc<NodeCounter>) {
     let listen_addr = format!("{}:{}", from.ip.clone(), from.alternator_port);
     let connect_addr = format!("{}:{}", to.ip.clone(), ALTERNATOR_PORT);
     start_counting_proxy(listen_addr, connect_addr, request_counter).await;
 }
 
-// This is the proxy that calls to the node go through. Used to count calls and ensure that client calls the correct nodes.
-pub(crate) async fn start_proxy_on_node(
-    node: Node,
-    proxy_port: u16,
-    request_counter: Arc<NodeCounter>,
-) {
-    let listen_addr = format!("{}:{}", node.ip, proxy_port);
-    let connect_addr = format!("{}:{}", node.ip, ALTERNATOR_PORT);
-    start_counting_proxy(listen_addr, connect_addr, request_counter).await;
-}
-
-pub(crate) async fn start_proxies(
-    cluster: &mut Cluster,
-    proxy_port: u16,
-    request_counter: &RequestCounter,
-) {
-    cluster.update_all_nodes_port(proxy_port);
-    let counter = &request_counter.counter;
-    for node in cluster.nodes() {
-        if node.is_up {
-            let node_counter = Arc::clone(counter.get(&node.ip).unwrap());
-            start_proxy_on_node(node.clone(), proxy_port, node_counter).await;
-        }
-    }
-}
-
-pub(crate) async fn start_redirecting_proxies(
+async fn start_redirecting_proxies(
     cluster: &mut Cluster,
     proxy_port: u16,
     request_counter: &RequestCounter,
 ) {
     cluster.update_all_nodes_port(proxy_port);
     let to = &redirect_target_node(cluster);
-    let counter = &request_counter.counter;
     for node in cluster.nodes() {
-        let node_counter = Arc::clone(counter.get(&node.ip).unwrap());
+        let node_counter = request_counter.get(&node.ip);
         start_redirecting_proxy(node, to, node_counter).await;
     }
 }
 
-// Struct with a hashmap underneath for holding and monitoring the counters for multiple nodes.
-#[derive(Debug)]
-pub(crate) struct RequestCounter {
-    counter: HashMap<String, Arc<NodeCounter>>,
-}
-
-impl RequestCounter {
-    pub(crate) fn new() -> Self {
-        Self {
-            counter: HashMap::new(),
-        }
-    }
-
-    pub(crate) fn from_cluster(cluster: &Cluster) -> Self {
-        let counter = cluster
-            .nodes()
-            .iter()
-            .map(|node| (node.ip.clone(), Arc::new(NodeCounter::new())))
-            .collect();
-        Self { counter }
-    }
-
-    pub(crate) fn get(&self, ip: &str) -> Arc<NodeCounter> {
-        Arc::clone(self.counter.get(ip).unwrap())
-    }
-
-    pub(crate) fn add(&mut self, ip: String) {
-        self.counter.insert(ip, Arc::new(NodeCounter::new()));
-    }
-
-    pub(crate) fn reset(&self) {
-        for c in self.counter.values() {
-            c.reset();
-        }
-    }
-
-    pub(crate) fn total_posts(&self) -> usize {
-        self.counter
-            .values()
-            .map(|c| c.posts.load(Ordering::Relaxed))
-            .sum()
-    }
-
-    pub(crate) fn get_posts_to_ips(&self, ips: &[&str]) -> usize {
-        ips.iter()
-            .map(|ip| self.counter.get(*ip).unwrap().posts.load(Ordering::Relaxed))
-            .sum()
-    }
-
-    pub(crate) fn get_posts_to_other_ips(&self, ips: &[&str]) -> usize {
-        self.counter
-            .iter()
-            .filter(|(ip, _)| !ips.contains(&ip.as_str()))
-            .map(|(_, c)| c.posts.load(Ordering::Relaxed))
-            .sum()
-    }
-
-    pub(crate) fn total_describe_tables(&self) -> usize {
-        self.counter
-            .values()
-            .map(|c| c.describe_tables.load(Ordering::Relaxed))
-            .sum()
-    }
-}
-
-// Make calls without caring about the result, used to count where calls are directed.
-async fn make_n_calls(client: &AlternatorClient, n: usize) {
-    for _ in 0..n {
-        let _ = client.list_tables().send().await;
-    }
-}
-
-pub(crate) async fn create_table(client: &AlternatorClient, table_name: &str) {
+async fn create_table(client: &AlternatorClient, table_name: &str) {
     client
         .create_table()
         .table_name(table_name)
@@ -312,7 +126,7 @@ pub(crate) async fn create_table(client: &AlternatorClient, table_name: &str) {
         .unwrap();
 }
 
-pub(crate) async fn put_item(client: &AlternatorClient, table_name: &str, item: &str) {
+async fn put_item(client: &AlternatorClient, table_name: &str, item: &str) {
     let _ = client
         .put_item()
         .table_name(table_name)
@@ -324,7 +138,7 @@ pub(crate) async fn put_item(client: &AlternatorClient, table_name: &str, item: 
         .await;
 }
 
-pub(crate) async fn delete_item(client: &AlternatorClient, table_name: &str, item: &str) {
+async fn delete_item(client: &AlternatorClient, table_name: &str, item: &str) {
     let _ = client
         .delete_item()
         .table_name(table_name)
@@ -336,12 +150,7 @@ pub(crate) async fn delete_item(client: &AlternatorClient, table_name: &str, ite
         .await;
 }
 
-pub(crate) async fn update_item(
-    client: &AlternatorClient,
-    table_name: &str,
-    item: &str,
-    new: &str,
-) {
+async fn update_item(client: &AlternatorClient, table_name: &str, item: &str, new: &str) {
     let _ = client
         .update_item()
         .table_name(table_name)
@@ -358,55 +167,13 @@ pub(crate) async fn update_item(
         .await;
 }
 
-// Create a basic client with scope.
-fn create_client_with_scope(cluster: &Cluster, scope: RoutingScope) -> AlternatorClient {
-    AlternatorClient::from_conf(
-        AlternatorConfig::builder()
-            .credentials_provider(
-                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
-            )
-            .region(aws_sdk_dynamodb::config::Region::new("eu-central-1"))
-            .behavior_version_latest()
-            .endpoint_url(default_endpoint_url(cluster))
-            .routing_scope(scope)
-            .build(),
-    )
-}
-
-// Poll until the client's live nodes match the given IPs, or timeout.
-async fn wait_until_live_nodes_match(client: &AlternatorClient, ips: Vec<&str>) {
-    let live_nodes = client.config().live_nodes().unwrap().clone();
-    tokio::time::timeout(POLLING_TIMEOUT, async {
-        loop {
-            let nodes = live_nodes.get_live_nodes();
-            let node_ips: Vec<&str> = nodes.iter().map(|url| url.host_str().unwrap()).collect();
-            if node_ips.len() == ips.len() && node_ips.iter().all(|ip| ips.contains(ip)) {
-                break;
-            }
-            tokio::time::sleep(POLLING_INTERVAL).await;
-        }
-    })
-    .await
-    .unwrap_or_else(|_| {
-        panic!(
-            "failed to update nodes\nexpected nodes {:?}, timed out after {:?}",
-            ips, POLLING_TIMEOUT
-        )
-    });
-}
-
 fn create_client_with_scope_and_affinity(
     cluster: &Cluster,
     scope: RoutingScope,
     affinity_config: KeyRouteAffinityConfig,
 ) -> AlternatorClient {
     AlternatorClient::from_conf(
-        AlternatorConfig::builder()
-            .credentials_provider(
-                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
-            )
-            .region(aws_sdk_dynamodb::config::Region::new("eu-central-1"))
-            .behavior_version_latest()
+        minimal_builder()
             .endpoint_url(default_endpoint_url(cluster))
             .routing_scope(scope)
             .key_route_affinity(affinity_config)

--- a/tests/load_balancing/mod.rs
+++ b/tests/load_balancing/mod.rs
@@ -1,7 +1,13 @@
+//! Integration tests using a real multi-node CCM cluster: load-balancing and
+//! routing, driven through counting proxies.
+
 #[path = "../common/proxy.rs"]
 pub mod proxy;
 
 #[path = "common/scope_utils.rs"]
 pub mod scope_utils;
+
+#[path = "common/cluster_utils.rs"]
+pub mod cluster_utils;
 
 pub mod load_balancing_tests;

--- a/tests/load_balancing/mod.rs
+++ b/tests/load_balancing/mod.rs
@@ -1,5 +1,5 @@
-//! Integration tests using a real multi-node CCM cluster: load-balancing and
-//! routing, driven through counting proxies.
+//! Integration tests using a real multi-node CCM cluster: load-balancing /
+//! routing and HTTP connection reuse, both driven through counting proxies.
 
 #[path = "../common/proxy.rs"]
 pub mod proxy;
@@ -11,3 +11,5 @@ pub mod scope_utils;
 pub mod cluster_utils;
 
 pub mod load_balancing_tests;
+
+pub mod connection_reuse;


### PR DESCRIPTION
Implements test plan from #41

Adds tests verifying the client reuses HTTP/TCP connections instead of reopening one per request, covering: keep-alive under load, reuse vs. a single reconnect across an idle gap, and reuse while background `/localnodes` discovery runs.

The shared CCM cluster/proxy test common code is extracted into`cluster_utils.rs` so both the existing load-balancing tests and the new ones can use it.

Closes #15