### PR TITLE
Add key-route affinity matrix and BatchWriteItem AnyWrite routing

### DIFF
--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -220,8 +220,8 @@ pub(crate) struct AffinityQueryPlanInterceptor {
 /// inspects the operation type, extracts the partition key if one applies,
 /// and constructs a seeded [QueryPlan] so that subsequent retries route to
 /// the same coordinator. Requests that don't qualify (read operations,
-/// `BatchWriteItem`, missing partition key info, unsupported PK types) get
-/// a basic round-robin plan instead.
+/// missing partition key info, unsupported PK types) get a basic round-robin
+/// plan instead.
 ///
 /// Partition key names are resolved lazily via [`PartitionKeyResolver`].
 /// On a cache miss, the request falls back to round-robin and discovery
@@ -256,24 +256,29 @@ impl AffinityQueryPlanInterceptor {
             return None;
         }
 
-        let table_name = op.table_name()?;
+        for candidate in op.partition_key_candidates() {
+            let pk_name = match self.resolver.get_partition_key(candidate.table_name) {
+                Some(cached_name) => cached_name,
+                None => {
+                    // CACHE MISS: Trigger background discovery.
+                    self.resolver.trigger_discovery(candidate.table_name);
 
-        let pk_name = match self.resolver.get_partition_key(table_name) {
-            Some(cached_name) => cached_name,
-            None => {
-                // CACHE MISS: Trigger background discovery.
-                self.resolver.trigger_discovery(table_name);
+                    // Use round-robin for this request.
+                    return None;
+                }
+            };
 
-                // Use round-robin for this request.
-                return None;
-            }
-        };
+            let Some(pk_value) = candidate.attributes.get(pk_name.as_ref()) else {
+                continue;
+            };
+            let Some(hash) = hasher::hash_attribute_value(pk_value) else {
+                continue;
+            };
 
-        // Get the partition key value.
-        let pk_value = op.partition_key(&pk_name)?;
+            return Some(QueryPlan::new_with_hash(self.live_nodes.clone(), hash));
+        }
 
-        let hash = hasher::hash_attribute_value(pk_value)?;
-        Some(QueryPlan::new_with_hash(self.live_nodes.clone(), hash))
+        None
     }
 
     /// Builds the [`QueryPlan`] for this request. Falls back to round-robin

--- a/src/keyrouting/affinity_config.rs
+++ b/src/keyrouting/affinity_config.rs
@@ -20,11 +20,10 @@ pub enum KeyRouteAffinityType {
     /// transactions (LWT): routing same-key requests to the same
     /// coordinator reduces Paxos round-trips.
     Rmw,
-    /// Route all write operations (`PutItem`, `UpdateItem`, `DeleteItem`)
-    /// to the same coordinator per partition key, regardless of
-    /// conditions. `BatchWriteItem` is excluded — a single batch can
-    /// target multiple partition keys across multiple tables and can't be
-    /// routed to one coordinator.
+    /// Route write operations (`PutItem`, `UpdateItem`, `DeleteItem`, and
+    /// `BatchWriteItem`) to the same coordinator per partition key,
+    /// regardless of conditions. For `BatchWriteItem`, the first usable
+    /// partition key in the batch is used.
     AnyWrite,
 }
 

--- a/src/keyrouting/classifier.rs
+++ b/src/keyrouting/classifier.rs
@@ -1,27 +1,30 @@
 use aws_sdk_dynamodb::operation::{
-    delete_item::DeleteItemInput, put_item::PutItemInput, update_item::UpdateItemInput,
+    batch_write_item::BatchWriteItemInput, delete_item::DeleteItemInput, put_item::PutItemInput,
+    update_item::UpdateItemInput,
 };
 use aws_sdk_dynamodb::types::{AttributeAction, AttributeValue, ReturnValue};
 use aws_smithy_runtime_api::client::interceptors::context::Input;
+use std::collections::HashMap;
 
 use super::affinity_config::KeyRouteAffinityType;
 
 /// Typed view over the DynamoDB operations key route affinity cares about.
-///
-/// `BatchWriteItem` is intentionally absent: a single request can target
-/// multiple partition keys across multiple tables, so it can't be routed
-/// deterministically to one coordinator. Those requests fall back to
-/// round-robin balancing.
 pub(crate) enum DynamoOp<'a> {
     Put(&'a PutItemInput),
     Update(&'a UpdateItemInput),
     Delete(&'a DeleteItemInput),
+    BatchWrite(&'a BatchWriteItemInput),
+}
+
+pub(crate) struct PartitionKeyCandidate<'a> {
+    pub table_name: &'a str,
+    pub attributes: &'a HashMap<String, AttributeValue>,
 }
 
 impl<'a> DynamoOp<'a> {
     /// Downcast the SDK's type-erased input into one of the variants we care
-    /// about. Anything else (Scan, BatchWriteItem, TransactWriteItems, etc.)
-    /// yields `None` and the caller treats the request as non-applicable.
+    /// about. Anything else (Scan, Query, TransactWriteItems, etc.) yields
+    /// `None` and the caller treats the request as non-applicable.
     pub fn from_input(input: &'a Input) -> Option<Self> {
         if let Some(r) = input.downcast_ref::<PutItemInput>() {
             return Some(Self::Put(r));
@@ -31,6 +34,9 @@ impl<'a> DynamoOp<'a> {
         }
         if let Some(r) = input.downcast_ref::<DeleteItemInput>() {
             return Some(Self::Delete(r));
+        }
+        if let Some(r) = input.downcast_ref::<BatchWriteItemInput>() {
+            return Some(Self::BatchWrite(r));
         }
         None
     }
@@ -46,25 +52,73 @@ impl<'a> DynamoOp<'a> {
             Self::Put(r) => should_apply_put(mode, r),
             Self::Delete(r) => should_apply_delete(mode, r),
             Self::Update(r) => should_apply_update(mode, r),
+            Self::BatchWrite(_) => mode == KeyRouteAffinityType::AnyWrite,
         }
     }
 
-    /// Returns the request's target table name, or `None` if the SDK input doesn't have one set.
-    pub fn table_name(&self) -> Option<&str> {
+    /// Returns ordered candidate table/key maps that can provide a partition
+    /// key. Single-item operations return at most one candidate; BatchWriteItem
+    /// can return multiple candidates so the caller can use the first one with
+    /// cached metadata and a supported partition-key value.
+    pub fn partition_key_candidates(&self) -> Vec<PartitionKeyCandidate<'a>> {
         match self {
-            Self::Put(r) => r.table_name(),
-            Self::Update(r) => r.table_name(),
-            Self::Delete(r) => r.table_name(),
-        }
-    }
+            Self::Put(r) => r
+                .table_name()
+                .zip(r.item())
+                .map(|(table_name, attributes)| {
+                    vec![PartitionKeyCandidate {
+                        table_name,
+                        attributes,
+                    }]
+                })
+                .unwrap_or_default(),
+            Self::Update(r) => r
+                .table_name()
+                .zip(r.key())
+                .map(|(table_name, attributes)| {
+                    vec![PartitionKeyCandidate {
+                        table_name,
+                        attributes,
+                    }]
+                })
+                .unwrap_or_default(),
+            Self::Delete(r) => r
+                .table_name()
+                .zip(r.key())
+                .map(|(table_name, attributes)| {
+                    vec![PartitionKeyCandidate {
+                        table_name,
+                        attributes,
+                    }]
+                })
+                .unwrap_or_default(),
+            Self::BatchWrite(r) => {
+                let mut items: Vec<_> = r
+                    .request_items()
+                    .into_iter()
+                    .flat_map(|items| items.iter())
+                    .collect();
+                items.sort_unstable_by(|(left_table, _), (right_table, _)| {
+                    left_table.cmp(right_table)
+                });
 
-    /// Looks up the partition key value by attribute name. Returns `None`
-    /// if the key map is unset or the attribute is missing.
-    pub fn partition_key(&self, pk_name: &str) -> Option<&AttributeValue> {
-        match self {
-            Self::Put(r) => r.item().and_then(|m| m.get(pk_name)),
-            Self::Update(r) => r.key().and_then(|m| m.get(pk_name)),
-            Self::Delete(r) => r.key().and_then(|m| m.get(pk_name)),
+                items
+                    .into_iter()
+                    .flat_map(|(table_name, writes)| {
+                        writes.iter().filter_map(|write| {
+                            let attributes = write
+                                .delete_request()
+                                .map(|delete| delete.key())
+                                .or_else(|| write.put_request().map(|put| put.item()))?;
+
+                            Some(PartitionKeyCandidate {
+                                table_name,
+                                attributes,
+                            })
+                        })
+                    })
+                    .collect()
+            }
         }
     }
 }
@@ -137,7 +191,8 @@ mod tests {
     use super::*;
     use aws_sdk_dynamodb::operation::scan::ScanInput;
     use aws_sdk_dynamodb::types::{
-        AttributeAction, AttributeValue, AttributeValueUpdate, ExpectedAttributeValue, ReturnValue,
+        AttributeAction, AttributeValue, AttributeValueUpdate, DeleteRequest,
+        ExpectedAttributeValue, PutRequest, ReturnValue, WriteRequest,
     };
 
     fn s(v: &str) -> AttributeValue {
@@ -399,6 +454,90 @@ mod tests {
         assert!(should_apply_update(KeyRouteAffinityType::AnyWrite, &r));
     }
 
+    // ----- BatchWriteItem -----
+
+    fn put_write(pk_name: &str, value: &str) -> WriteRequest {
+        let put = PutRequest::builder()
+            .item(pk_name, s(value))
+            .item("other", s("x"))
+            .build()
+            .unwrap();
+        WriteRequest::builder().put_request(put).build()
+    }
+
+    fn delete_write(pk_name: &str, value: &str) -> WriteRequest {
+        let delete = DeleteRequest::builder()
+            .key(pk_name, s(value))
+            .build()
+            .unwrap();
+        WriteRequest::builder().delete_request(delete).build()
+    }
+
+    #[test]
+    fn batch_write_applies_only_for_any_write() {
+        let r = BatchWriteItemInput::builder()
+            .request_items("t", vec![put_write("pk", "k")])
+            .build()
+            .unwrap();
+        let op = DynamoOp::BatchWrite(&r);
+
+        assert!(!op.should_apply(KeyRouteAffinityType::None));
+        assert!(!op.should_apply(KeyRouteAffinityType::Rmw));
+        assert!(op.should_apply(KeyRouteAffinityType::AnyWrite));
+    }
+
+    #[test]
+    fn batch_write_partition_key_candidates_include_put_and_delete() {
+        let r = BatchWriteItemInput::builder()
+            .request_items("put_table", vec![put_write("pk", "put_key")])
+            .request_items("delete_table", vec![delete_write("pk", "delete_key")])
+            .build()
+            .unwrap();
+
+        let candidates = DynamoOp::BatchWrite(&r).partition_key_candidates();
+
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates.iter().any(|candidate| {
+            candidate.table_name == "put_table"
+                && candidate.attributes.get("pk") == Some(&s("put_key"))
+        }));
+        assert!(candidates.iter().any(|candidate| {
+            candidate.table_name == "delete_table"
+                && candidate.attributes.get("pk") == Some(&s("delete_key"))
+        }));
+    }
+
+    #[test]
+    fn batch_write_partition_key_candidates_are_sorted_by_table_name() {
+        let r = BatchWriteItemInput::builder()
+            .request_items("z_table", vec![put_write("pk", "z_key")])
+            .request_items("a_table", vec![put_write("pk", "a_key")])
+            .build()
+            .unwrap();
+
+        let candidates = DynamoOp::BatchWrite(&r).partition_key_candidates();
+        let ordered_tables: Vec<_> = candidates
+            .iter()
+            .map(|candidate| candidate.table_name)
+            .collect();
+
+        assert_eq!(ordered_tables, vec!["a_table", "z_table"]);
+    }
+
+    #[test]
+    fn batch_write_ignores_empty_write_requests() {
+        let r = BatchWriteItemInput::builder()
+            .request_items("t", vec![WriteRequest::builder().build()])
+            .build()
+            .unwrap();
+
+        assert!(
+            DynamoOp::BatchWrite(&r)
+                .partition_key_candidates()
+                .is_empty()
+        );
+    }
+
     // ----- Enum dispatch / None mode -----
 
     #[test]
@@ -415,7 +554,7 @@ mod tests {
     }
 
     #[test]
-    fn from_input_recognizes_put_update_delete() {
+    fn from_input_recognizes_put_update_delete_batch_write() {
         let p = PutItemInput::builder()
             .table_name("t")
             .item("pk", s("k"))
@@ -445,11 +584,20 @@ mod tests {
             DynamoOp::from_input(&Input::erase(d)),
             Some(DynamoOp::Delete(_))
         ));
+
+        let bw = BatchWriteItemInput::builder()
+            .request_items("t", vec![put_write("pk", "k")])
+            .build()
+            .unwrap();
+        assert!(matches!(
+            DynamoOp::from_input(&Input::erase(bw)),
+            Some(DynamoOp::BatchWrite(_))
+        ));
     }
 
     #[test]
     fn from_input_returns_none_for_unsupported_op() {
-        // Scan, BatchWriteItem, Query, etc. are intentionally not in the enum.
+        // Scan, Query, etc. are intentionally not in the enum.
         let scan = ScanInput::builder().table_name("t").build().unwrap();
         assert!(DynamoOp::from_input(&Input::erase(scan)).is_none());
     }
@@ -464,7 +612,11 @@ mod tests {
             .item("other", s("x"))
             .build()
             .unwrap();
-        assert_eq!(DynamoOp::Put(&r).partition_key("pk"), Some(&s("alice")));
+        let candidates = DynamoOp::Put(&r).partition_key_candidates();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].table_name, "t");
+        assert_eq!(candidates[0].attributes.get("pk"), Some(&s("alice")));
     }
 
     #[test]
@@ -474,7 +626,11 @@ mod tests {
             .key("pk", s("bob"))
             .build()
             .unwrap();
-        assert_eq!(DynamoOp::Update(&r).partition_key("pk"), Some(&s("bob")));
+        let candidates = DynamoOp::Update(&r).partition_key_candidates();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].table_name, "t");
+        assert_eq!(candidates[0].attributes.get("pk"), Some(&s("bob")));
     }
 
     #[test]
@@ -484,16 +640,16 @@ mod tests {
             .item("other", s("x"))
             .build()
             .unwrap();
-        assert!(DynamoOp::Put(&r).partition_key("pk").is_none());
+        let candidates = DynamoOp::Put(&r).partition_key_candidates();
+
+        assert_eq!(candidates.len(), 1);
+        assert!(!candidates[0].attributes.contains_key("pk"));
     }
 
     #[test]
-    fn table_name_extracts_correctly() {
-        let p = PutItemInput::builder()
-            .table_name("users")
-            .item("pk", s("a"))
-            .build()
-            .unwrap();
-        assert_eq!(DynamoOp::Put(&p).table_name(), Some("users"));
+    fn missing_table_name_returns_no_candidates() {
+        let r = PutItemInput::builder().item("pk", s("a")).build().unwrap();
+
+        assert!(DynamoOp::Put(&r).partition_key_candidates().is_empty());
     }
 }

--- a/tests/load_balancing/load_balancing_tests.rs
+++ b/tests/load_balancing/load_balancing_tests.rs
@@ -12,8 +12,8 @@ use alternator_driver::keyrouting::affinity_config::{
 };
 use alternator_driver::keyrouting::{go_rand::GoRand, hasher};
 use aws_sdk_dynamodb::types::{
-    AttributeAction, AttributeValue, AttributeValueUpdate, KeysAndAttributes, PutRequest,
-    ReturnValue, Select, WriteRequest,
+    AttributeAction, AttributeValue, AttributeValueUpdate, DeleteRequest, KeysAndAttributes,
+    PutRequest, ReturnValue, Select, WriteRequest,
 };
 use hyper::Method;
 use std::collections::HashMap;
@@ -442,6 +442,7 @@ enum MatrixOperation {
     UpdateLegacyPutReturnUpdatedNew,
     UpdateLegacyPutReturnAllNew,
     BatchWritePut,
+    BatchWriteDelete,
     GetItem,
     BatchGetItem,
     Query,
@@ -450,7 +451,7 @@ enum MatrixOperation {
 }
 
 impl MatrixOperation {
-    const ALL: [Self; 16] = [
+    const ALL: [Self; 17] = [
         MatrixOperation::PutPlain,
         MatrixOperation::PutConditional,
         MatrixOperation::DeletePlain,
@@ -462,6 +463,7 @@ impl MatrixOperation {
         MatrixOperation::UpdateLegacyPutReturnUpdatedNew,
         MatrixOperation::UpdateLegacyPutReturnAllNew,
         MatrixOperation::BatchWritePut,
+        MatrixOperation::BatchWriteDelete,
         MatrixOperation::GetItem,
         MatrixOperation::BatchGetItem,
         MatrixOperation::Query,
@@ -484,6 +486,7 @@ impl MatrixOperation {
             }
             MatrixOperation::UpdateLegacyPutReturnAllNew => "update_legacy_put_return_all_new",
             MatrixOperation::BatchWritePut => "batch_write_put",
+            MatrixOperation::BatchWriteDelete => "batch_write_delete",
             MatrixOperation::GetItem => "get_item",
             MatrixOperation::BatchGetItem => "batch_get_item",
             MatrixOperation::Query => "query",
@@ -654,6 +657,16 @@ async fn send_matrix_operation(
                 .build()
                 .unwrap();
             let write = WriteRequest::builder().put_request(put).build();
+
+            let _ = client
+                .batch_write_item()
+                .request_items(table_name, vec![write])
+                .send()
+                .await;
+        }
+        MatrixOperation::BatchWriteDelete => {
+            let delete = DeleteRequest::builder().key("id", s(key)).build().unwrap();
+            let write = WriteRequest::builder().delete_request(delete).build();
 
             let _ = client
                 .batch_write_item()
@@ -1257,6 +1270,11 @@ async fn key_route_affinity_operation_matrix_test() {
         },
         OperationMatrixCase {
             mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::BatchWriteDelete,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
             operation: MatrixOperation::GetItem,
             expected_routing: ExpectedRouting::RoundRobin,
         },
@@ -1315,12 +1333,15 @@ async fn key_route_affinity_operation_matrix_test() {
             operation: MatrixOperation::UpdateExpression,
             expected_routing: ExpectedRouting::Affinity,
         },
-        // The Rust driver intentionally keeps BatchWriteItem on round-robin:
-        // one request can contain multiple partition keys and tables.
         OperationMatrixCase {
             mode: KeyRouteAffinityType::AnyWrite,
             operation: MatrixOperation::BatchWritePut,
-            expected_routing: ExpectedRouting::RoundRobin,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::BatchWriteDelete,
+            expected_routing: ExpectedRouting::Affinity,
         },
         OperationMatrixCase {
             mode: KeyRouteAffinityType::AnyWrite,
@@ -1391,6 +1412,84 @@ async fn key_route_affinity_operation_matrix_test() {
                 assert_round_robin_counts(&request_counter, node_ips.as_slice(), &case_label);
             }
         }
+    }
+}
+
+/// Test that multi-table BatchWriteItem affinity is deterministic for repeated
+/// requests constructed the same way, including when table entries are inserted
+/// in different orders.
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn batch_write_affinity_multitable_routing_is_deterministic_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let scope = scope_utils::datacenter_scope_from_index(cluster, 1);
+    let request_counter = RequestCounter::from_cluster(cluster);
+
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let test_id = uuid::Uuid::new_v4();
+    let a_table_name = format!("a_batch_test_{test_id}");
+    let z_table_name = format!("z_batch_test_{test_id}");
+    let client = create_client_with_scope_and_affinity(
+        cluster,
+        scope.clone(),
+        KeyRouteAffinityConfig::builder()
+            .with_type(KeyRouteAffinityType::AnyWrite)
+            .with_pk_info(&a_table_name, "id")
+            .with_pk_info(&z_table_name, "id")
+            .build(),
+    );
+    let node_ips = scope_utils::working_nodes_ips_in_scope(cluster, &scope);
+
+    wait_until_live_nodes_match(&client, node_ips.clone()).await;
+    create_table(&client, &a_table_name).await;
+    create_table(&client, &z_table_name).await;
+
+    let a_key = "batch_a_key";
+    let z_key = "batch_z_key";
+    let expected_ip = expected_first_node(node_ips.as_slice(), a_key);
+
+    for z_table_first in [true, false] {
+        request_counter.reset();
+
+        for iteration in 0..node_ips.len() {
+            let a_put = PutRequest::builder()
+                .item("id", s(a_key))
+                .item("val", s(format!("a_value_{z_table_first}_{iteration}")))
+                .build()
+                .unwrap();
+            let z_put = PutRequest::builder()
+                .item("id", s(z_key))
+                .item("val", s(format!("z_value_{z_table_first}_{iteration}")))
+                .build()
+                .unwrap();
+            let a_write = WriteRequest::builder().put_request(a_put).build();
+            let z_write = WriteRequest::builder().put_request(z_put).build();
+
+            let builder = client.batch_write_item();
+            let builder = if z_table_first {
+                builder
+                    .request_items(z_table_name.as_str(), vec![z_write])
+                    .request_items(a_table_name.as_str(), vec![a_write])
+            } else {
+                builder
+                    .request_items(a_table_name.as_str(), vec![a_write])
+                    .request_items(z_table_name.as_str(), vec![z_write])
+            };
+
+            builder.send().await.unwrap();
+        }
+
+        let case_label = format!("batch_write_multitable_z_first_{z_table_first}");
+        assert_affinity_counts(
+            &request_counter,
+            node_ips.as_slice(),
+            expected_ip,
+            node_ips.len(),
+            &case_label,
+        );
     }
 }
 

--- a/tests/load_balancing/load_balancing_tests.rs
+++ b/tests/load_balancing/load_balancing_tests.rs
@@ -11,7 +11,10 @@ use alternator_driver::keyrouting::affinity_config::{
     KeyRouteAffinityConfig, KeyRouteAffinityType,
 };
 use alternator_driver::keyrouting::{go_rand::GoRand, hasher};
-use aws_sdk_dynamodb::types::AttributeValue;
+use aws_sdk_dynamodb::types::{
+    AttributeAction, AttributeValue, AttributeValueUpdate, KeysAndAttributes, PutRequest,
+    ReturnValue, Select, WriteRequest,
+};
 use hyper::Method;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -420,6 +423,343 @@ fn expected_first_node<'a>(nodes: &'a [&str], partition_key_value: &str) -> &'a 
     nodes[idx]
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExpectedRouting {
+    Affinity,
+    RoundRobin,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MatrixOperation {
+    PutPlain,
+    PutConditional,
+    DeletePlain,
+    DeleteConditional,
+    UpdateLegacyPut,
+    UpdateLegacyAdd,
+    UpdateLegacyDeleteWithValue,
+    UpdateExpression,
+    UpdateLegacyPutReturnUpdatedNew,
+    UpdateLegacyPutReturnAllNew,
+    BatchWritePut,
+    GetItem,
+    BatchGetItem,
+    Query,
+    Scan,
+    ListTables,
+}
+
+impl MatrixOperation {
+    const ALL: [Self; 16] = [
+        MatrixOperation::PutPlain,
+        MatrixOperation::PutConditional,
+        MatrixOperation::DeletePlain,
+        MatrixOperation::DeleteConditional,
+        MatrixOperation::UpdateLegacyPut,
+        MatrixOperation::UpdateLegacyAdd,
+        MatrixOperation::UpdateLegacyDeleteWithValue,
+        MatrixOperation::UpdateExpression,
+        MatrixOperation::UpdateLegacyPutReturnUpdatedNew,
+        MatrixOperation::UpdateLegacyPutReturnAllNew,
+        MatrixOperation::BatchWritePut,
+        MatrixOperation::GetItem,
+        MatrixOperation::BatchGetItem,
+        MatrixOperation::Query,
+        MatrixOperation::Scan,
+        MatrixOperation::ListTables,
+    ];
+
+    fn name(self) -> &'static str {
+        match self {
+            MatrixOperation::PutPlain => "put_plain",
+            MatrixOperation::PutConditional => "put_conditional",
+            MatrixOperation::DeletePlain => "delete_plain",
+            MatrixOperation::DeleteConditional => "delete_conditional",
+            MatrixOperation::UpdateLegacyPut => "update_legacy_put",
+            MatrixOperation::UpdateLegacyAdd => "update_legacy_add",
+            MatrixOperation::UpdateLegacyDeleteWithValue => "update_legacy_delete_with_value",
+            MatrixOperation::UpdateExpression => "update_expression",
+            MatrixOperation::UpdateLegacyPutReturnUpdatedNew => {
+                "update_legacy_put_return_updated_new"
+            }
+            MatrixOperation::UpdateLegacyPutReturnAllNew => "update_legacy_put_return_all_new",
+            MatrixOperation::BatchWritePut => "batch_write_put",
+            MatrixOperation::GetItem => "get_item",
+            MatrixOperation::BatchGetItem => "batch_get_item",
+            MatrixOperation::Query => "query",
+            MatrixOperation::Scan => "scan",
+            MatrixOperation::ListTables => "list_tables",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OperationMatrixCase {
+    mode: KeyRouteAffinityType,
+    operation: MatrixOperation,
+    expected_routing: ExpectedRouting,
+}
+
+fn mode_name(mode: KeyRouteAffinityType) -> &'static str {
+    match mode {
+        KeyRouteAffinityType::None => "none",
+        KeyRouteAffinityType::Rmw => "rmw",
+        KeyRouteAffinityType::AnyWrite => "any_write",
+    }
+}
+
+fn s(value: impl Into<String>) -> AttributeValue {
+    AttributeValue::S(value.into())
+}
+
+fn key_map(key: &str) -> HashMap<String, AttributeValue> {
+    HashMap::from([("id".to_string(), s(key))])
+}
+
+async fn send_matrix_operation(
+    client: &AlternatorClient,
+    table_name: &str,
+    operation: MatrixOperation,
+    key: &str,
+    iteration: usize,
+) {
+    match operation {
+        MatrixOperation::PutPlain => {
+            let _ = client
+                .put_item()
+                .table_name(table_name)
+                .item("id", s(key))
+                .item("val", s(format!("value_{iteration}")))
+                .send()
+                .await;
+        }
+        MatrixOperation::PutConditional => {
+            let _ = client
+                .put_item()
+                .table_name(table_name)
+                .item("id", s(key))
+                .item("val", s(format!("value_{iteration}")))
+                .condition_expression("attribute_not_exists(missing_attr)")
+                .send()
+                .await;
+        }
+        MatrixOperation::DeletePlain => {
+            let _ = client
+                .delete_item()
+                .table_name(table_name)
+                .key("id", s(key))
+                .send()
+                .await;
+        }
+        MatrixOperation::DeleteConditional => {
+            let _ = client
+                .delete_item()
+                .table_name(table_name)
+                .key("id", s(key))
+                .condition_expression("attribute_not_exists(missing_attr)")
+                .send()
+                .await;
+        }
+        MatrixOperation::UpdateLegacyPut => {
+            let _ = client
+                .update_item()
+                .table_name(table_name)
+                .key("id", s(key))
+                .attribute_updates(
+                    "val",
+                    AttributeValueUpdate::builder()
+                        .action(AttributeAction::Put)
+                        .value(s(format!("value_{iteration}")))
+                        .build(),
+                )
+                .send()
+                .await;
+        }
+        MatrixOperation::UpdateLegacyAdd => {
+            let _ = client
+                .update_item()
+                .table_name(table_name)
+                .key("id", s(key))
+                .attribute_updates(
+                    "counter",
+                    AttributeValueUpdate::builder()
+                        .action(AttributeAction::Add)
+                        .value(AttributeValue::N("1".to_string()))
+                        .build(),
+                )
+                .send()
+                .await;
+        }
+        MatrixOperation::UpdateLegacyDeleteWithValue => {
+            let _ = client
+                .update_item()
+                .table_name(table_name)
+                .key("id", s(key))
+                .attribute_updates(
+                    "tags",
+                    AttributeValueUpdate::builder()
+                        .action(AttributeAction::Delete)
+                        .value(AttributeValue::Ss(vec!["tag".to_string()]))
+                        .build(),
+                )
+                .send()
+                .await;
+        }
+        MatrixOperation::UpdateExpression => {
+            let _ = client
+                .update_item()
+                .table_name(table_name)
+                .key("id", s(key))
+                .update_expression("SET val = :v")
+                .expression_attribute_values(":v", s(format!("value_{iteration}")))
+                .send()
+                .await;
+        }
+        MatrixOperation::UpdateLegacyPutReturnUpdatedNew => {
+            let _ = client
+                .update_item()
+                .table_name(table_name)
+                .key("id", s(key))
+                .attribute_updates(
+                    "val",
+                    AttributeValueUpdate::builder()
+                        .action(AttributeAction::Put)
+                        .value(s(format!("value_{iteration}")))
+                        .build(),
+                )
+                .return_values(ReturnValue::UpdatedNew)
+                .send()
+                .await;
+        }
+        MatrixOperation::UpdateLegacyPutReturnAllNew => {
+            let _ = client
+                .update_item()
+                .table_name(table_name)
+                .key("id", s(key))
+                .attribute_updates(
+                    "val",
+                    AttributeValueUpdate::builder()
+                        .action(AttributeAction::Put)
+                        .value(s(format!("value_{iteration}")))
+                        .build(),
+                )
+                .return_values(ReturnValue::AllNew)
+                .send()
+                .await;
+        }
+        MatrixOperation::BatchWritePut => {
+            let put = PutRequest::builder()
+                .item("id", s(key))
+                .item("val", s(format!("value_{iteration}")))
+                .build()
+                .unwrap();
+            let write = WriteRequest::builder().put_request(put).build();
+
+            let _ = client
+                .batch_write_item()
+                .request_items(table_name, vec![write])
+                .send()
+                .await;
+        }
+        MatrixOperation::GetItem => {
+            let _ = client
+                .get_item()
+                .table_name(table_name)
+                .key("id", s(key))
+                .consistent_read(true)
+                .send()
+                .await;
+        }
+        MatrixOperation::BatchGetItem => {
+            let keys = KeysAndAttributes::builder()
+                .keys(key_map(key))
+                .consistent_read(true)
+                .build()
+                .unwrap();
+
+            let _ = client
+                .batch_get_item()
+                .request_items(table_name, keys)
+                .send()
+                .await;
+        }
+        MatrixOperation::Query => {
+            let _ = client
+                .query()
+                .table_name(table_name)
+                .key_condition_expression("id = :id")
+                .expression_attribute_values(":id", s(key))
+                .select(Select::Count)
+                .send()
+                .await;
+        }
+        MatrixOperation::Scan => {
+            let _ = client
+                .scan()
+                .table_name(table_name)
+                .select(Select::Count)
+                .send()
+                .await;
+        }
+        MatrixOperation::ListTables => {
+            let _ = client.list_tables().send().await;
+        }
+    }
+}
+
+fn assert_affinity_counts(
+    request_counter: &RequestCounter,
+    node_ips: &[&str],
+    expected_ip: &str,
+    expected_requests: usize,
+    case_label: &str,
+) {
+    assert_eq!(
+        request_counter.total_posts(),
+        expected_requests,
+        "{case_label}: unexpected total POST count"
+    );
+
+    for ip in node_ips {
+        let expected = if *ip == expected_ip {
+            expected_requests
+        } else {
+            0
+        };
+        assert_eq!(
+            request_counter.get(ip).posts(),
+            expected,
+            "{case_label}: unexpected POST count for {ip}"
+        );
+    }
+}
+
+fn assert_round_robin_counts(
+    request_counter: &RequestCounter,
+    node_ips: &[&str],
+    case_label: &str,
+) {
+    assert_eq!(
+        request_counter.total_posts(),
+        node_ips.len(),
+        "{case_label}: unexpected total POST count"
+    );
+
+    for ip in node_ips {
+        assert_eq!(
+            request_counter.get(ip).posts(),
+            1,
+            "{case_label}: round-robin request did not visit {ip} exactly once"
+        );
+    }
+
+    assert_eq!(
+        request_counter.get_posts_to_other_ips(node_ips),
+        0,
+        "{case_label}: request escaped the selected routing scope"
+    );
+}
+
 #[tokio::test]
 #[cfg_attr(not(ccm_tests), ignore)]
 async fn calls_correct_datacenter_scope_test() {
@@ -803,6 +1143,255 @@ async fn describe_table_not_called_with_config() {
     }
 
     assert_eq!(request_counter.total_describe_tables(), 0);
+}
+
+/// Matrix test for which DynamoDB operations use key-route affinity in each mode.
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn key_route_affinity_operation_matrix_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let scope = scope_utils::datacenter_scope_from_index(cluster, 1);
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let table_name = format!("test_table_{}", uuid::Uuid::new_v4());
+    {
+        // Drop the setup client before creating the three matrix clients: the
+        // test proxy accepts up to three concurrent client connections.
+        let setup_client = create_client_with_scope(cluster, scope.clone());
+        wait_until_live_nodes_match(
+            &setup_client,
+            scope_utils::working_nodes_ips_in_scope(cluster, &scope),
+        )
+        .await;
+        create_table(&setup_client, &table_name).await;
+    }
+
+    let none_client = create_client_with_scope_and_affinity(
+        cluster,
+        scope.clone(),
+        KeyRouteAffinityConfig::builder()
+            .with_type(KeyRouteAffinityType::None)
+            .with_pk_info(&table_name, "id")
+            .build(),
+    );
+    let rmw_client = create_client_with_scope_and_affinity(
+        cluster,
+        scope.clone(),
+        KeyRouteAffinityConfig::builder()
+            .with_type(KeyRouteAffinityType::Rmw)
+            .with_pk_info(&table_name, "id")
+            .build(),
+    );
+    let any_write_client = create_client_with_scope_and_affinity(
+        cluster,
+        scope.clone(),
+        KeyRouteAffinityConfig::builder()
+            .with_type(KeyRouteAffinityType::AnyWrite)
+            .with_pk_info(&table_name, "id")
+            .build(),
+    );
+    let node_ips = scope_utils::working_nodes_ips_in_scope(cluster, &scope);
+
+    wait_until_live_nodes_match(&none_client, node_ips.clone()).await;
+    wait_until_live_nodes_match(&rmw_client, node_ips.clone()).await;
+    wait_until_live_nodes_match(&any_write_client, node_ips.clone()).await;
+
+    let mut cases = vec![
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::PutPlain,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::PutConditional,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::DeletePlain,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::DeleteConditional,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::UpdateLegacyPut,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::UpdateLegacyAdd,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::UpdateLegacyDeleteWithValue,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::UpdateExpression,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::UpdateLegacyPutReturnUpdatedNew,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::UpdateLegacyPutReturnAllNew,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::BatchWritePut,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::GetItem,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::BatchGetItem,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::Query,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::Scan,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::Rmw,
+            operation: MatrixOperation::ListTables,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::PutPlain,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::DeletePlain,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::UpdateLegacyPut,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::UpdateLegacyAdd,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::UpdateLegacyDeleteWithValue,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::UpdateLegacyPutReturnUpdatedNew,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::UpdateExpression,
+            expected_routing: ExpectedRouting::Affinity,
+        },
+        // The Rust driver intentionally keeps BatchWriteItem on round-robin:
+        // one request can contain multiple partition keys and tables.
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::BatchWritePut,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::GetItem,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::BatchGetItem,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::Query,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::Scan,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+        OperationMatrixCase {
+            mode: KeyRouteAffinityType::AnyWrite,
+            operation: MatrixOperation::ListTables,
+            expected_routing: ExpectedRouting::RoundRobin,
+        },
+    ];
+
+    cases.extend(
+        MatrixOperation::ALL
+            .into_iter()
+            .map(|operation| OperationMatrixCase {
+                mode: KeyRouteAffinityType::None,
+                operation,
+                expected_routing: ExpectedRouting::RoundRobin,
+            }),
+    );
+
+    request_counter.reset();
+
+    for case in cases {
+        let client = match case.mode {
+            KeyRouteAffinityType::None => &none_client,
+            KeyRouteAffinityType::Rmw => &rmw_client,
+            KeyRouteAffinityType::AnyWrite => &any_write_client,
+        };
+        let case_label = format!("{}_{}", mode_name(case.mode), case.operation.name());
+        let key = format!("matrix_key_{case_label}");
+
+        request_counter.reset();
+
+        for iteration in 0..node_ips.len() {
+            send_matrix_operation(client, &table_name, case.operation, &key, iteration).await;
+        }
+
+        match case.expected_routing {
+            ExpectedRouting::Affinity => {
+                let expected_ip = expected_first_node(node_ips.as_slice(), &key);
+                assert_affinity_counts(
+                    &request_counter,
+                    node_ips.as_slice(),
+                    expected_ip,
+                    node_ips.len(),
+                    &case_label,
+                );
+            }
+            ExpectedRouting::RoundRobin => {
+                assert_round_robin_counts(&request_counter, node_ips.as_slice(), &case_label);
+            }
+        }
+    }
 }
 
 /// Test if the routing is deterministic, and all calls go to the same node.


### PR DESCRIPTION
## Summary

Fixes #54.
Fixes #53.

Adds a CCM-backed operation matrix test for key-route affinity routing. The matrix exercises Rust driver behavior across all affinity modes: `KeyRouteAffinityType::None`, `KeyRouteAffinityType::Rmw`, and `KeyRouteAffinityType::AnyWrite`.

Implements `BatchWriteItem` key-route affinity for `AnyWrite` mode. `Rmw` keeps `BatchWriteItem` on round-robin routing, while `AnyWrite` extracts a usable partition key from a put or delete request in the batch and routes same-key batch writes to the predicted affinity node. For multi-table batches, table entries are scanned in sorted table-name order so the best-effort heuristic is deterministic; write order within each table is preserved. The CCM suite verifies that repeated multi-table batch writes constructed the same way land on the same affinity node, and also checks both table insertion orders.

The matrix intentionally reflects current Rust driver behavior:

- `None` keeps all tested operations on round-robin routing.
- In `Rmw`, conditional `PutItem`/`DeleteItem`, update expressions, read-before-write return-value cases, legacy `ADD`, and legacy `DELETE` with a value use affinity.
- In `Rmw`, plain writes, legacy `UpdateItem` `PUT`, `UPDATED_NEW`, `BatchWriteItem`, reads, and unsupported operations stay round-robin.
- In `AnyWrite`, single-key `PutItem`, `DeleteItem`, `UpdateItem`, and `BatchWriteItem` writes use affinity, while reads and unsupported operations stay round-robin.

## Testing

- `cargo test keyrouting::classifier::tests`
- `cargo test --test load_balancing_tests --no-run`
- `RUSTFLAGS="--cfg ccm_tests" cargo test --test load_balancing_tests --no-run`
- `make static`
- `cargo test --test load_balancing_tests`
- `make test`
- `git diff --check`

Not fully run locally: `make ccm-tests` is blocked because the local `/home/dmitry.kropachev/.local/bin/ccm` launcher points to missing `/usr/local/bin/python3.11`. GitHub Actions has a fresh `scylla-ccm` install and runs `make ccm-tests` in CI.
