### PR TITLE
fix: discover all datacenters for cluster routing scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ let config = AlternatorConfig::builder()
     .build();
 ```
 
-The host in the URL is treated as a *seed*: the client immediately calls `/localnodes` on that node to discover the full cluster, and from that point onward all requests fan out across the discovered nodes. The endpoint URL is never used for actual data-plane traffic after discovery completes.
+The host in the URL is treated as a *seed*. For datacenter and rack scopes, the client calls `/localnodes` with the configured scope parameters. For the default cluster-wide scope, the client calls bare `/localnodes` on configured seed hosts and already-known live nodes, then unions the returned node lists. The endpoint URL is never used for actual data-plane traffic after discovery completes.
 
-To give the client multiple candidates for the initial `/localnodes` call, or for deployments where the seed node might be down at startup time, you can pass multiple seed addresses directly along with the scheme and the port:
+To give the client multiple candidates for initial discovery, or for deployments where a seed node might be down at startup time, pass multiple seed addresses directly along with the Alternator scheme and port:
 
 ```rust
 use alternator_driver::AlternatorConfig;
@@ -116,7 +116,7 @@ let config = AlternatorConfig::builder()
     .build();
 ```
 
-The client tries each seed in turn until one responds successfully to `/localnodes`. Once discovery succeeds, the seed list is no longer consulted (except as fallback if all currently-known nodes become unreachable).
+For cluster-wide scope, provide at least one working seed host from every datacenter that should receive traffic. If a datacenter has no working seed in the configuration, the client cannot reliably discover and refresh live Alternator nodes from that datacenter.
 
 ### Node discovery
 
@@ -137,7 +137,7 @@ The refresh task runs in the background for the lifetime of the client. It termi
 
 ### Routing scope
 
-By default, the client uses every Alternator node returned by `/localnodes`. For deployments spanning multiple datacenters or racks, you usually want requests to stay within a specific datacenter — or within a specific rack of a specific datacenter — to minimize cross-zone latency and bandwidth.
+By default, the client uses every live Alternator node it discovers across the cluster. For deployments spanning multiple datacenters or racks, you usually want requests to stay within a specific datacenter — or within a specific rack of a specific datacenter — to minimize cross-zone latency and bandwidth.
 
 This is configured via `RoutingScope`:
 
@@ -161,10 +161,6 @@ let config = AlternatorConfig::builder()
     .build();
 ```
 
-> **Note:** `RoutingScope::from_cluster()` currently routes only within a
-> single datacenter, not the whole cluster. See [issue #38](https://github.com/scylladb/alternator-client-rust/issues/38).
-
-
 ### Scope fallbacks
 
 A scope can be narrow enough that no nodes match it — for example, a specific rack that has no live nodes at the moment. In that case the client uses the configured fallback scope instead. Fallbacks are explicit and chainable:
@@ -186,7 +182,7 @@ let scope = RoutingScope::from_rack("dc1".to_string(), "rack1".to_string())
 The first one says:
 - prefer `rack1` of `dc1`
 - if no nodes there, use any node in `dc1`
-- if still nothing, use any node Alternator returns
+- if still nothing, use any live node discovered in the cluster
 
 The client walks the chain from preferred to broadest, picking the first scope that has live nodes.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,8 +119,8 @@ impl AlternatorConfig {
     /// This function can be used multiple times to create a chain of fallback scopes.
     /// Requests will always be routed to the most preferred scope in the chain with available nodes.
     ///
-    /// If this is not provided, the client will use the cluster scope, meaning load balancing will happen across nodes in the datacenter of the seed host.
-    /// If multiple seed hosts are provided, it will use the datacenter of one of the seed hosts, falling back to a different one if needed.
+    /// If this is not provided, the client will use the cluster scope, meaning load balancing will happen across live nodes in all discovered datacenters.
+    /// Cluster scope requires at least one working seed host from every datacenter that should receive traffic.
     ///
     /// Keep in mind that subsequent fallback scope should ideally be broader than or equal to the
     /// previous one, e.g., (rack -> datacenter -> cluster) or (rack -> another rack -> datacenter -> cluster).
@@ -326,8 +326,8 @@ impl AlternatorBuilder {
     /// This function can be used multiple times to create a chain of fallback scopes.
     /// Requests will always be routed to the most preferred scope in the chain with available nodes.
     ///
-    /// If this is not provided, the client will use the cluster scope, meaning load balancing will happen across nodes in the datacenter of the seed host.
-    /// If multiple seed hosts are provided, it will use the datacenter of one of the seed hosts, falling back to a different one if needed.
+    /// If this is not provided, the client will use the cluster scope, meaning load balancing will happen across live nodes in all discovered datacenters.
+    /// Cluster scope requires at least one working seed host from every datacenter that should receive traffic.
     ///
     /// Keep in mind that subsequent fallback scope should ideally be broader than or equal to the
     /// previous one, e.g., (rack -> datacenter -> cluster) or (rack -> another rack -> datacenter -> cluster).
@@ -347,8 +347,8 @@ impl AlternatorBuilder {
     /// This function can be used multiple times to create a chain of fallback scopes.
     /// Requests will always be routed to the most preferred scope in the chain with available nodes.
     ///
-    /// If this is not provided, the client will use the cluster scope, meaning load balancing will happen across nodes in the datacenter of the seed host.
-    /// If multiple seed hosts are provided, it will use the datacenter of one of the seed hosts, falling back to a different one if needed.
+    /// If this is not provided, the client will use the cluster scope, meaning load balancing will happen across live nodes in all discovered datacenters.
+    /// Cluster scope requires at least one working seed host from every datacenter that should receive traffic.
     ///
     /// Keep in mind that subsequent fallback scope should ideally be broader than or equal to the
     /// previous one, e.g., (rack -> datacenter -> cluster) or (rack -> another rack -> datacenter -> cluster).

--- a/src/live_nodes.rs
+++ b/src/live_nodes.rs
@@ -34,6 +34,11 @@
 //! - If the queue is exhausted without a successful response, it is populated with
 //!   the seed nodes, and the process repeats. If the seeds are exhausted without success, the refresh ends with no changes.
 //!
+//! For cluster-wide scope, the refresh queries `/localnodes` from configured
+//! seed nodes and already-known live nodes, then unions the responses. To cover
+//! all datacenters, the initial configuration must include at least one working
+//! seed host from every datacenter that should receive traffic.
+//!
 //! Once it successfully gets a non-empty response, it atomically updates the [`live_nodes`] list using [`ArcSwap`].
 //!
 //!  # Lifetime
@@ -162,6 +167,67 @@ impl LiveNodes {
         Ok(url)
     }
 
+    async fn fetch_live_nodes_for_scope(
+        &self,
+        scope: &RoutingScope,
+        node_addr: &Url,
+    ) -> Option<Vec<Arc<Url>>> {
+        let url = scope.build_localnodes_url(node_addr.clone());
+        let mut nodes = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .ok()?
+            .json::<Vec<String>>()
+            .await
+            .ok()?;
+
+        nodes.sort();
+        Some(
+            nodes
+                .into_iter()
+                .filter_map(|addr| self.host_to_uri(&addr).ok().map(Arc::new))
+                .collect(),
+        )
+    }
+
+    fn cluster_discovery_candidates(&self) -> Vec<Arc<Url>> {
+        let mut candidates = self.live_nodes.load().as_ref().clone();
+        candidates.extend(self.seed_urls.iter().cloned());
+        candidates.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        candidates.dedup_by(|a, b| a.as_str() == b.as_str());
+        candidates.shuffle(&mut rand::rng());
+        candidates
+    }
+
+    async fn discover_cluster_live_nodes(&self) -> Option<Vec<Arc<Url>>> {
+        let scope = RoutingScope::from_cluster();
+        let mut new_nodes = Vec::new();
+        let mut got_response = false;
+
+        for node_addr in self.cluster_discovery_candidates() {
+            if node_is_in_list(&node_addr, &new_nodes) {
+                continue;
+            }
+
+            if let Some(mut nodes) = self.fetch_live_nodes_for_scope(&scope, &node_addr).await {
+                got_response = true;
+                new_nodes.append(&mut nodes);
+                new_nodes.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+                new_nodes.dedup_by(|a, b| a.as_str() == b.as_str());
+            }
+        }
+
+        if !got_response {
+            return None;
+        }
+
+        new_nodes.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        new_nodes.dedup_by(|a, b| a.as_str() == b.as_str());
+        Some(new_nodes)
+    }
+
     /// Ensures the background discovery task is running.
     ///
     /// Idempotent and safe to call from any context: returns immediately if
@@ -274,33 +340,36 @@ impl LiveNodes {
         let mut using_seeds = false;
 
         while let Some(node_addr) = candidates.pop_front() {
-            let url = scope.build_localnodes_url((*node_addr).clone());
-            let result = async {
-                self.client
-                    .get(url)
-                    .send()
-                    .await
-                    .ok()?
-                    .json::<Vec<String>>()
-                    .await
-                    .ok()
+            if scope.is_cluster() {
+                let Some(new_nodes) = self.discover_cluster_live_nodes().await else {
+                    return;
+                };
+
+                if new_nodes.is_empty() {
+                    let Some(fallback) = scope.fallback() else {
+                        return;
+                    };
+                    scope = fallback;
+                    candidates.push_back(node_addr);
+                    continue;
+                }
+
+                if **self.live_nodes.load() != new_nodes {
+                    self.live_nodes.store(Arc::new(new_nodes));
+                }
+                return;
             }
-            .await;
+
+            let result = self.fetch_live_nodes_for_scope(scope, &node_addr).await;
 
             // Request failed: try the next candidate, or fall back to seeds.
-            let Some(mut nodes) = result else {
+            let Some(new_nodes) = result else {
                 if candidates.is_empty() && !using_seeds {
                     using_seeds = true;
                     candidates = self.seed_urls.clone().into();
                 }
                 continue;
             };
-
-            nodes.sort();
-            let new_nodes: Vec<Arc<Url>> = nodes
-                .into_iter()
-                .filter_map(|addr| self.host_to_uri(&addr).ok().map(Arc::new))
-                .collect();
 
             // Empty result: retry under a fallback scope if one exists.
             if new_nodes.is_empty() {
@@ -318,6 +387,13 @@ impl LiveNodes {
             return;
         }
     }
+}
+
+fn node_is_in_list(node: &Url, nodes: &[Arc<Url>]) -> bool {
+    nodes.iter().any(|known| {
+        known.host_str() == node.host_str()
+            && known.port_or_known_default() == node.port_or_known_default()
+    })
 }
 
 impl Drop for LiveNodes {

--- a/src/routing_scope.rs
+++ b/src/routing_scope.rs
@@ -11,9 +11,12 @@ pub struct RoutingScope {
 }
 
 impl RoutingScope {
-    /// Note that the cluster scope does not actually mean that client will use the whole cluster, but rather that it
-    /// won't specify any datacenter or rack. This means that load balancing will happen across nodes in the datacenter of
-    /// the node that it queried for local nodes, so one of the seed hosts or the nodes that it knew at the moment of fallback.
+    /// Routes across the whole cluster.
+    ///
+    /// The client queries `/localnodes` on configured seed hosts and
+    /// already-known live nodes, then unions the returned node lists.
+    /// Provide at least one working seed host from every datacenter that should
+    /// receive traffic.
     pub fn from_cluster() -> Self {
         Self {
             dc: None,
@@ -80,6 +83,10 @@ impl RoutingScope {
             }
         }
         base_url
+    }
+
+    pub(crate) fn is_cluster(&self) -> bool {
+        self.dc.is_none() && self.rack.is_none()
     }
 
     pub fn fallback(&self) -> Option<&RoutingScope> {

--- a/tests/load_balancing/load_balancing_tests.rs
+++ b/tests/load_balancing/load_balancing_tests.rs
@@ -107,6 +107,36 @@ async fn update_item(client: &AlternatorClient, table_name: &str, item: &str, ne
         .await;
 }
 
+fn create_client_with_scope_and_seed_hosts(
+    cluster: &Cluster,
+    scope: RoutingScope,
+    seed_hosts: Vec<String>,
+) -> AlternatorClient {
+    AlternatorClient::from_conf(
+        minimal_builder()
+            .scheme("http")
+            .port(cluster.nodes()[0].alternator_port)
+            .seed_hosts(seed_hosts)
+            .routing_scope(scope)
+            .build(),
+    )
+}
+
+fn first_working_seed_per_datacenter(cluster: &Cluster) -> Vec<String> {
+    cluster
+        .datacenters()
+        .iter()
+        .filter_map(|datacenter| {
+            datacenter
+                .racks()
+                .iter()
+                .flat_map(|rack| rack.nodes().iter())
+                .find(|node| node.is_up)
+                .map(|node| node.ip.clone())
+        })
+        .collect()
+}
+
 fn create_client_with_scope_and_affinity(
     cluster: &Cluster,
     scope: RoutingScope,
@@ -573,6 +603,31 @@ async fn calls_correct_rack_scope_test() {
             .get_posts_to_other_ips(scope_utils::ips_in_scope(cluster, &scope).as_slice()),
         0
     );
+}
+
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn calls_correct_cluster_scope_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+
+    let request_counter = RequestCounter::from_cluster(cluster);
+    start_proxies(cluster, PROXY_PORT, &request_counter).await;
+
+    let scope = RoutingScope::from_cluster();
+    let client = create_client_with_scope_and_seed_hosts(
+        cluster,
+        scope.clone(),
+        first_working_seed_per_datacenter(cluster),
+    );
+    let live_node_ips = scope_utils::working_nodes_ips_in_scope(cluster, &scope);
+
+    wait_until_live_nodes_match(&client, live_node_ips.clone()).await;
+
+    request_counter.reset();
+    make_n_calls(&client, live_node_ips.len()).await;
+
+    assert_round_robin_counts(&request_counter, &live_node_ips, "cluster scope");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #94.

## Summary
- Make cluster-wide routing scope aggregate bare `/localnodes` responses from configured seed hosts and already-known live nodes.
- Skip candidates already covered by a successful `/localnodes` response, so one non-empty response per covered datacenter is enough.
- Skip failed candidates; a failed node only prevents covering its datacenter if no other configured seed or already-known live node from that datacenter replies.
- Require/document at least one working seed host from every datacenter that should receive traffic.
- Preserve existing datacenter/rack scope behavior, including fallback-chain handling.
- Add CCM load-balancing coverage for cluster scope using one working seed per datacenter.
- Checked whether the same issue affects datacenter/rack scopes: the existing remote-scope CCM tests pass, so no separate issue was opened.

## Testing
- `cargo check`
- `cargo test --lib`
- `RUSTFLAGS='--cfg ccm_tests' cargo test --test load_balancing_tests calls_correct_datacenter_scope_test -- --nocapture`
- `RUSTFLAGS='--cfg ccm_tests' cargo test --test load_balancing_tests calls_correct_rack_scope_test -- --nocapture`
- `RUSTFLAGS='--cfg ccm_tests' cargo test --test load_balancing_tests calls_correct_cluster_scope_test -- --nocapture`
- `cargo test` was previously attempted, but the existing `http_content_tests` all failed immediately with `ConnectionRefused` from `tests/common/proxy.rs` while connecting to the test backend.