### PR TITLE
Default to no-auth when credentials are absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,12 +270,14 @@ let client = AlternatorClient::from_conf(
 
 ## Header stripping
 
-By default, the AWS Rust SDK attaches a number of headers to every DynamoDB request — some are required (`Host`, `Authorization`, `X-Amz-Date`, etc.), others are SDK metadata that Alternator doesn't use (`User-Agent` flavors, internal telemetry, retry information). For a small client-side optimization, this crate strips non-essential headers before transmission, keeping only the ones Alternator actually needs:
+By default, the AWS Rust SDK attaches a number of headers to every DynamoDB request — some are required for signed requests (`Host`, `Authorization`, `X-Amz-Date`, etc.), others are SDK metadata that Alternator doesn't use (`User-Agent` flavors, internal telemetry, retry information). For a small client-side optimization, this crate strips non-essential headers before transmission, keeping only the ones Alternator actually needs:
 - `host`
 - `x-amz-target`
 - `content-length`
 - `accept-encoding`
 - `content-encoding`
+
+For signed requests, it also keeps:
 - `authorization`
 - `x-amz-date`
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ tokio = { version = "1.18", features = ["macros", "rt-multi-thread", "sync", "ti
 ```
 > **Note**: This crate is not yet published to crates.io. Depend on it via the GitHub URL.
 
-Because the Alternator Client is designed with an interface identical to the AWS SDK for DynamoDB, developers can seamlessly swap out aws_sdk_dynamodb::Client in their projects, like so:
+Because the Alternator Client follows the AWS SDK for DynamoDB operation builder interface for Alternator-supported features, migration usually starts by replacing `aws_sdk_dynamodb::Client` and its config type, like so:
 
 ```rust
 use alternator_driver::*;              // <-- new import
@@ -65,7 +65,7 @@ async fn main() {
     // Build an AlternatorClient instead of an aws_sdk_dynamodb::Client.
     let client = AlternatorClient::from_conf(config); // <-- was aws_sdk_dynamodb::Client::from_conf
 
-    // From here on, the API is identical to the AWS SDK.
+    // From here on, use the AWS SDK operation builders for Alternator-supported operations.
     client
         .put_item()
         .table_name("ExampleTable")
@@ -77,7 +77,9 @@ async fn main() {
 }
 ```
 
-When no credentials provider is configured, `AlternatorClient` enables no-auth automatically. Clients with a credentials provider continue to sign requests through the AWS SDK. Alternator supports only SigV4 with static credentials or no-auth; custom AWS SDK auth schemes and auth scheme resolvers are rejected. Use `auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])` when a client without default credentials should require signed per-request credentials instead of falling back to no-auth.
+When no credentials provider is configured, `AlternatorClient` enables no-auth automatically. Clients with a credentials provider continue to sign requests through the AWS SDK. Alternator supports only SigV4 with static credentials or no-auth; custom AWS SDK auth schemes, auth scheme preferences, and auth scheme resolvers are rejected. Use `require_auth()` when a client without default credentials should require signed per-request credentials instead of falling back to no-auth.
+
+This client targets ScyllaDB Alternator. It does not guarantee that Alternator-specific configuration, no-auth defaults, or request optimizations remain compatible with AWS DynamoDB itself.
 
 ## Load balancing
 
@@ -366,6 +368,6 @@ client
     .unwrap();
 ```
 
-`alternator_config_override` is a direct extension of `config_override`, it also allows the developer to override all DynamoDB settings.
+`alternator_config_override` applies Alternator-specific per-operation settings. Use the AWS SDK's `config_override` separately for supported SDK-level per-operation overrides.
 
 > **Note**: load-balancing and endpoint settings cannot be overridden per-operation. They take effect only when the client is constructed. Per-operation override is for settings that apply to individual request processing — compression and header stripping.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ async fn main() {
     let config = AlternatorConfig::builder() // <-- was aws_sdk_dynamodb::Config::builder()
         .endpoint_url("http://localhost:8000")
         .behavior_version_latest()
-        .allow_no_auth()
         .build();
 
     // Build an AlternatorClient instead of an aws_sdk_dynamodb::Client.
@@ -78,6 +77,8 @@ async fn main() {
 }
 ```
 
+When no credentials provider is configured, `AlternatorClient` enables no-auth automatically. Clients with a credentials provider continue to sign requests through the AWS SDK.
+
 ## Load balancing
 
 A single Alternator cluster typically consists of multiple nodes, any of which can serve any request. This crate distributes requests across the live nodes of the cluster rather than sending everything to one address. There's no separate load-balancer process, routing happens entirely client-side.
@@ -92,7 +93,6 @@ use alternator_driver::AlternatorConfig;
 let config = AlternatorConfig::builder()
     .endpoint_url("http://10.0.0.1:8043")
     .behavior_version_latest()
-    .allow_no_auth()
     .build();
 ```
 
@@ -112,7 +112,6 @@ let config = AlternatorConfig::builder()
         "10.0.0.3",
     ])
     .behavior_version_latest()
-    .allow_no_auth()
     .build();
 ```
 
@@ -157,7 +156,6 @@ let config = AlternatorConfig::builder()
     .endpoint_url("http://10.0.0.1:8043")
     .routing_scope(scope)
     .behavior_version_latest()
-    .allow_no_auth()
     .build();
 ```
 
@@ -241,7 +239,6 @@ let client = AlternatorClient::from_conf(
         .endpoint_url("http://10.0.0.1:8043")
         .key_route_affinity(KeyRouteAffinityType::Rmw)
         .behavior_version_latest()
-        .allow_no_auth()
         .build(),
 );
 ```
@@ -264,7 +261,6 @@ let client = AlternatorClient::from_conf(
         .endpoint_url("http://10.0.0.1:8043")
         .key_route_affinity(affinity)
         .behavior_version_latest()
-        .allow_no_auth()
         .build(),
 );
 ```
@@ -293,7 +289,6 @@ let client = AlternatorClient::from_conf(
         .endpoint_url("http://10.0.0.1:8043")
         .optimize_headers(false)
         .behavior_version_latest()
-        .allow_no_auth()
         .build(),
 );
 ```
@@ -315,7 +310,6 @@ let client = AlternatorClient::from_conf(
             1024, // body-size threshold in bytes
         ))
         .behavior_version_latest()
-        .allow_no_auth()
         .build(),
 );
 ```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ async fn main() {
 }
 ```
 
-When no credentials provider is configured, `AlternatorClient` enables no-auth automatically. Clients with a credentials provider continue to sign requests through the AWS SDK.
+When no credentials provider is configured, `AlternatorClient` enables no-auth automatically. Clients with a credentials provider continue to sign requests through the AWS SDK. Alternator supports only SigV4 with static credentials or no-auth; custom AWS SDK auth schemes and auth scheme resolvers are rejected. Use `auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])` when a client without default credentials should require signed per-request credentials instead of falling back to no-auth.
 
 ## Load balancing
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,7 +41,7 @@ impl AlternatorClient {
 
         let mut builder = dynamodb_config.to_builder();
 
-        if !has_credentials_provider && !config.disable_implicit_no_auth() {
+        if !has_credentials_provider && !config.requires_auth() && !config.allows_no_auth() {
             builder = builder.allow_no_auth();
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -41,7 +41,7 @@ impl AlternatorClient {
 
         let mut builder = dynamodb_config.to_builder();
 
-        if !has_credentials_provider {
+        if !has_credentials_provider && !config.disable_implicit_no_auth() {
             builder = builder.allow_no_auth();
         }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,15 +36,20 @@ impl AlternatorClient {
             .unwrap_or(RequestCompression::disabled());
         let response_compression = extensions.response_compression.unwrap_or_default();
         let optimize_headers = extensions.optimize_headers.unwrap_or(true);
+        let has_credentials_provider = config.has_credentials_provider();
         let has_region = dynamodb_config.region().is_some();
 
-        let mut builder = dynamodb_config
-            .to_builder()
-            .interceptor(AlternatorInterceptor::new(
-                request_compression,
-                response_compression,
-                optimize_headers,
-            ));
+        let mut builder = dynamodb_config.to_builder();
+
+        if !has_credentials_provider {
+            builder = builder.allow_no_auth();
+        }
+
+        builder = builder.interceptor(AlternatorInterceptor::new(
+            request_compression,
+            response_compression,
+            optimize_headers,
+        ));
 
         // If live nodes are not in config - create new config with live nodes.
         let (config, live_nodes) = if let Some(nodes) = config.live_nodes() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -49,6 +49,7 @@ impl AlternatorClient {
             request_compression,
             response_compression,
             optimize_headers,
+            has_credentials_provider,
         ));
 
         // If live nodes are not in config - create new config with live nodes.

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,8 @@ pub(crate) struct AlternatorExtensions {
     pub(crate) response_compression: Option<ResponseCompression>,
     pub(crate) optimize_headers: Option<bool>,
     pub(crate) has_credentials_provider: bool,
-    pub(crate) disable_implicit_no_auth: bool,
+    pub(crate) require_auth: bool,
+    pub(crate) allow_no_auth: bool,
     pub(crate) active_interval: Option<std::time::Duration>,
     pub(crate) idle_interval: Option<std::time::Duration>,
     pub(crate) routing_scope: Option<RoutingScope>,
@@ -25,37 +26,16 @@ pub(crate) struct AlternatorExtensions {
     pub(crate) key_route_affinity: Option<keyrouting::affinity_config::KeyRouteAffinityConfig>,
 }
 
-const UNSUPPORTED_AUTH_API_MESSAGE: &str = "Alternator supports only SigV4 with static credentials or no-auth. Use credentials_provider(...), per-request config_override(...credentials_provider(...)), auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID]) for strict signed requests, or allow_no_auth(). Custom AWS SDK auth schemes and resolvers are not supported.";
+const UNSUPPORTED_AUTH_API_MESSAGE: &str = "Alternator supports only SigV4 with static credentials or no-auth. Use credentials_provider(...), per-request config_override(...credentials_provider(...)) with require_auth() for strict signed requests, or allow_no_auth() for unsigned requests. Custom AWS SDK auth schemes, auth scheme resolvers, and auth scheme preferences are not supported.";
+
+const INCOMPATIBLE_AUTH_OPTIONS_MESSAGE: &str = "require_auth() cannot be combined with allow_no_auth(): require_auth() makes missing credentials fail before sending an unsigned request, while allow_no_auth() explicitly permits unsigned requests.";
 
 fn unsupported_auth_api(api: &str) -> ! {
     panic!("{api} is not supported by alternator-driver: {UNSUPPORTED_AUTH_API_MESSAGE}");
 }
 
-fn is_supported_auth_scheme(
-    scheme_id: &aws_smithy_runtime_api::client::auth::AuthSchemeId,
-) -> bool {
-    scheme_id == &aws_runtime::auth::sigv4::SCHEME_ID
-        || scheme_id == &aws_smithy_runtime::client::auth::no_auth::NO_AUTH_SCHEME_ID
-}
-
-fn normalize_auth_scheme_preference(
-    preference: aws_smithy_runtime_api::client::auth::AuthSchemePreference,
-) -> (
-    Vec<aws_smithy_runtime_api::client::auth::AuthSchemeId>,
-    bool,
-) {
-    let preference: Vec<_> = preference.into_iter().collect();
-    if let Some(scheme_id) = preference.iter().find(|id| !is_supported_auth_scheme(id)) {
-        panic!(
-            "unsupported auth scheme preference {:?}: {UNSUPPORTED_AUTH_API_MESSAGE}",
-            scheme_id.inner()
-        );
-    }
-    let disable_implicit_no_auth = !preference.is_empty()
-        && !preference
-            .iter()
-            .any(|id| id == &aws_smithy_runtime::client::auth::no_auth::NO_AUTH_SCHEME_ID);
-    (preference, disable_implicit_no_auth)
+fn incompatible_auth_options() -> ! {
+    panic!("{INCOMPATIBLE_AUTH_OPTIONS_MESSAGE}");
 }
 
 /// [AlternatorClient]'s config
@@ -137,8 +117,16 @@ impl AlternatorConfig {
         self.alternator_ext.has_credentials_provider
     }
 
-    pub(crate) fn disable_implicit_no_auth(&self) -> bool {
-        self.alternator_ext.disable_implicit_no_auth
+    /// Returns whether this config requires every request to resolve credentials.
+    ///
+    /// When this is enabled, a client built from this config will not add the
+    /// driver's implicit no-auth fallback for missing default credentials.
+    pub fn requires_auth(&self) -> bool {
+        self.alternator_ext.require_auth
+    }
+
+    pub(crate) fn allows_no_auth(&self) -> bool {
+        self.alternator_ext.allow_no_auth
     }
 
     /// Gets the active interval for refreshing the list of known nodes when the client is active.
@@ -613,16 +601,13 @@ impl AlternatorBuilder {
 impl From<&aws_types::sdk_config::SdkConfig> for AlternatorBuilder {
     fn from(sdk_config: &aws_types::sdk_config::SdkConfig) -> Self {
         let has_credentials_provider = sdk_config.credentials_provider().is_some();
-        let disable_implicit_no_auth = sdk_config
-            .auth_scheme_preference()
-            .cloned()
-            .map(|preference| normalize_auth_scheme_preference(preference).1)
-            .unwrap_or(false);
+        if sdk_config.auth_scheme_preference().is_some() {
+            unsupported_auth_api("auth_scheme_preference");
+        }
         AlternatorBuilder {
             dynamodb_builder: aws_sdk_dynamodb::config::Builder::from(sdk_config),
             alternator_ext: AlternatorExtensions {
                 has_credentials_provider,
-                disable_implicit_no_auth,
                 ..Default::default()
             },
         }
@@ -658,12 +643,6 @@ impl AlternatorConfig {
         &self,
     ) -> Option<aws_smithy_runtime_api::client::auth::SharedAuthSchemeOptionResolver> {
         self.dynamodb_config.auth_scheme_resolver()
-    }
-
-    pub fn auth_scheme_preference(
-        &self,
-    ) -> Option<&aws_smithy_runtime_api::client::auth::AuthSchemePreference> {
-        self.dynamodb_config.auth_scheme_preference()
     }
 
     pub fn endpoint_resolver(
@@ -787,41 +766,58 @@ impl AlternatorBuilder {
         unsupported_auth_api("set_auth_scheme_resolver")
     }
 
+    /// Require every request made by a client built from this config to use credentials.
+    ///
+    /// By default, an Alternator client with no default credentials enables the AWS SDK's no-auth
+    /// mode automatically, because many Alternator deployments do not require signing. Use
+    /// `require_auth()` for clients that intentionally have no default credentials but must still
+    /// be signed by per-request credentials supplied with `customize().config_override(...)`.
+    ///
+    /// When this option is set and no credentials are available for an operation, the AWS SDK
+    /// fails auth resolution before the request is sent instead of falling back to an unsigned
+    /// request. This is a client construction option; it cannot remove no-auth from an already
+    /// constructed client as a per-operation override.
+    ///
+    /// Panics if combined with [`allow_no_auth`](Self::allow_no_auth), because that option
+    /// explicitly permits unsigned requests.
+    pub fn require_auth(mut self) -> Self {
+        self.set_require_auth(true);
+        self
+    }
+
+    /// Sets whether this config requires credentials for every request.
+    ///
+    /// See [`require_auth`](Self::require_auth) for the behavior and intended use case.
+    pub fn set_require_auth(&mut self, require_auth: bool) -> &mut Self {
+        if require_auth && self.alternator_ext.allow_no_auth {
+            incompatible_auth_options();
+        }
+        self.alternator_ext.require_auth = require_auth;
+        self
+    }
+
+    /// Explicitly permit unsigned requests.
+    ///
+    /// This mirrors the AWS SDK no-auth escape hatch. It cannot be combined with
+    /// [`require_auth`](Self::require_auth), which intentionally makes missing credentials fail.
     pub fn allow_no_auth(mut self) -> Self {
+        if self.alternator_ext.require_auth {
+            incompatible_auth_options();
+        }
+        self.alternator_ext.allow_no_auth = true;
         self.dynamodb_builder = self.dynamodb_builder.allow_no_auth();
         self
     }
 
+    /// Explicitly permit unsigned requests.
+    ///
+    /// See [`allow_no_auth`](Self::allow_no_auth).
     pub fn set_allow_no_auth(&mut self) -> &mut Self {
-        self.dynamodb_builder.set_allow_no_auth();
-        self
-    }
-
-    pub fn auth_scheme_preference(
-        mut self,
-        preference: impl Into<aws_smithy_runtime_api::client::auth::AuthSchemePreference>,
-    ) -> Self {
-        let (preference, disable_implicit_no_auth) =
-            normalize_auth_scheme_preference(preference.into());
-        self.alternator_ext.disable_implicit_no_auth = disable_implicit_no_auth;
-        self.dynamodb_builder = self.dynamodb_builder.auth_scheme_preference(preference);
-        self
-    }
-
-    pub fn set_auth_scheme_preference(
-        &mut self,
-        preference: Option<aws_smithy_runtime_api::client::auth::AuthSchemePreference>,
-    ) -> &mut Self {
-        let preference = preference.map(|preference| {
-            let (preference, disable_implicit_no_auth) =
-                normalize_auth_scheme_preference(preference);
-            self.alternator_ext.disable_implicit_no_auth = disable_implicit_no_auth;
-            preference.into()
-        });
-        if preference.is_none() {
-            self.alternator_ext.disable_implicit_no_auth = false;
+        if self.alternator_ext.require_auth {
+            incompatible_auth_options();
         }
-        self.dynamodb_builder.set_auth_scheme_preference(preference);
+        self.alternator_ext.allow_no_auth = true;
+        self.dynamodb_builder.set_allow_no_auth();
         self
     }
 
@@ -1217,56 +1213,55 @@ mod test {
     }
 
     #[test]
-    fn shared_sdk_config_auth_scheme_preference_is_remembered() {
+    #[should_panic(expected = "auth_scheme_preference is not supported by alternator-driver")]
+    fn shared_sdk_config_auth_scheme_preference_reports_unsupported_api() {
         let sdk_config = aws_types::SdkConfig::builder()
             .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])
             .build();
 
-        let config = AlternatorConfig::from(&sdk_config);
-
-        assert!(config.disable_implicit_no_auth());
+        let _ = AlternatorConfig::from(&sdk_config);
     }
 
     #[test]
-    fn sigv4_auth_scheme_preference_disables_implicit_no_auth() {
+    fn require_auth_requires_credentials() {
         let config = AlternatorConfig::builder()
-            .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])
+            .require_auth()
             .behavior_version_latest()
             .build();
 
-        assert!(config.disable_implicit_no_auth());
+        assert!(config.requires_auth());
     }
 
     #[test]
-    fn no_auth_scheme_preference_keeps_implicit_no_auth_enabled() {
-        let config = AlternatorConfig::builder()
-            .auth_scheme_preference([aws_smithy_runtime::client::auth::no_auth::NO_AUTH_SCHEME_ID])
-            .behavior_version_latest()
-            .build();
+    fn set_require_auth_false_restores_implicit_no_auth() {
+        let mut builder = AlternatorConfig::builder().require_auth();
 
-        assert!(!config.disable_implicit_no_auth());
-    }
-
-    #[test]
-    fn clearing_auth_scheme_preference_restores_implicit_no_auth() {
-        let mut builder = AlternatorConfig::builder()
-            .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID]);
-
-        builder.set_auth_scheme_preference(None);
+        builder.set_require_auth(false);
         let config = builder.behavior_version_latest().build();
 
-        assert!(!config.disable_implicit_no_auth());
+        assert!(!config.requires_auth());
     }
 
     #[test]
-    #[should_panic(expected = "unsupported auth scheme preference")]
-    fn unsupported_auth_scheme_preference_panics() {
-        let _ = AlternatorConfig::builder()
-            .auth_scheme_preference([aws_smithy_runtime_api::client::auth::AuthSchemeId::new(
-                "sigv4a",
-            )])
+    fn allow_no_auth_is_remembered() {
+        let config = AlternatorConfig::builder()
+            .allow_no_auth()
             .behavior_version_latest()
             .build();
+
+        assert!(config.allows_no_auth());
+    }
+
+    #[test]
+    #[should_panic(expected = "require_auth() cannot be combined with allow_no_auth()")]
+    fn require_auth_after_allow_no_auth_panics() {
+        let _ = AlternatorConfig::builder().allow_no_auth().require_auth();
+    }
+
+    #[test]
+    #[should_panic(expected = "require_auth() cannot be combined with allow_no_auth()")]
+    fn allow_no_auth_after_require_auth_panics() {
+        let _ = AlternatorConfig::builder().require_auth().allow_no_auth();
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub(crate) struct AlternatorExtensions {
     pub(crate) request_compression: Option<RequestCompression>,
     pub(crate) response_compression: Option<ResponseCompression>,
     pub(crate) optimize_headers: Option<bool>,
+    pub(crate) has_credentials_provider: bool,
     pub(crate) active_interval: Option<std::time::Duration>,
     pub(crate) idle_interval: Option<std::time::Duration>,
     pub(crate) routing_scope: Option<RoutingScope>,
@@ -96,6 +97,10 @@ impl AlternatorConfig {
     /// Not set by default (disabled).
     pub fn response_compression(&self) -> Option<ResponseCompression> {
         self.alternator_ext.response_compression.clone()
+    }
+
+    pub(crate) fn has_credentials_provider(&self) -> bool {
+        self.alternator_ext.has_credentials_provider
     }
 
     /// Gets the active interval for refreshing the list of known nodes when the client is active.
@@ -569,9 +574,13 @@ impl AlternatorBuilder {
 
 impl From<&aws_types::sdk_config::SdkConfig> for AlternatorBuilder {
     fn from(sdk_config: &aws_types::sdk_config::SdkConfig) -> Self {
+        let has_credentials_provider = sdk_config.credentials_provider().is_some();
         AlternatorBuilder {
             dynamodb_builder: aws_sdk_dynamodb::config::Builder::from(sdk_config),
-            alternator_ext: AlternatorExtensions::default(),
+            alternator_ext: AlternatorExtensions {
+                has_credentials_provider,
+                ..Default::default()
+            },
         }
     }
 }
@@ -1031,6 +1040,7 @@ impl AlternatorBuilder {
         mut self,
         credentials_provider: impl aws_sdk_dynamodb::config::ProvideCredentials + 'static,
     ) -> Self {
+        self.alternator_ext.has_credentials_provider = true;
         self.dynamodb_builder = self
             .dynamodb_builder
             .credentials_provider(credentials_provider);
@@ -1041,6 +1051,9 @@ impl AlternatorBuilder {
         &mut self,
         credentials_provider: Option<aws_sdk_dynamodb::config::SharedCredentialsProvider>,
     ) -> &mut Self {
+        if credentials_provider.is_some() {
+            self.alternator_ext.has_credentials_provider = true;
+        }
         self.dynamodb_builder
             .set_credentials_provider(credentials_provider);
         self
@@ -1129,6 +1142,28 @@ mod test {
                 .expect("does not have length")
                 == 0
         );
+    }
+
+    #[test]
+    fn shared_sdk_config_credentials_provider_is_remembered() {
+        let sdk_config = aws_types::SdkConfig::builder()
+            .credentials_provider(aws_sdk_dynamodb::config::SharedCredentialsProvider::new(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            ))
+            .build();
+
+        let config = AlternatorConfig::from(&sdk_config);
+
+        assert!(config.has_credentials_provider());
+    }
+
+    #[test]
+    fn shared_sdk_config_without_credentials_provider_is_no_auth() {
+        let sdk_config = aws_types::SdkConfig::builder().build();
+
+        let config = AlternatorConfig::from(&sdk_config);
+
+        assert!(!config.has_credentials_provider());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub(crate) struct AlternatorExtensions {
     pub(crate) response_compression: Option<ResponseCompression>,
     pub(crate) optimize_headers: Option<bool>,
     pub(crate) has_credentials_provider: bool,
+    pub(crate) disable_implicit_no_auth: bool,
     pub(crate) active_interval: Option<std::time::Duration>,
     pub(crate) idle_interval: Option<std::time::Duration>,
     pub(crate) routing_scope: Option<RoutingScope>,
@@ -22,6 +23,39 @@ pub(crate) struct AlternatorExtensions {
     pub(crate) seed_hosts: Option<Vec<String>>,
     pub(crate) live_nodes: Option<std::sync::Arc<LiveNodes>>,
     pub(crate) key_route_affinity: Option<keyrouting::affinity_config::KeyRouteAffinityConfig>,
+}
+
+const UNSUPPORTED_AUTH_API_MESSAGE: &str = "Alternator supports only SigV4 with static credentials or no-auth. Use credentials_provider(...), per-request config_override(...credentials_provider(...)), auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID]) for strict signed requests, or allow_no_auth(). Custom AWS SDK auth schemes and resolvers are not supported.";
+
+fn unsupported_auth_api(api: &str) -> ! {
+    panic!("{api} is not supported by alternator-driver: {UNSUPPORTED_AUTH_API_MESSAGE}");
+}
+
+fn is_supported_auth_scheme(
+    scheme_id: &aws_smithy_runtime_api::client::auth::AuthSchemeId,
+) -> bool {
+    scheme_id == &aws_runtime::auth::sigv4::SCHEME_ID
+        || scheme_id == &aws_smithy_runtime::client::auth::no_auth::NO_AUTH_SCHEME_ID
+}
+
+fn normalize_auth_scheme_preference(
+    preference: aws_smithy_runtime_api::client::auth::AuthSchemePreference,
+) -> (
+    Vec<aws_smithy_runtime_api::client::auth::AuthSchemeId>,
+    bool,
+) {
+    let preference: Vec<_> = preference.into_iter().collect();
+    if let Some(scheme_id) = preference.iter().find(|id| !is_supported_auth_scheme(id)) {
+        panic!(
+            "unsupported auth scheme preference {:?}: {UNSUPPORTED_AUTH_API_MESSAGE}",
+            scheme_id.inner()
+        );
+    }
+    let disable_implicit_no_auth = !preference.is_empty()
+        && !preference
+            .iter()
+            .any(|id| id == &aws_smithy_runtime::client::auth::no_auth::NO_AUTH_SCHEME_ID);
+    (preference, disable_implicit_no_auth)
 }
 
 /// [AlternatorClient]'s config
@@ -101,6 +135,10 @@ impl AlternatorConfig {
 
     pub(crate) fn has_credentials_provider(&self) -> bool {
         self.alternator_ext.has_credentials_provider
+    }
+
+    pub(crate) fn disable_implicit_no_auth(&self) -> bool {
+        self.alternator_ext.disable_implicit_no_auth
     }
 
     /// Gets the active interval for refreshing the list of known nodes when the client is active.
@@ -575,10 +613,16 @@ impl AlternatorBuilder {
 impl From<&aws_types::sdk_config::SdkConfig> for AlternatorBuilder {
     fn from(sdk_config: &aws_types::sdk_config::SdkConfig) -> Self {
         let has_credentials_provider = sdk_config.credentials_provider().is_some();
+        let disable_implicit_no_auth = sdk_config
+            .auth_scheme_preference()
+            .cloned()
+            .map(|preference| normalize_auth_scheme_preference(preference).1)
+            .unwrap_or(false);
         AlternatorBuilder {
             dynamodb_builder: aws_sdk_dynamodb::config::Builder::from(sdk_config),
             alternator_ext: AlternatorExtensions {
                 has_credentials_provider,
+                disable_implicit_no_auth,
                 ..Default::default()
             },
         }
@@ -723,30 +767,24 @@ impl AlternatorBuilder {
     }
 
     pub fn push_auth_scheme(
-        mut self,
-        auth_scheme: impl aws_smithy_runtime_api::client::auth::AuthScheme + 'static,
+        self,
+        _auth_scheme: impl aws_smithy_runtime_api::client::auth::AuthScheme + 'static,
     ) -> Self {
-        self.dynamodb_builder = self.dynamodb_builder.push_auth_scheme(auth_scheme);
-        self
+        unsupported_auth_api("push_auth_scheme")
     }
 
     pub fn auth_scheme_resolver(
-        mut self,
-        auth_scheme_resolver: impl aws_sdk_dynamodb::config::auth::ResolveAuthScheme + 'static,
+        self,
+        _auth_scheme_resolver: impl aws_sdk_dynamodb::config::auth::ResolveAuthScheme + 'static,
     ) -> Self {
-        self.dynamodb_builder = self
-            .dynamodb_builder
-            .auth_scheme_resolver(auth_scheme_resolver);
-        self
+        unsupported_auth_api("auth_scheme_resolver")
     }
 
     pub fn set_auth_scheme_resolver(
         &mut self,
-        auth_scheme_resolver: impl aws_sdk_dynamodb::config::auth::ResolveAuthScheme + 'static,
+        _auth_scheme_resolver: impl aws_sdk_dynamodb::config::auth::ResolveAuthScheme + 'static,
     ) -> &mut Self {
-        self.dynamodb_builder
-            .set_auth_scheme_resolver(auth_scheme_resolver);
-        self
+        unsupported_auth_api("set_auth_scheme_resolver")
     }
 
     pub fn allow_no_auth(mut self) -> Self {
@@ -763,6 +801,9 @@ impl AlternatorBuilder {
         mut self,
         preference: impl Into<aws_smithy_runtime_api::client::auth::AuthSchemePreference>,
     ) -> Self {
+        let (preference, disable_implicit_no_auth) =
+            normalize_auth_scheme_preference(preference.into());
+        self.alternator_ext.disable_implicit_no_auth = disable_implicit_no_auth;
         self.dynamodb_builder = self.dynamodb_builder.auth_scheme_preference(preference);
         self
     }
@@ -771,6 +812,15 @@ impl AlternatorBuilder {
         &mut self,
         preference: Option<aws_smithy_runtime_api::client::auth::AuthSchemePreference>,
     ) -> &mut Self {
+        let preference = preference.map(|preference| {
+            let (preference, disable_implicit_no_auth) =
+                normalize_auth_scheme_preference(preference);
+            self.alternator_ext.disable_implicit_no_auth = disable_implicit_no_auth;
+            preference.into()
+        });
+        if preference.is_none() {
+            self.alternator_ext.disable_implicit_no_auth = false;
+        }
         self.dynamodb_builder.set_auth_scheme_preference(preference);
         self
     }
@@ -1164,6 +1214,67 @@ mod test {
         let config = AlternatorConfig::from(&sdk_config);
 
         assert!(!config.has_credentials_provider());
+    }
+
+    #[test]
+    fn shared_sdk_config_auth_scheme_preference_is_remembered() {
+        let sdk_config = aws_types::SdkConfig::builder()
+            .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])
+            .build();
+
+        let config = AlternatorConfig::from(&sdk_config);
+
+        assert!(config.disable_implicit_no_auth());
+    }
+
+    #[test]
+    fn sigv4_auth_scheme_preference_disables_implicit_no_auth() {
+        let config = AlternatorConfig::builder()
+            .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])
+            .behavior_version_latest()
+            .build();
+
+        assert!(config.disable_implicit_no_auth());
+    }
+
+    #[test]
+    fn no_auth_scheme_preference_keeps_implicit_no_auth_enabled() {
+        let config = AlternatorConfig::builder()
+            .auth_scheme_preference([aws_smithy_runtime::client::auth::no_auth::NO_AUTH_SCHEME_ID])
+            .behavior_version_latest()
+            .build();
+
+        assert!(!config.disable_implicit_no_auth());
+    }
+
+    #[test]
+    fn clearing_auth_scheme_preference_restores_implicit_no_auth() {
+        let mut builder = AlternatorConfig::builder()
+            .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID]);
+
+        builder.set_auth_scheme_preference(None);
+        let config = builder.behavior_version_latest().build();
+
+        assert!(!config.disable_implicit_no_auth());
+    }
+
+    #[test]
+    #[should_panic(expected = "unsupported auth scheme preference")]
+    fn unsupported_auth_scheme_preference_panics() {
+        let _ = AlternatorConfig::builder()
+            .auth_scheme_preference([aws_smithy_runtime_api::client::auth::AuthSchemeId::new(
+                "sigv4a",
+            )])
+            .behavior_version_latest()
+            .build();
+    }
+
+    #[test]
+    #[should_panic(expected = "Alternator supports only SigV4 with static credentials or no-auth")]
+    fn unsupported_auth_scheme_resolver_panics() {
+        let _ = AlternatorConfig::builder().auth_scheme_resolver(
+            aws_sdk_dynamodb::config::auth::DefaultAuthSchemeResolver::default(),
+        );
     }
 
     #[test]

--- a/src/customize.rs
+++ b/src/customize.rs
@@ -65,6 +65,12 @@ impl<T, E, B> AlternatorCustomizableOperation<T, E, B> for CustomizableOperation
             ));
         }
 
+        if config_override.alternator_ext.has_credentials_provider {
+            this = this.interceptor(AlternatorOverrideInterceptor::for_preserve_auth_headers(
+                true,
+            ));
+        }
+
         this
     }
 }

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -31,17 +31,20 @@ pub(crate) struct AlternatorInterceptor {
     request_compression: RequestCompression,
     response_compression: ResponseCompression,
     optimize_headers: bool,
+    preserve_auth_headers: bool,
 }
 impl AlternatorInterceptor {
     pub fn new(
         request_compression: RequestCompression,
         response_compression: ResponseCompression,
         optimize_headers: bool,
+        preserve_auth_headers: bool,
     ) -> Self {
         Self {
             request_compression,
             response_compression,
             optimize_headers,
+            preserve_auth_headers,
         }
     }
 }
@@ -98,10 +101,15 @@ impl Intercept for AlternatorInterceptor {
             .load::<OptimizeHeadersStore>()
             .map(|store| store.optimize_headers)
             .unwrap_or(self.optimize_headers);
+        let preserve_auth_headers = cfg
+            .interceptor_state()
+            .load::<PreserveAuthHeadersStore>()
+            .map(|store| store.preserve_auth_headers)
+            .unwrap_or(self.preserve_auth_headers);
 
         // optimize headers
         if optimize_headers {
-            strip_headers(context.request_mut());
+            strip_headers(context.request_mut(), preserve_auth_headers);
         }
 
         Ok(())
@@ -208,6 +216,14 @@ impl Storable for ResponseCompressionStore {
     type Storer = StoreReplace<Self>;
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct PreserveAuthHeadersStore {
+    preserve_auth_headers: bool,
+}
+impl Storable for PreserveAuthHeadersStore {
+    type Storer = StoreReplace<Self>;
+}
+
 /// An interceptor used to override [AlternatorClient]'s config.
 ///
 /// Adds specified config overrides to [ConfigBag], so that [AlternatorInterceptor] can later look for it.
@@ -255,6 +271,15 @@ impl AlternatorOverrideInterceptor<ResponseCompressionStore> {
         AlternatorOverrideInterceptor {
             store: ResponseCompressionStore {
                 response_compression,
+            },
+        }
+    }
+}
+impl AlternatorOverrideInterceptor<PreserveAuthHeadersStore> {
+    pub(crate) fn for_preserve_auth_headers(preserve_auth_headers: bool) -> Self {
+        AlternatorOverrideInterceptor {
+            store: PreserveAuthHeadersStore {
+                preserve_auth_headers,
             },
         }
     }

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -5,7 +5,7 @@ use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::interceptors::context::Input;
 use aws_smithy_runtime_api::client::interceptors::context::{
     BeforeDeserializationInterceptorContextMut, BeforeSerializationInterceptorContextMut,
-    BeforeTransmitInterceptorContextMut,
+    BeforeTransmitInterceptorContextMut, BeforeTransmitInterceptorContextRef,
 };
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
@@ -110,6 +110,22 @@ impl Intercept for AlternatorInterceptor {
         // optimize headers
         if optimize_headers {
             strip_headers(context.request_mut(), preserve_auth_headers);
+        }
+
+        Ok(())
+    }
+
+    fn read_after_signing(
+        &self,
+        context: &BeforeTransmitInterceptorContextRef<'_>,
+        _: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let headers = context.request().headers();
+        if headers.contains_key("authorization") && headers.contains_key("x-amz-date") {
+            cfg.interceptor_state().store_put(PreserveAuthHeadersStore {
+                preserve_auth_headers: true,
+            });
         }
 
         Ok(())

--- a/src/keyrouting/resolver.rs
+++ b/src/keyrouting/resolver.rs
@@ -419,6 +419,7 @@ mod tests {
                 RequestCompression::disabled(),
                 ResponseCompression::disabled(),
                 true,
+                true,
             ));
 
         let discovery_client = aws_sdk_dynamodb::Client::from_conf(

--- a/src/optimize_headers.rs
+++ b/src/optimize_headers.rs
@@ -3,26 +3,85 @@ use aws_smithy_runtime_api::http::Request;
 /// To be used in an interceptor
 ///
 /// Removes unwanted headers from the given request
-pub(crate) fn strip_headers(request: &mut Request) {
+pub(crate) fn strip_headers(request: &mut Request, preserve_auth_headers: bool) {
     let headers = request.headers_mut();
 
-    const WHITELIST: [&str; 7] = [
+    const WHITELIST: [&str; 5] = [
         "host",
         "x-amz-target",
         "content-length",
         "accept-encoding",
         "content-encoding",
-        "authorization",
-        "x-amz-date",
     ];
+    const AUTH_WHITELIST: [&str; 2] = ["authorization", "x-amz-date"];
 
     let unallowed_keys: Vec<String> = headers
         .iter()
         .map(|(key, _)| key.to_string())
-        .filter(|key| !WHITELIST.contains(&key.as_str()))
+        .filter(|key| {
+            !(WHITELIST.contains(&key.as_str())
+                || preserve_auth_headers && AUTH_WHITELIST.contains(&key.as_str()))
+        })
         .collect();
 
     for key in unallowed_keys {
         headers.remove(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request_with_headers() -> Request {
+        let mut request = Request::empty();
+        request.headers_mut().insert("host", "localhost:8000");
+        request
+            .headers_mut()
+            .insert("x-amz-target", "DynamoDB_20120810.PutItem");
+        request.headers_mut().insert("content-length", "10");
+        request.headers_mut().insert("accept-encoding", "gzip");
+        request.headers_mut().insert("content-encoding", "gzip");
+        request.headers_mut().insert("authorization", "signature");
+        request
+            .headers_mut()
+            .insert("x-amz-date", "20260626T120000Z");
+        request.headers_mut().insert("user-agent", "test");
+        request.headers_mut().insert("amz-sdk-request", "attempt=1");
+        request
+    }
+
+    #[test]
+    fn no_auth_allowlist_drops_auth_headers_and_keeps_compression_headers() {
+        let mut request = request_with_headers();
+
+        strip_headers(&mut request, false);
+
+        assert!(request.headers().contains_key("host"));
+        assert!(request.headers().contains_key("x-amz-target"));
+        assert!(request.headers().contains_key("content-length"));
+        assert!(request.headers().contains_key("accept-encoding"));
+        assert!(request.headers().contains_key("content-encoding"));
+        assert!(!request.headers().contains_key("authorization"));
+        assert!(!request.headers().contains_key("x-amz-date"));
+        assert!(!request.headers().contains_key("user-agent"));
+        assert!(!request.headers().contains_key("amz-sdk-request"));
+    }
+
+    #[test]
+    fn signed_allowlist_preserves_auth_headers_and_compression_headers() {
+        let mut request = request_with_headers();
+
+        strip_headers(&mut request, true);
+
+        assert!(request.headers().contains_key("host"));
+        assert!(request.headers().contains_key("x-amz-target"));
+        assert!(request.headers().contains_key("content-length"));
+        assert!(request.headers().contains_key("accept-encoding"));
+        assert!(request.headers().contains_key("content-encoding"));
+        assert!(request.headers().contains_key("authorization"));
+        assert!(request.headers().contains_key("x-amz-date"));
+        assert!(!request.headers().contains_key("user-agent"));
+        assert!(!request.headers().contains_key("amz-sdk-request"));
     }
 }

--- a/tests/dynamodb_compatibility.rs
+++ b/tests/dynamodb_compatibility.rs
@@ -176,6 +176,7 @@ fn test_config() {
     // allow exceptions
     let mut with_exceptions = dynamodb_config_methods;
     with_exceptions.remove(&(None, "credentials_provider".into())); // credentials_provider is deprecated and always returns None
+    with_exceptions.remove(&(None, "auth_scheme_preference".into())); // use AlternatorBuilder::require_auth instead of AWS auth preference hints
 
     let unimplemented = with_exceptions.difference(&alternator_config_methods);
     let all_implemented = unimplemented.clone().next().is_none();
@@ -206,6 +207,8 @@ fn test_builder() {
 
     with_exceptions.remove(&(None, "set_idempotency_token_provider".into())); // not supported as IdempotencyTokenProvider is private
     with_exceptions.remove(&(None, "idempotency_token_provider".into()));
+    with_exceptions.remove(&(None, "auth_scheme_preference".into())); // use require_auth for strict signed requests
+    with_exceptions.remove(&(None, "set_auth_scheme_preference".into()));
 
     let unimplemented = with_exceptions.difference(&alternator_builder_methods);
     let all_implemented = unimplemented.clone().next().is_none();

--- a/tests/http_content/optimize_headers.rs
+++ b/tests/http_content/optimize_headers.rs
@@ -4,24 +4,32 @@
 //! use from outgoing requests. A proxy is used to intercept messages exchanged
 //! between the driver and Alternator.
 //!
-//! There are six test cases:
+//! There are eight test cases:
 //! 1. Without credentials:
 //!    Disable credentials and verify that requests follow this whitelist:
 //!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding"]
 //! 2. Without credentials, with injected auth headers:
 //!    Disable credentials, inject auth headers before header stripping, and
 //!    verify that requests still follow the no-auth whitelist.
-//! 3. With credentials:
+//! 3. With per-request credentials:
+//!    Disable global credentials, provide credentials through a single SDK
+//!    operation override, prefer SigV4 auth, and verify that SigV4 headers are
+//!    preserved.
+//! 4. Without per-request credentials:
+//!    Disable global credentials, prefer SigV4 auth, and verify that a missing
+//!    per-request credentials override fails locally instead of being sent
+//!    unsigned.
+//! 5. With credentials:
 //!    Enable credentials and verify that requests follow this whitelist:
 //!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding", "authorization", "x-amz-date"]
-//! 4. Whitelist needed:
+//! 6. Whitelist needed:
 //!    Enable credentials, disable header stripping, and verify that
 //!    unnecessary headers are present, confirming that stripping is useful.
-//! 5. Enabled by per-request customization:
+//! 7. Enabled by per-request customization:
 //!    Disable header stripping in the client config, override it for one call,
 //!    and then make another non-customized call to verify that the override
 //!    does not persist.
-//! 6. Disabled by per-request customization:
+//! 8. Disabled by per-request customization:
 //!    Enable header stripping in the client config, override it for one call,
 //!    and then make another non-customized call to verify that the override
 //!    does not persist.
@@ -57,6 +65,10 @@ use aws_sdk_dynamodb::types::{
 };
 
 use alternator_driver::*;
+
+fn request_credentials() -> aws_sdk_dynamodb::config::Credentials {
+    aws_sdk_dynamodb::config::Credentials::new("access-key", "secret-key", None, None, "test")
+}
 
 #[derive(Debug)]
 struct InjectAuthHeadersInterceptor;
@@ -255,6 +267,57 @@ pub async fn test_without_credentials_drops_injected_auth_headers(
     // perform calls to alternator, use proxy to peek and forward requests
     // proxy ensures the injected auth headers are dropped according to the no-auth whitelist
     make_calls(&client, ctx).await;
+}
+
+#[test_context(HttpTestContext<WithCredentialsConfig>)]
+#[tokio::test]
+pub async fn test_per_request_credentials_preserve_signed_headers(
+    ctx: &mut HttpTestContext<WithCredentialsConfig>,
+) {
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .optimize_headers(true)
+            .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])
+            .build(),
+    );
+
+    client
+        .list_tables()
+        .customize()
+        .config_override(
+            aws_sdk_dynamodb::Config::builder()
+                .credentials_provider(request_credentials())
+                .region(aws_sdk_dynamodb::config::Region::new("eu-central-1")),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_context(HttpTestContext<PerRequestCustomizationConfig>)]
+#[tokio::test]
+pub async fn test_missing_per_request_credentials_fails_before_no_auth_fallback(
+    ctx: &mut HttpTestContext<PerRequestCustomizationConfig>,
+) {
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .optimize_headers(true)
+            .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])
+            .build(),
+    );
+
+    let result = client.list_tables().send().await;
+
+    assert!(
+        result.is_err(),
+        "missing per-request credentials should fail before sending an unsigned request"
+    );
 }
 
 struct WithCredentialsConfig;

--- a/tests/http_content/optimize_headers.rs
+++ b/tests/http_content/optimize_headers.rs
@@ -177,6 +177,8 @@ impl HttpTestConfig for WithoutCredentialsConfig {
             rogue.unwrap(),
             whitelist
         );
+        assert!(!parts.headers.contains_key("authorization"));
+        assert!(!parts.headers.contains_key("x-amz-date"));
 
         // forward
         let (parts, body) = collect_received_response(parts, body, sender).await;
@@ -198,7 +200,6 @@ pub async fn test_without_credentials(ctx: &mut HttpTestContext<WithoutCredentia
             .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .optimize_headers(true)
-            .allow_no_auth()
             .build(),
     );
 
@@ -237,6 +238,8 @@ impl HttpTestConfig for WithCredentialsConfig {
             rogue.unwrap(),
             whitelist
         );
+        assert!(parts.headers.contains_key("authorization"));
+        assert!(parts.headers.contains_key("x-amz-date"));
 
         // forward
         let (parts, body) = collect_received_response(parts, body, sender).await;

--- a/tests/http_content/optimize_headers.rs
+++ b/tests/http_content/optimize_headers.rs
@@ -4,21 +4,24 @@
 //! use from outgoing requests. A proxy is used to intercept messages exchanged
 //! between the driver and Alternator.
 //!
-//! There are five test cases:
+//! There are six test cases:
 //! 1. Without credentials:
 //!    Disable credentials and verify that requests follow this whitelist:
 //!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding"]
-//! 2. With credentials:
+//! 2. Without credentials, with injected auth headers:
+//!    Disable credentials, inject auth headers before header stripping, and
+//!    verify that requests still follow the no-auth whitelist.
+//! 3. With credentials:
 //!    Enable credentials and verify that requests follow this whitelist:
 //!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding", "authorization", "x-amz-date"]
-//! 3. Whitelist needed:
+//! 4. Whitelist needed:
 //!    Enable credentials, disable header stripping, and verify that
 //!    unnecessary headers are present, confirming that stripping is useful.
-//! 4. Enabled by per-request customization:
+//! 5. Enabled by per-request customization:
 //!    Disable header stripping in the client config, override it for one call,
 //!    and then make another non-customized call to verify that the override
 //!    does not persist.
-//! 5. Disabled by per-request customization:
+//! 6. Disabled by per-request customization:
 //!    Enable header stripping in the client config, override it for one call,
 //!    and then make another non-customized call to verify that the override
 //!    does not persist.
@@ -42,6 +45,11 @@ use test_context::test_context;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::config_bag::ConfigBag;
+
 use aws_sdk_dynamodb::client::Waiters;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
@@ -49,6 +57,26 @@ use aws_sdk_dynamodb::types::{
 };
 
 use alternator_driver::*;
+
+#[derive(Debug)]
+struct InjectAuthHeadersInterceptor;
+impl aws_sdk_dynamodb::config::Intercept for InjectAuthHeadersInterceptor {
+    fn name(&self) -> &'static str {
+        "InjectAuthHeadersInterceptor"
+    }
+
+    fn modify_before_transmit(
+        &self,
+        context: &mut BeforeTransmitInterceptorContextMut<'_>,
+        _: &RuntimeComponents,
+        _: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let headers = context.request_mut().headers_mut();
+        headers.insert("authorization", "AWS4-HMAC-SHA256 fake");
+        headers.insert("x-amz-date", "20260626T120000Z");
+        Ok(())
+    }
+}
 
 async fn cleanup_calls(resources: Vec<String>, alternator_address: &str) {
     let client = aws_sdk_dynamodb::Client::from_conf(
@@ -205,6 +233,27 @@ pub async fn test_without_credentials(ctx: &mut HttpTestContext<WithoutCredentia
 
     // perform calls to alternator, use proxy to peek and forward requests
     // proxy ensures all requests to have headers stripped according to the whitelist in WithoutCredentialsConfig
+    make_calls(&client, ctx).await;
+}
+
+#[test_context(HttpTestContext<WithoutCredentialsConfig>)]
+#[tokio::test]
+pub async fn test_without_credentials_drops_injected_auth_headers(
+    ctx: &mut HttpTestContext<WithoutCredentialsConfig>,
+) {
+    // construct client with credentials disabled
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .optimize_headers(true)
+            .interceptor(InjectAuthHeadersInterceptor)
+            .build(),
+    );
+
+    // perform calls to alternator, use proxy to peek and forward requests
+    // proxy ensures the injected auth headers are dropped according to the no-auth whitelist
     make_calls(&client, ctx).await;
 }
 

--- a/tests/http_content/optimize_headers.rs
+++ b/tests/http_content/optimize_headers.rs
@@ -67,7 +67,7 @@ use aws_sdk_dynamodb::types::{
 use alternator_driver::*;
 
 fn request_credentials() -> aws_sdk_dynamodb::config::Credentials {
-    aws_sdk_dynamodb::config::Credentials::new("access-key", "secret-key", None, None, "test")
+    aws_sdk_dynamodb::config::Credentials::for_tests()
 }
 
 #[derive(Debug)]
@@ -96,9 +96,7 @@ async fn cleanup_calls(resources: Vec<String>, alternator_address: &str) {
             .endpoint_url(format!("http://{}", alternator_address))
             .region(aws_sdk_dynamodb::config::Region::new("eu-central-1"))
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
-            .credentials_provider(
-                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
-            )
+            .credentials_provider(aws_sdk_dynamodb::config::Credentials::for_tests())
             .build(),
     );
 
@@ -280,7 +278,7 @@ pub async fn test_per_request_credentials_preserve_signed_headers(
             .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .optimize_headers(true)
-            .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])
+            .require_auth()
             .build(),
     );
 
@@ -308,7 +306,7 @@ pub async fn test_missing_per_request_credentials_fails_before_no_auth_fallback(
             .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .optimize_headers(true)
-            .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])
+            .require_auth()
             .build(),
     );
 
@@ -373,9 +371,7 @@ pub async fn test_with_credentials(ctx: &mut HttpTestContext<WithCredentialsConf
             .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .optimize_headers(true)
-            .credentials_provider(
-                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
-            )
+            .credentials_provider(aws_sdk_dynamodb::config::Credentials::for_tests())
             .build(),
     );
 
@@ -434,9 +430,7 @@ pub async fn test_whitelist_needed(ctx: &mut HttpTestContext<WhitelistNeededConf
             .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
             .optimize_headers(false)
-            .credentials_provider(
-                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
-            )
+            .credentials_provider(aws_sdk_dynamodb::config::Credentials::for_tests())
             .build(),
     );
 
@@ -544,9 +538,7 @@ pub async fn test_enabled_by_per_request_customization(
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
             .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
-            .credentials_provider(
-                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
-            )
+            .credentials_provider(aws_sdk_dynamodb::config::Credentials::for_tests())
             .optimize_headers(false)
             .build(),
     );
@@ -572,9 +564,7 @@ pub async fn test_disabled_by_per_request_customization(
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
             .seed_hosts(Vec::<String>::new())
             .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
-            .credentials_provider(
-                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
-            )
+            .credentials_provider(aws_sdk_dynamodb::config::Credentials::for_tests())
             .optimize_headers(true)
             .build(),
     );


### PR DESCRIPTION
## Summary
- default Alternator clients without a credentials provider to SDK no-auth
- preserve signed per-request credentials after SDK signing, including plain SDK `config_override` credentials
- add explicit `require_auth()` for no-default-credentials clients that must fail instead of falling back to no-auth when per-request credentials are missing
- reject unsupported custom auth schemes/resolvers/preferences with an Alternator-specific message because Alternator supports only SigV4 static credentials or no-auth
- keep compression headers in both optimized allowlists and simplify no-auth README examples

Fixes #62
Fixes #63

## Testing
- `cargo fmt -- --check`
- `cargo test --lib`
- `docker compose up -d --wait`
- `cargo test --test http_content_tests optimize_headers -- --nocapture`
- `cargo test`
- `docker compose down --remove-orphans -v`