### PR TITLE
Cross-language: Add BatchWrite key-affinity majority routing

### DIFF
--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -243,6 +243,23 @@ impl AffinityQueryPlanInterceptor {
         }
     }
 
+    fn candidate_partition_key_hash(
+        &self,
+        candidate: &classifier::PartitionKeyCandidate<'_>,
+    ) -> Option<u64> {
+        let pk_name = match self.resolver.get_partition_key(candidate.table_name) {
+            Some(cached_name) => cached_name,
+            None => {
+                // CACHE MISS: Trigger background discovery.
+                self.resolver.trigger_discovery(candidate.table_name);
+                return None;
+            }
+        };
+
+        let pk_value = candidate.attributes.get(pk_name.as_ref())?;
+        hasher::hash_attribute_value(pk_value)
+    }
+
     /// Tries to build an affinity-routed plan for `input`. Returns `None`
     /// when affinity doesn't apply or no usable partition key can be found. On
     /// cache miss this also triggers background PK discovery as a side effect.
@@ -262,19 +279,7 @@ impl AffinityQueryPlanInterceptor {
 
         if !is_batch_write {
             for candidate in candidates {
-                let pk_name = match self.resolver.get_partition_key(candidate.table_name) {
-                    Some(cached_name) => cached_name,
-                    None => {
-                        // CACHE MISS: Trigger background discovery.
-                        self.resolver.trigger_discovery(candidate.table_name);
-                        continue;
-                    }
-                };
-
-                let Some(pk_value) = candidate.attributes.get(pk_name.as_ref()) else {
-                    continue;
-                };
-                let Some(hash) = hasher::hash_attribute_value(pk_value) else {
+                let Some(hash) = self.candidate_partition_key_hash(&candidate) else {
                     continue;
                 };
 
@@ -288,19 +293,7 @@ impl AffinityQueryPlanInterceptor {
         let mut votes: HashMap<Arc<Url>, usize> = HashMap::new();
 
         for candidate in candidates {
-            let pk_name = match self.resolver.get_partition_key(candidate.table_name) {
-                Some(cached_name) => cached_name,
-                None => {
-                    // CACHE MISS: Trigger background discovery.
-                    self.resolver.trigger_discovery(candidate.table_name);
-                    continue;
-                }
-            };
-
-            let Some(pk_value) = candidate.attributes.get(pk_name.as_ref()) else {
-                continue;
-            };
-            let Some(hash) = hasher::hash_attribute_value(pk_value) else {
+            let Some(hash) = self.candidate_partition_key_hash(&candidate) else {
                 continue;
             };
 

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -9,7 +9,9 @@ use aws_smithy_runtime_api::client::interceptors::context::{
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
+use std::collections::HashMap;
 use std::sync::Arc;
+use url::Url;
 
 use crate::keyrouting::affinity_config::KeyRouteAffinityConfig;
 use crate::keyrouting::classifier;
@@ -218,8 +220,8 @@ pub(crate) struct AffinityQueryPlanInterceptor {
 ///
 /// On the first attempt of each request, [`modify_before_serialization`]
 /// inspects the operation type, extracts the partition key if one applies,
-/// and constructs a seeded [QueryPlan] so that subsequent retries route to
-/// the same coordinator. Requests that don't qualify (read operations,
+/// and constructs an affinity [QueryPlan] so that subsequent retries prefer
+/// related coordinators. Requests that don't qualify (read operations,
 /// missing partition key info, unsupported PK types) get a basic round-robin
 /// plan instead.
 ///
@@ -242,9 +244,8 @@ impl AffinityQueryPlanInterceptor {
     }
 
     /// Tries to build an affinity-routed plan for `input`. Returns `None`
-    /// when affinity doesn't apply (mode disabled, non-qualifying op, no
-    /// table, cache miss, no PK value, unsupported PK type). On cache
-    /// miss this also triggers background PK discovery as a side effect.
+    /// when affinity doesn't apply or no usable partition key can be found. On
+    /// cache miss this also triggers background PK discovery as a side effect.
     pub fn try_affinity_plan(&self, input: &Input) -> Option<QueryPlan> {
         if !self.config.is_enabled() {
             return None;
@@ -256,15 +257,43 @@ impl AffinityQueryPlanInterceptor {
             return None;
         }
 
-        for candidate in op.partition_key_candidates() {
+        let is_batch_write = matches!(&op, classifier::DynamoOp::BatchWrite(_));
+        let candidates = op.partition_key_candidates();
+
+        if !is_batch_write {
+            for candidate in candidates {
+                let pk_name = match self.resolver.get_partition_key(candidate.table_name) {
+                    Some(cached_name) => cached_name,
+                    None => {
+                        // CACHE MISS: Trigger background discovery.
+                        self.resolver.trigger_discovery(candidate.table_name);
+                        continue;
+                    }
+                };
+
+                let Some(pk_value) = candidate.attributes.get(pk_name.as_ref()) else {
+                    continue;
+                };
+                let Some(hash) = hasher::hash_attribute_value(pk_value) else {
+                    continue;
+                };
+
+                return Some(QueryPlan::new_with_hash(self.live_nodes.clone(), hash));
+            }
+
+            return None;
+        }
+
+        let affinity_nodes = QueryPlan::sorted_affinity_nodes(&self.live_nodes);
+        let mut votes: HashMap<Arc<Url>, usize> = HashMap::new();
+
+        for candidate in candidates {
             let pk_name = match self.resolver.get_partition_key(candidate.table_name) {
                 Some(cached_name) => cached_name,
                 None => {
                     // CACHE MISS: Trigger background discovery.
                     self.resolver.trigger_discovery(candidate.table_name);
-
-                    // Use round-robin for this request.
-                    return None;
+                    continue;
                 }
             };
 
@@ -275,10 +304,15 @@ impl AffinityQueryPlanInterceptor {
                 continue;
             };
 
-            return Some(QueryPlan::new_with_hash(self.live_nodes.clone(), hash));
+            let preferred_node = affinity_nodes.preferred_node_for_hash(hash)?;
+            *votes.entry(preferred_node).or_insert(0) += 1;
         }
 
-        None
+        let preferred_nodes = vote_preference_order(votes)?;
+        Some(QueryPlan::new_with_preferred_nodes(
+            self.live_nodes.clone(),
+            preferred_nodes,
+        ))
     }
 
     /// Builds the [`QueryPlan`] for this request. Falls back to round-robin
@@ -287,6 +321,21 @@ impl AffinityQueryPlanInterceptor {
         self.try_affinity_plan(input)
             .unwrap_or_else(|| QueryPlan::new_basic(self.live_nodes.clone()))
     }
+}
+
+fn vote_preference_order(votes: HashMap<Arc<Url>, usize>) -> Option<Vec<Arc<Url>>> {
+    let mut voted_nodes: Vec<_> = votes.into_iter().collect();
+    if voted_nodes.is_empty() {
+        return None;
+    }
+
+    voted_nodes.sort_unstable_by(|(left_node, left_count), (right_node, right_count)| {
+        right_count
+            .cmp(left_count)
+            .then_with(|| left_node.as_str().cmp(right_node.as_str()))
+    });
+
+    Some(voted_nodes.into_iter().map(|(node, _)| node).collect())
 }
 
 impl Intercept for AffinityQueryPlanInterceptor {
@@ -305,5 +354,419 @@ impl Intercept for AffinityQueryPlanInterceptor {
 
         cfg.interceptor_state().store_put(query_plan);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keyrouting::KeyRouteAffinityType;
+    use aws_sdk_dynamodb::config::{BehaviorVersion, Region};
+    use aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemInput;
+    use aws_sdk_dynamodb::types::{AttributeValue, DeleteRequest, PutRequest, WriteRequest};
+    use std::collections::HashMap;
+
+    fn s(value: &str) -> AttributeValue {
+        AttributeValue::S(value.to_string())
+    }
+
+    fn make_client() -> aws_sdk_dynamodb::Client {
+        let config = aws_sdk_dynamodb::Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new("us-east-1"))
+            .endpoint_url("http://127.0.0.1:1")
+            .build();
+        aws_sdk_dynamodb::Client::from_conf(config)
+    }
+
+    fn make_live_nodes() -> Arc<LiveNodes> {
+        let seed_hosts: Vec<_> = (1..=10)
+            .rev()
+            .map(|i| format!("node{i}.example.com"))
+            .collect();
+        let config = AlternatorConfig::builder()
+            .scheme("http")
+            .port(8000)
+            .seed_hosts(seed_hosts)
+            .build();
+
+        LiveNodes::new(&config).expect("live nodes")
+    }
+
+    fn make_interceptor(
+        pk_info: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> (AffinityQueryPlanInterceptor, Arc<LiveNodes>) {
+        let mut config_builder =
+            KeyRouteAffinityConfig::builder().with_type(KeyRouteAffinityType::AnyWrite);
+        for (table, pk) in pk_info {
+            config_builder = config_builder.with_pk_info(table, pk);
+        }
+        let config = config_builder.build();
+        let live_nodes = make_live_nodes();
+        let resolver = Arc::new(resolver::PartitionKeyResolver::new(
+            make_client(),
+            config.pk_info_per_table.clone(),
+        ));
+        let interceptor = AffinityQueryPlanInterceptor::new(config, live_nodes.clone(), resolver);
+
+        (interceptor, live_nodes)
+    }
+
+    fn put_write(pk_name: &str, pk_value: AttributeValue, payload: &str) -> WriteRequest {
+        let put = PutRequest::builder()
+            .item(pk_name, pk_value)
+            .item("payload", s(payload))
+            .build()
+            .unwrap();
+        WriteRequest::builder().put_request(put).build()
+    }
+
+    fn delete_write(pk_name: &str, pk_value: AttributeValue) -> WriteRequest {
+        let delete = DeleteRequest::builder()
+            .key(pk_name, pk_value)
+            .build()
+            .unwrap();
+        WriteRequest::builder().delete_request(delete).build()
+    }
+
+    fn batch_input(table_name: &str, writes: Vec<WriteRequest>) -> Input {
+        let input = BatchWriteItemInput::builder()
+            .request_items(table_name, writes)
+            .build()
+            .unwrap();
+        Input::erase(input)
+    }
+
+    fn multi_table_batch_input(
+        first_table: &str,
+        first_writes: Vec<WriteRequest>,
+        second_table: &str,
+        second_writes: Vec<WriteRequest>,
+    ) -> Input {
+        let input = BatchWriteItemInput::builder()
+            .request_items(first_table, first_writes)
+            .request_items(second_table, second_writes)
+            .build()
+            .unwrap();
+        Input::erase(input)
+    }
+
+    fn short_name(url: &Url) -> String {
+        let host = url.host_str().expect("url has host");
+        host.strip_suffix(".example.com")
+            .unwrap_or(host)
+            .to_string()
+    }
+
+    fn first_node(plan: QueryPlan) -> String {
+        short_name(&plan.next_node().expect("plan has first node"))
+    }
+
+    fn node_sequence(plan: &QueryPlan, count: usize) -> Vec<String> {
+        let mut out = Vec::with_capacity(count);
+        for _ in 0..count {
+            let Some(node) = plan.next_node() else {
+                break;
+            };
+            out.push(short_name(&node));
+        }
+        out
+    }
+
+    fn sorted_live_node_names(live_nodes: &Arc<LiveNodes>) -> Vec<String> {
+        let mut nodes = live_nodes.get_live_nodes();
+        nodes.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        nodes.iter().map(|node| short_name(node)).collect()
+    }
+
+    fn expected_preferred_order(
+        live_nodes: &Arc<LiveNodes>,
+        voted_nodes: impl IntoIterator<Item = String>,
+    ) -> Vec<String> {
+        let mut expected: Vec<_> = voted_nodes.into_iter().collect();
+        for node in sorted_live_node_names(live_nodes) {
+            if !expected.contains(&node) {
+                expected.push(node);
+            }
+        }
+        expected
+    }
+
+    fn preferred_node_for_key(live_nodes: &Arc<LiveNodes>, key: &str) -> String {
+        let nodes = QueryPlan::sorted_affinity_nodes(live_nodes);
+        let hash = hasher::hash_attribute_value(&s(key)).expect("string key is supported");
+        let node = nodes
+            .preferred_node_for_hash(hash)
+            .expect("nodes are present");
+        short_name(&node)
+    }
+
+    fn find_two_keys_on_one_node_and_one_on_another(
+        live_nodes: &Arc<LiveNodes>,
+    ) -> (String, String, String, String) {
+        let mut buckets: HashMap<String, Vec<String>> = HashMap::new();
+
+        for i in 0..1000 {
+            let key = format!("key-{i}");
+            let node = preferred_node_for_key(live_nodes, &key);
+            buckets.entry(node).or_default().push(key);
+        }
+
+        let (majority_node, majority_keys) = buckets
+            .iter()
+            .find(|(_, keys)| keys.len() >= 2)
+            .expect("test key space should contain two keys for one node");
+        let other_key = buckets
+            .iter()
+            .find(|(node, keys)| *node != majority_node && !keys.is_empty())
+            .map(|(_, keys)| keys[0].clone())
+            .expect("test key space should contain another node");
+
+        (
+            majority_keys[0].clone(),
+            majority_keys[1].clone(),
+            other_key,
+            majority_node.clone(),
+        )
+    }
+
+    #[test]
+    fn batch_write_majority_preferred_node_wins() {
+        let (interceptor, live_nodes) = make_interceptor([("orders", "pk")]);
+        let (majority_key_1, majority_key_2, other_key, expected_node) =
+            find_two_keys_on_one_node_and_one_on_another(&live_nodes);
+        let input = batch_input(
+            "orders",
+            vec![
+                put_write("pk", s(&majority_key_1), "a"),
+                put_write("pk", s(&other_key), "b"),
+                put_write("pk", s(&majority_key_2), "c"),
+            ],
+        );
+
+        let plan = interceptor
+            .try_affinity_plan(&input)
+            .expect("majority should select an affinity plan");
+
+        assert_eq!(first_node(plan), expected_node);
+    }
+
+    #[test]
+    fn batch_write_majority_votes_drive_full_retry_order() {
+        let (interceptor, live_nodes) = make_interceptor([("orders", "pk")]);
+        let (majority_key_1, majority_key_2, other_key, majority_node) =
+            find_two_keys_on_one_node_and_one_on_another(&live_nodes);
+        let other_node = preferred_node_for_key(&live_nodes, &other_key);
+        let input = batch_input(
+            "orders",
+            vec![
+                put_write("pk", s(&majority_key_1), "a"),
+                put_write("pk", s(&other_key), "b"),
+                put_write("pk", s(&majority_key_2), "c"),
+            ],
+        );
+
+        let plan = interceptor
+            .try_affinity_plan(&input)
+            .expect("usable votes should select an affinity plan");
+
+        let expected = expected_preferred_order(&live_nodes, [majority_node, other_node]);
+        assert_eq!(node_sequence(&plan, expected.len()), expected);
+    }
+
+    #[test]
+    fn batch_write_equal_top_votes_use_deterministic_tie_break() {
+        let (interceptor, live_nodes) = make_interceptor([("orders", "pk")]);
+        let (majority_key, _, other_key, _) =
+            find_two_keys_on_one_node_and_one_on_another(&live_nodes);
+        let mut tied_nodes = vec![
+            preferred_node_for_key(&live_nodes, &majority_key),
+            preferred_node_for_key(&live_nodes, &other_key),
+        ];
+        tied_nodes.sort_unstable();
+        let input = batch_input(
+            "orders",
+            vec![
+                put_write("pk", s(&majority_key), "a"),
+                put_write("pk", s(&other_key), "b"),
+            ],
+        );
+
+        let plan = interceptor
+            .try_affinity_plan(&input)
+            .expect("tied usable votes should still select an affinity plan");
+
+        let expected = expected_preferred_order(&live_nodes, tied_nodes);
+        assert_eq!(node_sequence(&plan, expected.len()), expected);
+    }
+
+    #[test]
+    fn batch_write_delete_majority_preferred_node_wins() {
+        let (interceptor, live_nodes) = make_interceptor([("orders", "pk")]);
+        let (majority_key_1, majority_key_2, other_key, expected_node) =
+            find_two_keys_on_one_node_and_one_on_another(&live_nodes);
+        let input = batch_input(
+            "orders",
+            vec![
+                delete_write("pk", s(&majority_key_1)),
+                delete_write("pk", s(&other_key)),
+                delete_write("pk", s(&majority_key_2)),
+            ],
+        );
+
+        let plan = interceptor
+            .try_affinity_plan(&input)
+            .expect("delete majority should select an affinity plan");
+
+        assert_eq!(first_node(plan), expected_node);
+    }
+
+    #[test]
+    fn batch_write_mixed_put_and_delete_votes_select_majority() {
+        let (interceptor, live_nodes) = make_interceptor([("orders", "pk")]);
+        let (majority_key_1, majority_key_2, other_key, expected_node) =
+            find_two_keys_on_one_node_and_one_on_another(&live_nodes);
+        let input = batch_input(
+            "orders",
+            vec![
+                put_write("pk", s(&majority_key_1), "a"),
+                delete_write("pk", s(&other_key)),
+                delete_write("pk", s(&majority_key_2)),
+            ],
+        );
+
+        let plan = interceptor
+            .try_affinity_plan(&input)
+            .expect("mixed majority should select an affinity plan");
+
+        assert_eq!(first_node(plan), expected_node);
+    }
+
+    #[test]
+    fn batch_write_voting_is_invariant_to_write_request_order() {
+        let (interceptor, live_nodes) = make_interceptor([("orders", "pk")]);
+        let (majority_key_1, majority_key_2, other_key, expected_node) =
+            find_two_keys_on_one_node_and_one_on_another(&live_nodes);
+        let first = batch_input(
+            "orders",
+            vec![
+                put_write("pk", s(&majority_key_1), "a"),
+                delete_write("pk", s(&other_key)),
+                put_write("pk", s(&majority_key_2), "c"),
+            ],
+        );
+        let second = batch_input(
+            "orders",
+            vec![
+                put_write("pk", s(&majority_key_2), "c"),
+                put_write("pk", s(&majority_key_1), "a"),
+                delete_write("pk", s(&other_key)),
+            ],
+        );
+
+        let first_plan = interceptor.try_affinity_plan(&first).unwrap();
+        let second_plan = interceptor.try_affinity_plan(&second).unwrap();
+
+        assert_eq!(first_node(first_plan), expected_node);
+        assert_eq!(first_node(second_plan), expected_node);
+    }
+
+    #[test]
+    fn batch_write_voting_is_invariant_to_table_insertion_order() {
+        let (interceptor, live_nodes) = make_interceptor([("a_orders", "pk"), ("z_orders", "pk")]);
+        let (majority_key_1, majority_key_2, other_key, expected_node) =
+            find_two_keys_on_one_node_and_one_on_another(&live_nodes);
+        let first = multi_table_batch_input(
+            "a_orders",
+            vec![put_write("pk", s(&majority_key_1), "a")],
+            "z_orders",
+            vec![
+                delete_write("pk", s(&other_key)),
+                put_write("pk", s(&majority_key_2), "c"),
+            ],
+        );
+        let second = multi_table_batch_input(
+            "z_orders",
+            vec![
+                put_write("pk", s(&majority_key_2), "c"),
+                delete_write("pk", s(&other_key)),
+            ],
+            "a_orders",
+            vec![put_write("pk", s(&majority_key_1), "a")],
+        );
+
+        let first_plan = interceptor.try_affinity_plan(&first).unwrap();
+        let second_plan = interceptor.try_affinity_plan(&second).unwrap();
+
+        assert_eq!(first_node(first_plan), expected_node);
+        assert_eq!(first_node(second_plan), expected_node);
+    }
+
+    #[test]
+    fn batch_write_non_key_attributes_do_not_change_selected_node() {
+        let (interceptor, live_nodes) = make_interceptor([("orders", "pk")]);
+        let (majority_key_1, majority_key_2, other_key, expected_node) =
+            find_two_keys_on_one_node_and_one_on_another(&live_nodes);
+        let first = batch_input(
+            "orders",
+            vec![
+                put_write("pk", s(&majority_key_1), "payload-a"),
+                put_write("pk", s(&other_key), "payload-b"),
+                put_write("pk", s(&majority_key_2), "payload-c"),
+            ],
+        );
+        let second = batch_input(
+            "orders",
+            vec![
+                put_write("pk", s(&majority_key_1), "zzz"),
+                put_write("pk", s(&other_key), "aaa"),
+                put_write("pk", s(&majority_key_2), "mmm"),
+            ],
+        );
+
+        let first_plan = interceptor.try_affinity_plan(&first).unwrap();
+        let second_plan = interceptor.try_affinity_plan(&second).unwrap();
+
+        assert_eq!(first_node(first_plan), expected_node);
+        assert_eq!(first_node(second_plan), expected_node);
+    }
+
+    #[test]
+    fn batch_write_unknown_table_metadata_does_not_block_known_candidate() {
+        let (interceptor, live_nodes) = make_interceptor([("z_known", "pk")]);
+        let known_key = "known-key";
+        let expected_node = preferred_node_for_key(&live_nodes, known_key);
+        let input = multi_table_batch_input(
+            "a_unknown",
+            vec![put_write("pk", s("unknown-key"), "a")],
+            "z_known",
+            vec![put_write("pk", s(known_key), "b")],
+        );
+
+        let plan = interceptor
+            .try_affinity_plan(&input)
+            .expect("known candidate should still be usable");
+
+        assert_eq!(first_node(plan), expected_node);
+    }
+
+    #[test]
+    fn batch_write_unsupported_partition_key_type_is_skipped() {
+        let (interceptor, live_nodes) = make_interceptor([("orders", "pk")]);
+        let supported_key = "supported-key";
+        let expected_node = preferred_node_for_key(&live_nodes, supported_key);
+        let input = batch_input(
+            "orders",
+            vec![
+                put_write("pk", AttributeValue::Bool(true), "unsupported"),
+                put_write("pk", s(supported_key), "supported"),
+            ],
+        );
+
+        let plan = interceptor
+            .try_affinity_plan(&input)
+            .expect("supported candidate should still be usable");
+
+        assert_eq!(first_node(plan), expected_node);
     }
 }

--- a/src/keyrouting/affinity_config.rs
+++ b/src/keyrouting/affinity_config.rs
@@ -22,8 +22,9 @@ pub enum KeyRouteAffinityType {
     Rmw,
     /// Route write operations (`PutItem`, `UpdateItem`, `DeleteItem`, and
     /// `BatchWriteItem`) to the same coordinator per partition key,
-    /// regardless of conditions. For `BatchWriteItem`, the first usable
-    /// partition key in the batch is used.
+    /// regardless of conditions. For `BatchWriteItem`, usable partition keys
+    /// vote for preferred coordinators. Voted coordinators are tried first by
+    /// descending vote count, with deterministic node-order tie breaking.
     AnyWrite,
 }
 

--- a/src/keyrouting/classifier.rs
+++ b/src/keyrouting/classifier.rs
@@ -56,10 +56,10 @@ impl<'a> DynamoOp<'a> {
         }
     }
 
-    /// Returns ordered candidate table/key maps that can provide a partition
-    /// key. Single-item operations return at most one candidate; BatchWriteItem
-    /// can return multiple candidates so the caller can use the first one with
-    /// cached metadata and a supported partition-key value.
+    /// Returns candidate table/key maps that can provide a partition key.
+    /// Single-item operations return at most one candidate; BatchWriteItem can
+    /// return multiple candidates so the caller can apply batch-level routing
+    /// policy across all usable keys.
     pub fn partition_key_candidates(&self) -> Vec<PartitionKeyCandidate<'a>> {
         match self {
             Self::Put(r) => r
@@ -92,35 +92,31 @@ impl<'a> DynamoOp<'a> {
                     }]
                 })
                 .unwrap_or_default(),
-            Self::BatchWrite(r) => {
-                let mut items: Vec<_> = r
-                    .request_items()
-                    .into_iter()
-                    .flat_map(|items| items.iter())
-                    .collect();
-                items.sort_unstable_by(|(left_table, _), (right_table, _)| {
-                    left_table.cmp(right_table)
-                });
-
-                items
-                    .into_iter()
-                    .flat_map(|(table_name, writes)| {
-                        writes.iter().filter_map(|write| {
-                            let attributes = write
-                                .delete_request()
-                                .map(|delete| delete.key())
-                                .or_else(|| write.put_request().map(|put| put.item()))?;
-
-                            Some(PartitionKeyCandidate {
-                                table_name,
-                                attributes,
-                            })
+            Self::BatchWrite(r) => r
+                .request_items()
+                .into_iter()
+                .flat_map(|items| items.iter())
+                .flat_map(|(table_name, writes)| {
+                    writes.iter().filter_map(|write| {
+                        let attributes = batch_write_request_attributes(write)?;
+                        Some(PartitionKeyCandidate {
+                            table_name: table_name.as_str(),
+                            attributes,
                         })
                     })
-                    .collect()
-            }
+                })
+                .collect(),
         }
     }
+}
+
+fn batch_write_request_attributes(
+    write: &aws_sdk_dynamodb::types::WriteRequest,
+) -> Option<&HashMap<String, AttributeValue>> {
+    if let Some(delete) = write.delete_request() {
+        return Some(delete.key());
+    }
+    write.put_request().map(|put| put.item())
 }
 
 /// Checks if a `PutItem` operation qualifies for Key Route Affinity based on the configured mode.
@@ -533,7 +529,7 @@ mod tests {
     }
 
     #[test]
-    fn batch_write_partition_key_candidates_preserve_write_order_within_table() {
+    fn batch_write_partition_key_candidates_include_requests_without_pk() {
         let r = BatchWriteItemInput::builder()
             .request_items(
                 "t",
@@ -549,16 +545,30 @@ mod tests {
         let candidates = DynamoOp::BatchWrite(&r).partition_key_candidates();
 
         assert_eq!(candidates.len(), 3);
-        assert_eq!(candidates[0].table_name, "t");
-        assert!(!candidates[0].attributes.contains_key("pk"));
-        assert_eq!(candidates[1].table_name, "t");
-        assert_eq!(candidates[1].attributes.get("pk"), Some(&s("delete_key")));
-        assert_eq!(candidates[2].table_name, "t");
-        assert_eq!(candidates[2].attributes.get("pk"), Some(&s("put_key")));
+        assert!(
+            candidates
+                .iter()
+                .all(|candidate| candidate.table_name == "t")
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| !candidate.attributes.contains_key("pk"))
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| candidate.attributes.get("pk") == Some(&s("delete_key")))
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|candidate| candidate.attributes.get("pk") == Some(&s("put_key")))
+        );
     }
 
     #[test]
-    fn batch_write_partition_key_candidates_are_sorted_by_table_name() {
+    fn batch_write_partition_key_candidates_include_multiple_tables() {
         for z_table_first in [true, false] {
             let builder = BatchWriteItemInput::builder();
             let builder = if z_table_first {
@@ -575,10 +585,14 @@ mod tests {
             let candidates = DynamoOp::BatchWrite(&r).partition_key_candidates();
 
             assert_eq!(candidates.len(), 2);
-            assert_eq!(candidates[0].table_name, "a_table");
-            assert_eq!(candidates[0].attributes.get("pk"), Some(&s("a_key")));
-            assert_eq!(candidates[1].table_name, "z_table");
-            assert_eq!(candidates[1].attributes.get("pk"), Some(&s("z_key")));
+            assert!(candidates.iter().any(|candidate| {
+                candidate.table_name == "a_table"
+                    && candidate.attributes.get("pk") == Some(&s("a_key"))
+            }));
+            assert!(candidates.iter().any(|candidate| {
+                candidate.table_name == "z_table"
+                    && candidate.attributes.get("pk") == Some(&s("z_key"))
+            }));
         }
     }
 
@@ -594,6 +608,29 @@ mod tests {
                 .partition_key_candidates()
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn batch_write_partition_key_candidates_use_put_items_and_delete_keys() {
+        let r = BatchWriteItemInput::builder()
+            .request_items(
+                "orders",
+                vec![put_write("pk", "put_key"), delete_write("pk", "delete_key")],
+            )
+            .build()
+            .unwrap();
+
+        let candidates = DynamoOp::BatchWrite(&r).partition_key_candidates();
+
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates.iter().any(|candidate| {
+            candidate.attributes.get("pk") == Some(&s("put_key"))
+                && candidate.attributes.get("other") == Some(&s("x"))
+        }));
+        assert!(candidates.iter().any(|candidate| {
+            candidate.attributes.get("pk") == Some(&s("delete_key"))
+                && !candidate.attributes.contains_key("other")
+        }));
     }
 
     #[test]

--- a/src/live_nodes.rs
+++ b/src/live_nodes.rs
@@ -119,7 +119,7 @@ impl LiveNodes {
         let port = config.port();
         let seed_nodes = config.seed_hosts().unwrap_or_default();
 
-        let seed_urls = seed_nodes
+        let mut seed_urls = seed_nodes
             .iter()
             .filter_map(|addr| {
                 let mut url = Url::parse(&format!("{}://{}", alternator_scheme, addr)).ok()?;
@@ -127,6 +127,7 @@ impl LiveNodes {
                 Some(Arc::new(url))
             })
             .collect::<Vec<_>>();
+        seed_urls.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
         if seed_urls.is_empty() {
             return None;
         }

--- a/src/query_plan.rs
+++ b/src/query_plan.rs
@@ -6,7 +6,7 @@
 use crate::keyrouting::go_rand::GoRand;
 use crate::live_nodes::LiveNodes;
 use aws_smithy_types::config_bag::{Storable, StoreReplace};
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 use url::Url;
 
@@ -14,6 +14,11 @@ use url::Url;
 pub(crate) struct QueryPlan {
     live_nodes: Arc<LiveNodes>,
     state: Mutex<QueryPlanState>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SortedAffinityNodes {
+    nodes: Vec<Arc<Url>>,
 }
 
 #[derive(Debug)]
@@ -25,6 +30,11 @@ enum QueryPlanState {
         // Boxed to prevent "large size difference between variants" warning
         go_rand: Box<GoRand>,
         remaining_nodes: Option<Vec<Arc<Url>>>,
+    },
+    /// Deterministic order with selected nodes before the rest.
+    PreferredNodes {
+        preferred_nodes: Vec<Arc<Url>>,
+        remaining_nodes: Option<VecDeque<Arc<Url>>>,
     },
 }
 
@@ -54,6 +64,27 @@ impl QueryPlan {
         }
     }
 
+    /// Creates a query plan that tries `preferred_nodes` first, then the
+    /// remaining live nodes in sorted order.
+    pub(crate) fn new_with_preferred_nodes(
+        live_nodes: Arc<LiveNodes>,
+        preferred_nodes: Vec<Arc<Url>>,
+    ) -> Self {
+        Self {
+            live_nodes,
+            state: Mutex::new(QueryPlanState::PreferredNodes {
+                preferred_nodes,
+                remaining_nodes: None,
+            }),
+        }
+    }
+
+    /// Returns the current live-node list in the canonical order used by
+    /// affinity routing.
+    pub(crate) fn sorted_affinity_nodes(live_nodes: &Arc<LiveNodes>) -> SortedAffinityNodes {
+        SortedAffinityNodes::from_live_nodes(live_nodes)
+    }
+
     /// Gets the next node to use in this query plan, or `None` if the plan is exhausted.
     ///
     /// With round-robin, on every attempt, the first node that hasn't been used yet in this request is returned.
@@ -73,8 +104,11 @@ impl QueryPlan {
                 go_rand,
                 remaining_nodes,
             } => {
-                let remaining =
-                    remaining_nodes.get_or_insert_with(|| self.live_nodes.get_live_nodes());
+                let remaining = remaining_nodes.get_or_insert_with(|| {
+                    let mut nodes = self.live_nodes.get_live_nodes();
+                    sort_node_urls(&mut nodes);
+                    nodes
+                });
 
                 if remaining.is_empty() {
                     return None;
@@ -90,8 +124,52 @@ impl QueryPlan {
 
                 Some(selected_node)
             }
+            QueryPlanState::PreferredNodes {
+                preferred_nodes,
+                remaining_nodes,
+            } => {
+                let remaining = remaining_nodes.get_or_insert_with(|| {
+                    let mut nodes = self.live_nodes.get_live_nodes();
+                    sort_node_urls(&mut nodes);
+
+                    let mut ordered = VecDeque::with_capacity(nodes.len());
+                    for preferred_node in preferred_nodes.iter() {
+                        if let Some(index) = nodes.iter().position(|node| node == preferred_node) {
+                            ordered.push_back(nodes.remove(index));
+                        }
+                    }
+                    ordered.extend(nodes);
+                    ordered
+                });
+
+                remaining.pop_front()
+            }
         }
     }
+}
+
+impl SortedAffinityNodes {
+    fn from_live_nodes(live_nodes: &Arc<LiveNodes>) -> Self {
+        let mut nodes = live_nodes.get_live_nodes();
+        sort_node_urls(&mut nodes);
+        Self { nodes }
+    }
+
+    /// Returns the first node the seeded affinity plan would select without
+    /// consuming a full query plan.
+    pub(crate) fn preferred_node_for_hash(&self, seed: u64) -> Option<Arc<Url>> {
+        if self.nodes.is_empty() {
+            return None;
+        }
+
+        let mut go_rand = GoRand::new(seed as i64);
+        let idx = go_rand.intn(self.nodes.len() as i32) as usize;
+        Some(self.nodes[idx].clone())
+    }
+}
+
+fn sort_node_urls(nodes: &mut [Arc<Url>]) {
+    nodes.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
 }
 
 #[cfg(test)]
@@ -121,8 +199,11 @@ mod tests {
             count,
             "LiveNodes lost or duplicated seed entries"
         );
-        for (i, url) in urls.iter().enumerate() {
-            let expected_host = format!("node{}.example.com", i + 1);
+        let mut expected_hosts = (1..=count)
+            .map(|i| format!("node{i}.example.com"))
+            .collect::<Vec<_>>();
+        expected_hosts.sort_unstable();
+        for (url, expected_host) in urls.iter().zip(expected_hosts) {
             assert_eq!(url.host_str(), Some(expected_host.as_str()));
         }
 
@@ -151,14 +232,14 @@ mod tests {
 
     // ----- Cross-language test vectors -----
     //
-    // These tests are mirrored version of the ones in Java implementation.
+    // These vectors use the canonical lexicographic live-node order.
 
     #[test]
     fn cross_lang_seed_42_10_nodes() {
         let plan = QueryPlan::new_with_hash(make_live_nodes(10), 42);
         assert_eq!(
             sequence(&plan, 6),
-            vec!["node6", "node9", "node5", "node2", "node7", "node1"],
+            vec!["node5", "node8", "node4", "node10", "node6", "node1"],
         );
     }
 
@@ -167,7 +248,7 @@ mod tests {
         let plan = QueryPlan::new_with_hash(make_live_nodes(10), 123);
         assert_eq!(
             sequence(&plan, 6),
-            vec!["node6", "node1", "node4", "node3", "node10", "node5"],
+            vec!["node5", "node1", "node3", "node2", "node9", "node4"],
         );
     }
 
@@ -176,7 +257,7 @@ mod tests {
         let plan = QueryPlan::new_with_hash(make_live_nodes(10), 999);
         assert_eq!(
             sequence(&plan, 6),
-            vec!["node5", "node10", "node4", "node1", "node2", "node3"],
+            vec!["node4", "node9", "node3", "node1", "node10", "node2"],
         );
     }
 
@@ -185,7 +266,7 @@ mod tests {
         let plan = QueryPlan::new_with_hash(make_live_nodes(10), 0);
         assert_eq!(
             sequence(&plan, 6),
-            vec!["node5", "node1", "node2", "node10", "node6", "node8"],
+            vec!["node4", "node1", "node10", "node9", "node5", "node7"],
         );
     }
 
@@ -196,7 +277,7 @@ mod tests {
         let plan = QueryPlan::new_with_hash(make_live_nodes(10), u64::MAX);
         assert_eq!(
             sequence(&plan, 6),
-            vec!["node2", "node5", "node1", "node3", "node6", "node10"],
+            vec!["node10", "node4", "node1", "node2", "node5", "node9"],
         );
     }
 
@@ -214,7 +295,7 @@ mod tests {
         let plan = QueryPlan::new_with_hash(make_live_nodes(10), 12345);
         assert_eq!(
             sequence(&plan, 6),
-            vec!["node4", "node5", "node1", "node7", "node6", "node8"],
+            vec!["node3", "node4", "node1", "node6", "node5", "node7"],
         );
     }
 
@@ -224,7 +305,28 @@ mod tests {
         let plan = QueryPlan::new_with_hash(make_live_nodes(10), i64::MAX as u64);
         assert_eq!(
             sequence(&plan, 6),
-            vec!["node2", "node7", "node8", "node1", "node10", "node4"],
+            vec!["node10", "node6", "node7", "node1", "node9", "node3"],
+        );
+    }
+
+    #[test]
+    fn preferred_nodes_plan_uses_selected_nodes_first_then_sorted_remaining() {
+        let live_nodes = make_live_nodes(5);
+        let preferred_3 = live_nodes
+            .get_live_nodes()
+            .into_iter()
+            .find(|node| node.host_str() == Some("node3.example.com"))
+            .expect("preferred node exists");
+        let preferred_5 = live_nodes
+            .get_live_nodes()
+            .into_iter()
+            .find(|node| node.host_str() == Some("node5.example.com"))
+            .expect("preferred node exists");
+        let plan = QueryPlan::new_with_preferred_nodes(live_nodes, vec![preferred_3, preferred_5]);
+
+        assert_eq!(
+            sequence(&plan, 5),
+            vec!["node3", "node5", "node1", "node2", "node4"],
         );
     }
 

--- a/tests/load_balancing/load_balancing_tests.rs
+++ b/tests/load_balancing/load_balancing_tests.rs
@@ -417,10 +417,42 @@ fn create_client_with_scope_and_affinity(
 fn expected_first_node<'a>(nodes: &'a [&str], partition_key_value: &str) -> &'a str {
     let pk = AttributeValue::S(partition_key_value.to_string());
     let hash = hasher::hash_attribute_value(&pk).unwrap();
+    let mut nodes = nodes.to_vec();
+    nodes.sort_unstable();
 
     let mut rng = GoRand::new(hash as i64);
     let idx = rng.intn(nodes.len() as i32) as usize;
     nodes[idx]
+}
+
+fn find_two_keys_on_one_node_and_one_on_another(
+    nodes: &[&str],
+    key_prefix: &str,
+) -> (String, String, String, String) {
+    let mut buckets: HashMap<String, Vec<String>> = HashMap::new();
+
+    for i in 0..1000 {
+        let key = format!("{key_prefix}_{i}");
+        let node = expected_first_node(nodes, &key).to_string();
+        buckets.entry(node).or_default().push(key);
+    }
+
+    let (majority_node, majority_keys) = buckets
+        .iter()
+        .find(|(_, keys)| keys.len() >= 2)
+        .expect("test key space should contain two keys for one node");
+    let other_key = buckets
+        .iter()
+        .find(|(node, keys)| *node != majority_node && !keys.is_empty())
+        .map(|(_, keys)| keys[0].clone())
+        .expect("test key space should contain another node");
+
+    (
+        majority_keys[0].clone(),
+        majority_keys[1].clone(),
+        other_key,
+        majority_node.clone(),
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1447,35 +1479,40 @@ async fn batch_write_affinity_multitable_routing_is_deterministic_test() {
     create_table(&client, &a_table_name).await;
     create_table(&client, &z_table_name).await;
 
-    let a_key = "batch_a_key";
-    let z_key = "batch_z_key";
-    let expected_ip = expected_first_node(node_ips.as_slice(), a_key);
+    let (a_key_1, a_key_2, z_key, expected_ip) =
+        find_two_keys_on_one_node_and_one_on_another(node_ips.as_slice(), "batch_multi_key");
 
     for z_table_first in [true, false] {
         request_counter.reset();
 
         for iteration in 0..node_ips.len() {
-            let a_put = PutRequest::builder()
-                .item("id", s(a_key))
-                .item("val", s(format!("a_value_{z_table_first}_{iteration}")))
+            let a_put_1 = PutRequest::builder()
+                .item("id", s(&a_key_1))
+                .item("val", s(format!("a_value_1_{z_table_first}_{iteration}")))
+                .build()
+                .unwrap();
+            let a_put_2 = PutRequest::builder()
+                .item("id", s(&a_key_2))
+                .item("val", s(format!("a_value_2_{z_table_first}_{iteration}")))
                 .build()
                 .unwrap();
             let z_put = PutRequest::builder()
-                .item("id", s(z_key))
+                .item("id", s(&z_key))
                 .item("val", s(format!("z_value_{z_table_first}_{iteration}")))
                 .build()
                 .unwrap();
-            let a_write = WriteRequest::builder().put_request(a_put).build();
+            let a_write_1 = WriteRequest::builder().put_request(a_put_1).build();
+            let a_write_2 = WriteRequest::builder().put_request(a_put_2).build();
             let z_write = WriteRequest::builder().put_request(z_put).build();
 
             let builder = client.batch_write_item();
             let builder = if z_table_first {
                 builder
                     .request_items(z_table_name.as_str(), vec![z_write])
-                    .request_items(a_table_name.as_str(), vec![a_write])
+                    .request_items(a_table_name.as_str(), vec![a_write_1, a_write_2])
             } else {
                 builder
-                    .request_items(a_table_name.as_str(), vec![a_write])
+                    .request_items(a_table_name.as_str(), vec![a_write_2, a_write_1])
                     .request_items(z_table_name.as_str(), vec![z_write])
             };
 
@@ -1486,7 +1523,7 @@ async fn batch_write_affinity_multitable_routing_is_deterministic_test() {
         assert_affinity_counts(
             &request_counter,
             node_ips.as_slice(),
-            expected_ip,
+            &expected_ip,
             node_ips.len(),
             &case_label,
         );


### PR DESCRIPTION
## Summary

Refs #60.

This implements cross-language `BatchWriteItem` key-affinity routing for the Rust client using the updated vote-ranked preferred-node algorithm.

`BatchWriteItem` no longer selects a candidate by sorting/canonicalizing the full write item. Instead, each usable write contributes its partition key to the routing decision. The client hashes each supported partition key, maps it to the preferred coordinator from a lexicographically sorted live-node list, and counts votes per preferred node.

The query plan now preserves the full voting signal: voted coordinators are tried first by vote count descending, equal vote counts are broken by canonical node URL, and zero-vote live nodes are appended in canonical order. If there are no usable candidates, the request falls back to the normal round-robin plan.

## Details

- Applies only to `BatchWriteItem` under `ANY_WRITE` affinity.
- Uses `PutRequest.Item` and `DeleteRequest.Key` as candidate attribute maps.
- Ignores non-key attributes when deciding coordinator votes.
- Skips candidates with missing partition-key attributes or unsupported partition-key types.
- On missing table metadata, triggers partition-key discovery and continues evaluating other candidates instead of immediately falling back.
- Uses deterministic vote ordering for ties instead of falling back to unrelated round-robin nodes.
- Normalizes seed-node ordering so affinity behaves the same before and after discovery.
- Keeps single-key write affinity on the existing hash-based path.

## Tests

- `cargo fmt --check`
- `cargo test --lib interceptors::tests::batch_write -- --nocapture`
- `cargo test --lib query_plan::tests::preferred_nodes_plan_uses_selected_nodes_first_then_sorted_remaining -- --nocapture`
- `cargo test --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test load_balancing_tests` (test target builds; tests are ignored by default)
- `cargo test --no-run`
