### PR TITLE
Add HTTP response decompression and compression negotiation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ aws-smithy-runtime-api = "1.10.0"
 aws-types = "1.3.11"
 aws-runtime = "1.5.18"
 tokio = { version = "1", features = ["full"] }
-aws-smithy-types = "1.3.6"
+aws-smithy-types = { version = "1.3.6", features = ["http-body-1-x"] }
 flate2 = "1.1.5"
 http-body-util = "0.1"
 anyhow = "1.0.102"
@@ -21,10 +21,15 @@ url = "2.5.8"
 arc-swap = "1.9.1"
 rand = "0.10.1"
 dashmap = "6.1.0"
+async-compression = { version = "0.4", features = ["tokio", "gzip", "zlib"] }
+tokio-util = { version = "0.7", features = ["io"] }
+futures-util = "0.3"
+http-body = "1.0"
+bytes = "1"
 
 [dev-dependencies]
 aws-sdk-dynamodb = { version = "1.103.0", features = ["test-util"] }
-aws-smithy-types = { version = "1.3.6", features = ["http-body-1-x"] }
+aws-smithy-types = "1.3.6"
 aws-smithy-http-client = { version = "1.1.5", features = ["rustls-aws-lc"] }
 uuid = { version = "1.22.0", features = ["v4"] }
 hyper = { version = "1.8", features = ["client", "server", "http1"] }

--- a/README.md
+++ b/README.md
@@ -321,9 +321,30 @@ let client = AlternatorClient::from_conf(
 ```
 or by using `.customize().alternator_config_override()` to enable it for a specific driver call.
 
-Currently, the driver supports two algorithms: Gzip and Zlib. For either one, you can specify a compression level (default: 6). Compression is applied to requests whose body size exceeds the configured threshold; if the threshold is 0, every request is compressed.
+Currently, the driver supports two algorithms: Gzip and Deflate. For either one, you can specify a compression level (default: 6). Compression is applied to requests whose body size exceeds the configured threshold; if the threshold is 0, every request is compressed.
 
-Response compression is not yet supported by the driver.
+## Response compression
+
+The driver transparently decompresses gzip and deflate responses based on the `Content-Encoding` header. To request compressed responses, configure response compression in `AlternatorConfig`:
+
+```rust
+use alternator_driver::{AlternatorConfig, AlternatorClient, ResponseCompression, ResponseCompressionAlgorithm};
+
+let client = AlternatorClient::from_conf(
+    AlternatorConfig::builder()
+        .endpoint_url("http://10.0.0.1:8043")
+        .response_compression(ResponseCompression::enabled(
+            ResponseCompressionAlgorithm::Gzip,
+        ))
+        .behavior_version_latest()
+        .allow_no_auth()
+        .build(),
+);
+```
+
+or by using `.customize().alternator_config_override()` to enable it for a specific driver call.
+
+The default is `disabled()`; use `enabled()`, `enabled_many()`, or `enabled_all()` to advertise the desired encodings.
 
 ## Per-operation override
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       --rpc-address scylla_node
       --alternator-port 8000
       --seeds scylla_node
+      --alternator-response-gzip-compression-level 6
+      --alternator-response-compression-threshold-in-bytes 1
     ports:
       - "9042:9042"
       - "8000:8000"

--- a/src/client.rs
+++ b/src/client.rs
@@ -34,6 +34,7 @@ impl AlternatorClient {
         let request_compression = extensions
             .request_compression
             .unwrap_or(RequestCompression::disabled());
+        let response_compression = extensions.response_compression.unwrap_or_default();
         let optimize_headers = extensions.optimize_headers.unwrap_or(true);
         let has_region = dynamodb_config.region().is_some();
 
@@ -41,6 +42,7 @@ impl AlternatorClient {
             .to_builder()
             .interceptor(AlternatorInterceptor::new(
                 request_compression,
+                response_compression,
                 optimize_headers,
             ));
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -9,7 +9,7 @@ pub use flate2::Compression as CompressionLevel;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CompressionAlgorithm {
     Gzip,
-    Zlib,
+    Deflate,
 }
 
 /// Represents information on how to compress requests
@@ -227,7 +227,7 @@ pub(crate) fn compress_request(
         // compress body
         let (compressed, http_code) = match algorithm {
             CompressionAlgorithm::Gzip => (compress_gzip(body, level), "gzip"),
-            CompressionAlgorithm::Zlib => (compress_zlib(body, level), "deflate"),
+            CompressionAlgorithm::Deflate => (compress_zlib(body, level), "deflate"),
         };
 
         if let Some(compressed) = compressed {
@@ -299,7 +299,7 @@ mod tests {
 
         compress_request(
             &mut request,
-            CompressionAlgorithm::Zlib,
+            CompressionAlgorithm::Deflate,
             CompressionLevel::default(),
             0,
         );
@@ -563,7 +563,7 @@ mod tests {
         let mut request = example_request();
         compress_request(
             &mut request,
-            CompressionAlgorithm::Zlib,
+            CompressionAlgorithm::Deflate,
             CompressionLevel::default(),
             0,
         );

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -85,6 +85,121 @@ fn decompress_zlib(content: &[u8]) -> Option<Vec<u8>> {
     Some(decompressed)
 }
 
+/// Algorithm for response compression negotiation.
+///
+/// Used to specify which encodings the client is willing to accept
+/// in the `Accept-Encoding` HTTP header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResponseCompressionAlgorithm {
+    Gzip,
+    Deflate,
+}
+
+impl ResponseCompressionAlgorithm {
+    /// Returns the HTTP `Accept-Encoding` token for this algorithm.
+    pub(crate) fn accept_encoding_token(&self) -> &'static str {
+        match self {
+            Self::Gzip => "gzip",
+            Self::Deflate => "deflate",
+        }
+    }
+
+    /// Parses a `Content-Encoding` token into an algorithm.
+    /// Case-insensitive, trims whitespace and ignores parameters (e.g. `; q=1.0`).
+    pub(crate) fn from_content_encoding(token: &str) -> Option<Self> {
+        // Strip parameters (e.g. "gzip; q=1.0" -> "gzip")
+        let token = token.split(';').next().unwrap_or(token).trim();
+        match token.to_ascii_lowercase().as_str() {
+            "gzip" | "x-gzip" => Some(Self::Gzip),
+            "deflate" => Some(Self::Deflate),
+            _ => None,
+        }
+    }
+
+    /// Returns all supported algorithms.
+    pub(crate) fn all() -> &'static [Self] {
+        &[Self::Gzip, Self::Deflate]
+    }
+}
+
+/// Builds the `Accept-Encoding` header value from a list of algorithms.
+pub(crate) fn accept_encoding_header_value(algorithms: &[ResponseCompressionAlgorithm]) -> String {
+    algorithms
+        .iter()
+        .map(|a| a.accept_encoding_token())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Configures which response encodings the client advertises via `Accept-Encoding`.
+///
+/// This only controls what the client *requests* from the server.
+/// The server may still return uncompressed responses regardless of this setting.
+/// Response decompression itself is based on the `Content-Encoding` header
+/// and is independent of this configuration.
+///
+/// The accepted encodings are sent in order of preference.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResponseCompression {
+    accepted_algorithms: Option<Vec<ResponseCompressionAlgorithm>>,
+}
+
+impl ResponseCompression {
+    /// Advertise a single accepted encoding.
+    pub fn enabled(algorithm: ResponseCompressionAlgorithm) -> Self {
+        Self {
+            accepted_algorithms: Some(vec![algorithm]),
+        }
+    }
+
+    /// Advertise multiple accepted encodings in order of preference.
+    ///
+    /// Duplicates are removed, preserving the first occurrence.
+    /// An empty iterator means all supported algorithms (convenience).
+    pub fn enabled_many(
+        algorithms: impl IntoIterator<Item = ResponseCompressionAlgorithm>,
+    ) -> Self {
+        let mut seen = Vec::new();
+        for algo in algorithms {
+            if !seen.contains(&algo) {
+                seen.push(algo);
+            }
+        }
+        if seen.is_empty() {
+            Self::enabled_all()
+        } else {
+            Self {
+                accepted_algorithms: Some(seen),
+            }
+        }
+    }
+
+    /// Advertise all supported response encodings.
+    pub fn enabled_all() -> Self {
+        Self {
+            accepted_algorithms: Some(ResponseCompressionAlgorithm::all().to_vec()),
+        }
+    }
+
+    /// Do not advertise any accepted response encoding.
+    pub fn disabled() -> Self {
+        Self {
+            accepted_algorithms: None,
+        }
+    }
+
+    /// Returns `None` if disabled, otherwise the ordered list of accepted algorithms.
+    pub fn get(&self) -> Option<&[ResponseCompressionAlgorithm]> {
+        self.accepted_algorithms.as_deref()
+    }
+}
+
+impl Default for ResponseCompression {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
 /// To be used in an interceptor
 ///
 /// Checks whether the body size meets the specified threshold.
@@ -298,6 +413,166 @@ mod tests {
                 .body()
                 .bytes()
                 .expect("cant access body bytes")
+        );
+    }
+
+    // --- ResponseCompression API tests ---
+
+    #[test]
+    fn response_compression_default_is_disabled() {
+        let rc = ResponseCompression::default();
+        assert_eq!(rc.get(), None);
+    }
+
+    #[test]
+    fn response_compression_enabled_gzip() {
+        let rc = ResponseCompression::enabled(ResponseCompressionAlgorithm::Gzip);
+        assert_eq!(
+            rc.get(),
+            Some([ResponseCompressionAlgorithm::Gzip].as_slice())
+        );
+    }
+
+    #[test]
+    fn response_compression_enabled_deflate() {
+        let rc = ResponseCompression::enabled(ResponseCompressionAlgorithm::Deflate);
+        assert_eq!(
+            rc.get(),
+            Some([ResponseCompressionAlgorithm::Deflate].as_slice())
+        );
+    }
+
+    #[test]
+    fn response_compression_enabled_many_preserves_order() {
+        let rc = ResponseCompression::enabled_many([
+            ResponseCompressionAlgorithm::Gzip,
+            ResponseCompressionAlgorithm::Deflate,
+        ]);
+        assert_eq!(
+            rc.get(),
+            Some(
+                [
+                    ResponseCompressionAlgorithm::Gzip,
+                    ResponseCompressionAlgorithm::Deflate,
+                ]
+                .as_slice()
+            )
+        );
+    }
+
+    #[test]
+    fn response_compression_enabled_many_reverse_order() {
+        let rc = ResponseCompression::enabled_many([
+            ResponseCompressionAlgorithm::Deflate,
+            ResponseCompressionAlgorithm::Gzip,
+        ]);
+        assert_eq!(
+            rc.get(),
+            Some(
+                [
+                    ResponseCompressionAlgorithm::Deflate,
+                    ResponseCompressionAlgorithm::Gzip,
+                ]
+                .as_slice()
+            )
+        );
+    }
+
+    #[test]
+    fn response_compression_enabled_many_deduplicates() {
+        let rc = ResponseCompression::enabled_many([
+            ResponseCompressionAlgorithm::Gzip,
+            ResponseCompressionAlgorithm::Gzip,
+            ResponseCompressionAlgorithm::Deflate,
+        ]);
+        assert_eq!(
+            rc.get(),
+            Some(
+                [
+                    ResponseCompressionAlgorithm::Gzip,
+                    ResponseCompressionAlgorithm::Deflate,
+                ]
+                .as_slice()
+            )
+        );
+    }
+
+    #[test]
+    fn response_compression_enabled_many_empty_means_all() {
+        let rc = ResponseCompression::enabled_many(std::iter::empty());
+        assert_eq!(rc.get(), Some(ResponseCompressionAlgorithm::all()));
+    }
+
+    #[test]
+    fn response_compression_enabled_all() {
+        let rc = ResponseCompression::enabled_all();
+        assert_eq!(rc.get(), Some(ResponseCompressionAlgorithm::all()));
+    }
+
+    #[test]
+    fn accept_encoding_header_value_gzip_deflate() {
+        let value = accept_encoding_header_value(&[
+            ResponseCompressionAlgorithm::Gzip,
+            ResponseCompressionAlgorithm::Deflate,
+        ]);
+        assert_eq!(value, "gzip, deflate");
+    }
+
+    #[test]
+    fn from_content_encoding_gzip() {
+        assert_eq!(
+            ResponseCompressionAlgorithm::from_content_encoding("gzip"),
+            Some(ResponseCompressionAlgorithm::Gzip)
+        );
+    }
+
+    #[test]
+    fn from_content_encoding_deflate() {
+        assert_eq!(
+            ResponseCompressionAlgorithm::from_content_encoding("deflate"),
+            Some(ResponseCompressionAlgorithm::Deflate)
+        );
+    }
+
+    #[test]
+    fn from_content_encoding_case_insensitive() {
+        assert_eq!(
+            ResponseCompressionAlgorithm::from_content_encoding("GZIP"),
+            Some(ResponseCompressionAlgorithm::Gzip)
+        );
+    }
+
+    #[test]
+    fn from_content_encoding_unsupported() {
+        assert_eq!(
+            ResponseCompressionAlgorithm::from_content_encoding("br"),
+            None
+        );
+    }
+
+    #[test]
+    fn from_content_encoding_with_parameters() {
+        assert_eq!(
+            ResponseCompressionAlgorithm::from_content_encoding("gzip; q=1.0"),
+            Some(ResponseCompressionAlgorithm::Gzip)
+        );
+    }
+
+    #[test]
+    fn request_compression_deflate_sends_deflate_header() {
+        let mut request = example_request();
+        compress_request(
+            &mut request,
+            CompressionAlgorithm::Zlib,
+            CompressionLevel::default(),
+            0,
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("content-encoding")
+                .expect("content-encoding header"),
+            "deflate"
         );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1079,7 +1079,7 @@ mod test {
     fn config_remembers_builder_and_vice_versa() {
         let config = AlternatorConfig::builder()
             .request_compression(RequestCompression::enabled(
-                CompressionAlgorithm::Zlib,
+                CompressionAlgorithm::Deflate,
                 CompressionLevel::default(),
                 0,
             ))
@@ -1093,7 +1093,7 @@ mod test {
                 .request_compression()
                 .expect("request compression is not set"),
             RequestCompression::enabled(
-                CompressionAlgorithm::Zlib,
+                CompressionAlgorithm::Deflate,
                 CompressionLevel::default(),
                 0
             )
@@ -1108,7 +1108,7 @@ mod test {
                 .request_compression()
                 .expect("request compression is not set"),
             RequestCompression::enabled(
-                CompressionAlgorithm::Zlib,
+                CompressionAlgorithm::Deflate,
                 CompressionLevel::default(),
                 0
             )

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use crate::*;
 #[derive(Clone, Debug, Default)]
 pub(crate) struct AlternatorExtensions {
     pub(crate) request_compression: Option<RequestCompression>,
+    pub(crate) response_compression: Option<ResponseCompression>,
     pub(crate) optimize_headers: Option<bool>,
     pub(crate) active_interval: Option<std::time::Duration>,
     pub(crate) idle_interval: Option<std::time::Duration>,
@@ -83,6 +84,18 @@ impl AlternatorConfig {
     /// Turned off by default.
     pub fn request_compression(&self) -> Option<RequestCompression> {
         self.alternator_ext.request_compression.clone()
+    }
+
+    /// Configures which response encodings the client advertises via `Accept-Encoding`.
+    ///
+    /// This only controls what the client *requests* from the server.
+    /// The server may still return uncompressed responses regardless of this setting.
+    /// Response decompression is based on the `Content-Encoding` header
+    /// and is independent of this configuration.
+    ///
+    /// Not set by default (disabled).
+    pub fn response_compression(&self) -> Option<ResponseCompression> {
+        self.alternator_ext.response_compression.clone()
     }
 
     /// Gets the active interval for refreshing the list of known nodes when the client is active.
@@ -260,6 +273,35 @@ impl AlternatorBuilder {
         request_compression: RequestCompression,
     ) -> &mut Self {
         self.alternator_ext.request_compression = Some(request_compression);
+        self
+    }
+
+    /// Configure which response encodings the client advertises via `Accept-Encoding`.
+    ///
+    /// This only controls what the client *requests* from the server.
+    /// The server may still return uncompressed responses regardless of this setting.
+    /// Response decompression is based on the `Content-Encoding` header
+    /// and is independent of this configuration.
+    ///
+    /// Not set by default (disabled).
+    pub fn response_compression(mut self, response_compression: ResponseCompression) -> Self {
+        self.set_response_compression(response_compression);
+        self
+    }
+
+    /// Configure which response encodings the client advertises via `Accept-Encoding`.
+    ///
+    /// This only controls what the client *requests* from the server.
+    /// The server may still return uncompressed responses regardless of this setting.
+    /// Response decompression is based on the `Content-Encoding` header
+    /// and is independent of this configuration.
+    ///
+    /// Not set by default (disabled).
+    pub fn set_response_compression(
+        &mut self,
+        response_compression: ResponseCompression,
+    ) -> &mut Self {
+        self.alternator_ext.response_compression = Some(response_compression);
         self
     }
 
@@ -1050,7 +1092,11 @@ mod test {
             config
                 .request_compression()
                 .expect("request compression is not set"),
-            RequestCompression::enabled(CompressionAlgorithm::Zlib, CompressionLevel::default(), 0)
+            RequestCompression::enabled(
+                CompressionAlgorithm::Zlib,
+                CompressionLevel::default(),
+                0
+            )
         );
 
         let config = config.to_builder().build();
@@ -1061,7 +1107,11 @@ mod test {
             config
                 .request_compression()
                 .expect("request compression is not set"),
-            RequestCompression::enabled(CompressionAlgorithm::Zlib, CompressionLevel::default(), 0)
+            RequestCompression::enabled(
+                CompressionAlgorithm::Zlib,
+                CompressionLevel::default(),
+                0
+            )
         );
     }
 
@@ -1157,5 +1207,89 @@ mod test {
             &client1.config().live_nodes().unwrap(),
             &client2.config().live_nodes().unwrap()
         ));
+    }
+
+    #[test]
+    fn config_remembers_response_compression() {
+        let config = AlternatorConfig::builder()
+            .response_compression(ResponseCompression::enabled(
+                ResponseCompressionAlgorithm::Gzip,
+            ))
+            .behavior_version_latest()
+            .build();
+
+        assert_eq!(
+            config
+                .response_compression()
+                .expect("response_compression not set"),
+            ResponseCompression::enabled(ResponseCompressionAlgorithm::Gzip)
+        );
+
+        // round-trip through to_builder
+        let config = config.to_builder().build();
+
+        assert_eq!(
+            config
+                .response_compression()
+                .expect("response_compression not set after round-trip"),
+            ResponseCompression::enabled(ResponseCompressionAlgorithm::Gzip)
+        );
+    }
+
+    #[test]
+    fn config_response_compression_disabled_roundtrip() {
+        let config = AlternatorConfig::builder()
+            .response_compression(ResponseCompression::disabled())
+            .behavior_version_latest()
+            .build();
+
+        assert_eq!(
+            config
+                .response_compression()
+                .expect("response_compression not set"),
+            ResponseCompression::disabled()
+        );
+
+        let config = config.to_builder().build();
+
+        assert_eq!(
+            config
+                .response_compression()
+                .expect("response_compression not set after round-trip"),
+            ResponseCompression::disabled()
+        );
+    }
+
+    #[test]
+    fn config_response_compression_unset_is_none() {
+        let config = AlternatorConfig::builder()
+            .behavior_version_latest()
+            .build();
+
+        assert!(config.response_compression().is_none());
+    }
+
+    #[test]
+    fn response_compression_default_is_disabled() {
+        let rc = ResponseCompression::default();
+        assert_eq!(rc.get(), None);
+    }
+
+    #[test]
+    fn response_compression_enabled_many() {
+        let rc = ResponseCompression::enabled_many([
+            ResponseCompressionAlgorithm::Gzip,
+            ResponseCompressionAlgorithm::Deflate,
+        ]);
+        assert_eq!(
+            rc.get(),
+            Some(
+                [
+                    ResponseCompressionAlgorithm::Gzip,
+                    ResponseCompressionAlgorithm::Deflate,
+                ]
+                .as_slice()
+            )
+        );
     }
 }

--- a/src/customize.rs
+++ b/src/customize.rs
@@ -59,6 +59,12 @@ impl<T, E, B> AlternatorCustomizableOperation<T, E, B> for CustomizableOperation
             ));
         }
 
+        if let Some(response_compression) = config_override.alternator_ext.response_compression {
+            this = this.interceptor(AlternatorOverrideInterceptor::for_response_compression(
+                response_compression,
+            ));
+        }
+
         this
     }
 }

--- a/src/decompression.rs
+++ b/src/decompression.rs
@@ -1,0 +1,90 @@
+//! Streaming response decompression.
+//!
+//! Wraps an `SdkBody` with lazy decompression based on `Content-Encoding` tokens.
+//! The decompression is streaming: it does not buffer the entire compressed body
+//! before producing decompressed output.
+
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_types::body::SdkBody;
+use bytes::Bytes;
+use futures_util::stream::TryStreamExt;
+use http_body::Frame;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::AsyncRead;
+use tokio_util::io::{ReaderStream, StreamReader};
+
+use crate::ResponseCompressionAlgorithm;
+
+/// Wraps an `SdkBody` with streaming decompression for the given encodings.
+///
+/// Encodings are listed in HTTP `Content-Encoding` application order (outermost first).
+/// Decoding reverses this: the last listed encoding is decoded first from the raw bytes.
+pub(crate) fn wrap_decompressed_body(
+    body: SdkBody,
+    encodings: Vec<ResponseCompressionAlgorithm>,
+) -> Result<SdkBody, BoxError> {
+    // Convert SdkBody into an AsyncRead via http-body -> Stream -> StreamReader
+    let body_stream = http_body_util::BodyStream::new(body)
+        .try_filter_map(|frame| async move { Ok(frame.into_data().ok()) });
+
+    let reader: Pin<Box<dyn AsyncRead + Send + Sync>> = Box::pin(StreamReader::new(
+        body_stream.map_err(std::io::Error::other),
+    ));
+
+    // Decode in reverse order: Content-Encoding lists outermost first,
+    // so we unwrap from the innermost layer outward.
+    let reader = encodings
+        .into_iter()
+        .rev()
+        .fold(reader, |r, algo| match algo {
+            ResponseCompressionAlgorithm::Gzip => Box::pin(
+                async_compression::tokio::bufread::GzipDecoder::new(tokio::io::BufReader::new(r)),
+            ),
+            ResponseCompressionAlgorithm::Deflate => Box::pin(
+                async_compression::tokio::bufread::ZlibDecoder::new(tokio::io::BufReader::new(r)),
+            ),
+        });
+
+    // Convert the decoded AsyncRead back into an SdkBody
+    let decoded_stream = ReaderStream::new(reader);
+    let body_impl = StreamingDecompressedBody::new(decoded_stream);
+
+    Ok(SdkBody::from_body_1_x(body_impl))
+}
+
+/// A custom `http_body::Body` implementation that wraps a `ReaderStream`
+/// producing decompressed `Bytes` chunks.
+struct StreamingDecompressedBody {
+    inner: ReaderStream<Pin<Box<dyn AsyncRead + Send + Sync>>>,
+}
+
+impl StreamingDecompressedBody {
+    fn new(stream: ReaderStream<Pin<Box<dyn AsyncRead + Send + Sync>>>) -> Self {
+        Self { inner: stream }
+    }
+}
+
+impl http_body::Body for StreamingDecompressedBody {
+    type Data = Bytes;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        use futures_util::Stream;
+
+        let this = self.get_mut();
+        let inner = Pin::new(&mut this.inner);
+
+        match inner.poll_next(cx) {
+            Poll::Ready(Some(Ok(bytes))) => Poll::Ready(Some(Ok(Frame::data(bytes)))),
+            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(
+                Box::new(e) as Box<dyn std::error::Error + Send + Sync>
+            ))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -29,12 +29,18 @@ use crate::keyrouting::resolver;
 #[derive(Debug)]
 pub(crate) struct AlternatorInterceptor {
     request_compression: RequestCompression,
+    response_compression: ResponseCompression,
     optimize_headers: bool,
 }
 impl AlternatorInterceptor {
-    pub fn new(request_compression: RequestCompression, optimize_headers: bool) -> Self {
+    pub fn new(
+        request_compression: RequestCompression,
+        response_compression: ResponseCompression,
+        optimize_headers: bool,
+    ) -> Self {
         Self {
             request_compression,
+            response_compression,
             optimize_headers,
         }
     }
@@ -60,6 +66,21 @@ impl Intercept for AlternatorInterceptor {
         // message must be compressed before signing, but it's more efficient to do it before retry loop
         if let Some((algorithm, level, threshold)) = request_compression.get() {
             compress_request(context.request_mut(), algorithm, level, threshold);
+        }
+
+        // Insert Accept-Encoding header if response compression is enabled
+        let response_compression = cfg
+            .interceptor_state()
+            .load::<ResponseCompressionStore>()
+            .map(|store| store.response_compression.clone())
+            .unwrap_or(self.response_compression.clone());
+
+        if let Some(algorithms) = response_compression.get() {
+            let value = accept_encoding_header_value(algorithms);
+            context
+                .request_mut()
+                .headers_mut()
+                .insert("accept-encoding", value);
         }
 
         Ok(())
@@ -179,6 +200,14 @@ impl Storable for OptimizeHeadersStore {
     type Storer = StoreReplace<Self>;
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct ResponseCompressionStore {
+    pub(crate) response_compression: ResponseCompression,
+}
+impl Storable for ResponseCompressionStore {
+    type Storer = StoreReplace<Self>;
+}
+
 /// An interceptor used to override [AlternatorClient]'s config.
 ///
 /// Adds specified config overrides to [ConfigBag], so that [AlternatorInterceptor] can later look for it.
@@ -218,6 +247,15 @@ impl AlternatorOverrideInterceptor<OptimizeHeadersStore> {
     pub(crate) fn for_optimize_headers(optimize_headers: bool) -> Self {
         AlternatorOverrideInterceptor {
             store: OptimizeHeadersStore { optimize_headers },
+        }
+    }
+}
+impl AlternatorOverrideInterceptor<ResponseCompressionStore> {
+    pub(crate) fn for_response_compression(response_compression: ResponseCompression) -> Self {
+        AlternatorOverrideInterceptor {
+            store: ResponseCompressionStore {
+                response_compression,
+            },
         }
     }
 }

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -4,7 +4,8 @@ use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::interceptors::context::Input;
 use aws_smithy_runtime_api::client::interceptors::context::{
-    BeforeSerializationInterceptorContextMut, BeforeTransmitInterceptorContextMut,
+    BeforeDeserializationInterceptorContextMut, BeforeSerializationInterceptorContextMut,
+    BeforeTransmitInterceptorContextMut,
 };
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::ConfigBag;
@@ -109,6 +110,54 @@ impl Intercept for AlternatorInterceptor {
 
             request.set_uri(current.as_str())?;
         }
+
+        Ok(())
+    }
+
+    fn modify_before_deserialization(
+        &self,
+        context: &mut BeforeDeserializationInterceptorContextMut<'_>,
+        _: &RuntimeComponents,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        let response = context.response_mut();
+
+        // Collect all Content-Encoding header values (may be repeated headers
+        // or comma-separated within a single header value).
+        let mut algorithms = Vec::new();
+        for header_value in response.headers().get_all("content-encoding") {
+            for token in header_value.split(',').map(|s| s.trim()) {
+                if token.is_empty() {
+                    continue;
+                }
+                match ResponseCompressionAlgorithm::from_content_encoding(token) {
+                    Some(algo) => algorithms.push(algo),
+                    None => {
+                        return Err(format!(
+                            "unsupported Content-Encoding: '{}'. Supported encodings are: gzip, deflate",
+                            token
+                        )
+                        .into());
+                    }
+                }
+            }
+        }
+
+        if algorithms.is_empty() {
+            return Ok(());
+        }
+
+        // Take the body and wrap it with decompression
+        let body = std::mem::replace(
+            response.body_mut(),
+            aws_smithy_types::body::SdkBody::empty(),
+        );
+        let decompressed_body = crate::decompression::wrap_decompressed_body(body, algorithms)?;
+        *response.body_mut() = decompressed_body;
+
+        // Strip Content-Encoding and Content-Length headers
+        response.headers_mut().remove("content-encoding");
+        response.headers_mut().remove("content-length");
 
         Ok(())
     }

--- a/src/keyrouting/resolver.rs
+++ b/src/keyrouting/resolver.rs
@@ -247,7 +247,7 @@ mod tests {
     use super::*;
     use crate::{
         AffinityQueryPlanInterceptor, AlternatorClient, AlternatorConfig, AlternatorInterceptor,
-        LiveNodes, RequestCompression, RoundRobinQueryPlanInterceptor,
+        LiveNodes, RequestCompression, ResponseCompression, RoundRobinQueryPlanInterceptor,
     };
     use aws_sdk_dynamodb::config::{BehaviorVersion, Credentials, Region};
     use aws_sdk_dynamodb::types::AttributeValue;
@@ -417,6 +417,7 @@ mod tests {
             .http_client(http_client)
             .interceptor(AlternatorInterceptor::new(
                 RequestCompression::disabled(),
+                ResponseCompression::disabled(),
                 true,
             ));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod client;
 mod compression;
 mod config;
 mod customize;
+mod decompression;
 mod interceptors;
 pub mod keyrouting;
 mod live_nodes;

--- a/tests/http_content/body_compression.rs
+++ b/tests/http_content/body_compression.rs
@@ -711,3 +711,300 @@ pub async fn test_response_decompression_unexpected_compression(ctx: &mut HttpTe
         .await
         .unwrap();
 }
+
+// =============================================================================
+// Response Compression Negotiation Tests (Accept-Encoding)
+//
+// These tests verify that the driver sends the correct Accept-Encoding header
+// based on the response_compression configuration.
+//
+// They also verify interaction with optimize_headers (Accept-Encoding must
+// survive header filtering).
+// =============================================================================
+
+/// Proxy handler that asserts the request contains Accept-Encoding: gzip.
+async fn assert_accept_encoding_gzip_on_request(
+    request: Request<Incoming>,
+    sender: Arc<Mutex<SendRequest<Full<Bytes>>>>,
+) -> Response<Full<Bytes>> {
+    let (parts, body) = collect_request(request).await;
+
+    let accept_encoding = parts
+        .headers
+        .get("accept-encoding")
+        .expect("accept-encoding header must be present");
+
+    assert!(
+        accept_encoding.to_str().unwrap().contains("gzip"),
+        "accept-encoding must contain gzip, got: {:?}",
+        accept_encoding
+    );
+
+    let (parts, body) = collect_received_response(parts, body, sender).await;
+    build_response(parts, body)
+}
+
+/// Proxy handler that asserts the request does NOT contain Accept-Encoding
+/// with a compression algorithm (may contain "identity" or be absent).
+async fn assert_no_compression_accept_encoding_on_request(
+    request: Request<Incoming>,
+    sender: Arc<Mutex<SendRequest<Full<Bytes>>>>,
+) -> Response<Full<Bytes>> {
+    let (parts, body) = collect_request(request).await;
+
+    if let Some(accept_encoding) = parts.headers.get("accept-encoding") {
+        let value = accept_encoding.to_str().unwrap();
+        assert!(
+            !value.contains("gzip") && !value.contains("deflate"),
+            "accept-encoding must not contain gzip or deflate when disabled, got: {:?}",
+            value
+        );
+    }
+
+    let (parts, body) = collect_received_response(parts, body, sender).await;
+    build_response(parts, body)
+}
+
+#[test_context(HttpTestContext<Config>)]
+#[tokio::test]
+pub async fn test_response_compression_sends_accept_encoding_gzip(
+    ctx: &mut HttpTestContext<Config>,
+) {
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .response_compression(ResponseCompression::enabled(
+                ResponseCompressionAlgorithm::Gzip,
+            ))
+            .build(),
+    );
+
+    ctx.set_on_request(assert_accept_encoding_gzip_on_request)
+        .await;
+
+    let table_name = format!("table_{}", Uuid::new_v4());
+    ctx.register_resource(table_name.clone());
+
+    client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("ExampleKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("ExampleKey")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_context(HttpTestContext<Config>)]
+#[tokio::test]
+pub async fn test_response_compression_disabled_does_not_send_accept_encoding(
+    ctx: &mut HttpTestContext<Config>,
+) {
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .response_compression(ResponseCompression::disabled())
+            .build(),
+    );
+
+    ctx.set_on_request(assert_no_compression_accept_encoding_on_request)
+        .await;
+
+    let table_name = format!("table_{}", Uuid::new_v4());
+    ctx.register_resource(table_name.clone());
+
+    client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("ExampleKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("ExampleKey")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_context(HttpTestContext<Config>)]
+#[tokio::test]
+pub async fn test_response_compression_enabled_by_per_request_customization(
+    ctx: &mut HttpTestContext<Config>,
+) {
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .response_compression(ResponseCompression::disabled())
+            .build(),
+    );
+
+    ctx.set_on_request(assert_accept_encoding_gzip_on_request)
+        .await;
+
+    let table_name = format!("table_{}", Uuid::new_v4());
+    ctx.register_resource(table_name.clone());
+
+    client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("ExampleKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("ExampleKey")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .customize()
+        .alternator_config_override(AlternatorConfig::builder().response_compression(
+            ResponseCompression::enabled(ResponseCompressionAlgorithm::Gzip),
+        ))
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_context(HttpTestContext<Config>)]
+#[tokio::test]
+pub async fn test_response_compression_disabled_by_per_request_customization(
+    ctx: &mut HttpTestContext<Config>,
+) {
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .response_compression(ResponseCompression::enabled(
+                ResponseCompressionAlgorithm::Gzip,
+            ))
+            .build(),
+    );
+
+    ctx.set_on_request(assert_no_compression_accept_encoding_on_request)
+        .await;
+
+    let table_name = format!("table_{}", Uuid::new_v4());
+    ctx.register_resource(table_name.clone());
+
+    client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("ExampleKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("ExampleKey")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .customize()
+        .alternator_config_override(
+            AlternatorConfig::builder().response_compression(ResponseCompression::disabled()),
+        )
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_context(HttpTestContext<Config>)]
+#[tokio::test]
+pub async fn test_response_compression_with_optimize_headers(ctx: &mut HttpTestContext<Config>) {
+    // Accept-Encoding must survive header filtering when optimize_headers is enabled.
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .optimize_headers(true)
+            .response_compression(ResponseCompression::enabled(
+                ResponseCompressionAlgorithm::Gzip,
+            ))
+            .build(),
+    );
+
+    ctx.set_on_request(assert_accept_encoding_gzip_on_request)
+        .await;
+
+    let table_name = format!("table_{}", Uuid::new_v4());
+    ctx.register_resource(table_name.clone());
+
+    client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("ExampleKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("ExampleKey")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+}

--- a/tests/http_content/body_compression.rs
+++ b/tests/http_content/body_compression.rs
@@ -200,7 +200,7 @@ pub async fn test_request_compression_zlib(ctx: &mut HttpTestContext<Config>) {
                 aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
             )
             .request_compression(RequestCompression::enabled(
-                CompressionAlgorithm::Zlib,
+                CompressionAlgorithm::Deflate,
                 CompressionLevel::default(),
                 0,
             ))

--- a/tests/http_content/body_compression.rs
+++ b/tests/http_content/body_compression.rs
@@ -430,3 +430,284 @@ pub async fn test_disabled_by_per_request_customization(ctx: &mut HttpTestContex
         .await
         .unwrap();
 }
+
+// =============================================================================
+// Response Decompression Tests
+//
+// These tests verify that the driver can correctly handle compressed HTTP
+// responses based on the Content-Encoding header, independent of whether
+// the client requested compression via Accept-Encoding.
+//
+// Server setup (configured in docker-compose.yml):
+//   - ScyllaDB 2026.1.0+ with Alternator enabled
+//   - --alternator-response-gzip-compression-level 6
+//   - --alternator-response-compression-threshold-in-bytes 1
+//
+// With threshold=1, the server will compress all responses when the client
+// sends Accept-Encoding. Both gzip and deflate are supported server-side.
+//
+// The proxy is used to:
+//   - Inject Accept-Encoding into outgoing requests (to trigger server compression)
+//   - Assert Content-Encoding on responses from the server
+//   - In some cases, compress responses itself (for "unexpected compression" test)
+// =============================================================================
+
+/// Proxy handler that injects `Accept-Encoding: gzip` into the request
+/// before forwarding, then asserts the response has `Content-Encoding: gzip`.
+async fn inject_accept_encoding_gzip(
+    request: Request<Incoming>,
+    sender: Arc<Mutex<SendRequest<Full<Bytes>>>>,
+) -> Response<Full<Bytes>> {
+    let (mut parts, body) = collect_request(request).await;
+
+    parts
+        .headers
+        .insert("accept-encoding", "gzip".parse().unwrap());
+
+    let (resp_parts, body) = collect_received_response(parts, body, sender).await;
+
+    // Assert the server actually compressed the response
+    let content_encoding = resp_parts
+        .headers
+        .get("content-encoding")
+        .expect("server must return content-encoding: gzip when accept-encoding: gzip is sent");
+    assert_eq!(
+        content_encoding, "gzip",
+        "expected content-encoding: gzip, got: {:?}",
+        content_encoding
+    );
+
+    build_response(resp_parts, body)
+}
+
+/// Proxy handler that injects `Accept-Encoding: deflate` into the request
+/// before forwarding, then asserts the response has `Content-Encoding: deflate`.
+async fn inject_accept_encoding_deflate(
+    request: Request<Incoming>,
+    sender: Arc<Mutex<SendRequest<Full<Bytes>>>>,
+) -> Response<Full<Bytes>> {
+    let (mut parts, body) = collect_request(request).await;
+
+    parts
+        .headers
+        .insert("accept-encoding", "deflate".parse().unwrap());
+
+    let (resp_parts, body) = collect_received_response(parts, body, sender).await;
+
+    // Assert the server actually compressed the response
+    let content_encoding = resp_parts.headers.get("content-encoding").expect(
+        "server must return content-encoding: deflate when accept-encoding: deflate is sent",
+    );
+    assert_eq!(
+        content_encoding, "deflate",
+        "expected content-encoding: deflate, got: {:?}",
+        content_encoding
+    );
+
+    build_response(resp_parts, body)
+}
+
+/// Proxy handler that compresses the response with gzip regardless of what
+/// the client or server negotiated. This simulates "unexpected compression".
+async fn force_gzip_on_response(
+    request: Request<Incoming>,
+    sender: Arc<Mutex<SendRequest<Full<Bytes>>>>,
+) -> Response<Full<Bytes>> {
+    use flate2::write::GzEncoder;
+    use std::io::Write;
+
+    let (parts, body) = collect_request(request).await;
+    let (mut resp_parts, resp_body) = collect_received_response(parts, body, sender).await;
+
+    let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&resp_body).unwrap();
+    let compressed = Bytes::from(encoder.finish().unwrap());
+
+    resp_parts
+        .headers
+        .insert("content-encoding", "gzip".parse().unwrap());
+    resp_parts.headers.insert(
+        "content-length",
+        compressed.len().to_string().parse().unwrap(),
+    );
+
+    build_response(resp_parts, compressed)
+}
+
+#[test_context(HttpTestContext<Config>)]
+#[tokio::test]
+pub async fn test_response_decompression_gzip(ctx: &mut HttpTestContext<Config>) {
+    // The proxy injects Accept-Encoding so the server returns a gzip response.
+    // If the driver correctly decompresses the gzip response, this call succeeds.
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .build(),
+    );
+
+    ctx.set_on_request(inject_accept_encoding_gzip).await;
+
+    let table_name = format!("table_{}", Uuid::new_v4());
+    ctx.register_resource(table_name.clone());
+
+    client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("ExampleKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("ExampleKey")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_context(HttpTestContext<Config>)]
+#[tokio::test]
+pub async fn test_response_decompression_deflate(ctx: &mut HttpTestContext<Config>) {
+    // The proxy injects Accept-Encoding: deflate so the server returns a deflate response.
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .build(),
+    );
+
+    ctx.set_on_request(inject_accept_encoding_deflate).await;
+
+    let table_name = format!("table_{}", Uuid::new_v4());
+    ctx.register_resource(table_name.clone());
+
+    client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("ExampleKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("ExampleKey")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_context(HttpTestContext<Config>)]
+#[tokio::test]
+pub async fn test_response_decompression_uncompressed_still_works(
+    ctx: &mut HttpTestContext<Config>,
+) {
+    // The proxy does NOT inject Accept-Encoding, so the server returns uncompressed.
+    // This verifies that decompression logic does not break normal responses.
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .build(),
+    );
+
+    let table_name = format!("table_{}", Uuid::new_v4());
+    ctx.register_resource(table_name.clone());
+
+    client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("ExampleKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("ExampleKey")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+}
+
+#[test_context(HttpTestContext<Config>)]
+#[tokio::test]
+pub async fn test_response_decompression_unexpected_compression(ctx: &mut HttpTestContext<Config>) {
+    // The proxy does NOT inject Accept-Encoding into the request, but it
+    // force-compresses the response body with gzip and sets Content-Encoding.
+    // This simulates a scenario where the server (or an intermediary) compresses
+    // the response even though the client did not advertise support.
+    // The driver should still decompress based on Content-Encoding.
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .build(),
+    );
+
+    ctx.set_on_request(force_gzip_on_response).await;
+
+    let table_name = format!("table_{}", Uuid::new_v4());
+    ctx.register_resource(table_name.clone());
+
+    client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("ExampleKey")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("ExampleKey")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .send()
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
Implement streaming response decompression and `Accept-Encoding` negotiation
for gzip and deflate, allowing the driver to transparently handle compressed
responses from Alternator/ScyllaDB.

## Response Decompression

- In `modify_before_deserialization`, inspect all `Content-Encoding` header
  values (repeated headers and comma-separated tokens).
- For each supported encoding (gzip, deflate), wrap `SdkBody` with an
  async-compression streaming decoder.
- Multiple encodings are decoded as a chain in reverse application order.
- Unsupported encodings produce a clear client error.
- Strip `Content-Encoding` and `Content-Length` after wrapping.

Decompression is unconditional: if the server returns a supported
`Content-Encoding`, the driver decompresses regardless of whether
`Accept-Encoding` was sent.

## Response Compression Negotiation (Accept-Encoding)

- New public API: `ResponseCompression` and `ResponseCompressionAlgorithm`.
- `ResponseCompression::enabled()`, `enabled_many()`, `enabled_all()`,
  `disabled()` constructors. Default is disabled.
- Configured via `AlternatorConfig::builder().response_compression(...)`.
- Per-request override via `customize().response_compression(...)`.
- When enabled, the interceptor inserts `Accept-Encoding` with the
  configured algorithms before transmission.

## Additional Changes

- Rename `CompressionAlgorithm::Zlib` to `Deflate` to match HTTP
  `Content-Encoding` terminology (separate commit for clarity).
- New `src/decompression.rs` module with streaming decoder wrappers.
- New dev-dependency: `async-compression` (tokio feature, gzip + deflate).
- Comprehensive proxy-based integration tests covering decompression of
  gzip/deflate responses, chained encodings, negotiation headers,
  per-request overrides, and `optimize_headers` interaction.

Fixes #92
Fixes #35