### PR TITLE
Clean up Alternator public API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,26 @@ async fn main() {
 }
 ```
 
-When no credentials provider is configured, `AlternatorClient` enables no-auth automatically. Clients with a credentials provider continue to sign requests through the AWS SDK. Alternator supports only SigV4 with static credentials or no-auth; custom AWS SDK auth schemes, auth scheme preferences, and auth scheme resolvers are rejected. Use `require_auth()` when a client without default credentials should require signed per-request credentials instead of falling back to no-auth.
+When no credentials provider is configured, `AlternatorClient` enables no-auth automatically. Clients with a credentials provider continue to sign requests through the AWS SDK. Alternator supports no-auth and SigV4 signing through configured or per-request credentials; custom AWS SDK auth schemes, auth scheme preferences, and auth scheme resolvers are not exposed. Use `require_auth()` when a client without default credentials should require signed per-request credentials instead of falling back to no-auth.
 
 This client targets ScyllaDB Alternator. It does not guarantee that Alternator-specific configuration, no-auth defaults, or request optimizations remain compatible with AWS DynamoDB itself.
+
+### Supported configuration surface
+
+Build clients with `AlternatorConfig::builder()` and set Alternator behavior explicitly. The driver intentionally does not import shared `aws_types::SdkConfig` values, because shared SDK config can contain AWS-specific auth and endpoint settings that do not map cleanly to Alternator.
+
+There is no `AlternatorClient::new(&SdkConfig)`, `AlternatorConfig::new(&SdkConfig)`, or `AlternatorConfig::from(&SdkConfig)` shortcut. Start from `AlternatorConfig::builder()` and copy only the supported SDK settings your client needs, such as `region(...)`, `credentials_provider(...)`, `retry_config(...)`, `timeout_config(...)`, `http_client(...)`, `app_name(...)`, or `interceptor(...)`.
+
+Supported auth modes are:
+- no-auth, enabled automatically when no credentials provider is configured, or explicitly with `allow_no_auth()`
+- SigV4 with a credentials provider configured through `credentials_provider(...)`
+- SigV4 with per-request credentials, usually with a client built using `require_auth()`
+
+The driver does not expose AWS custom auth schemes, auth scheme resolvers, auth scheme preferences, account ID endpoint mode, FIPS endpoints, dual-stack endpoints, or custom endpoint resolvers. These APIs are intentionally absent rather than accepted and ignored. Use `endpoint_url(...)` or the Alternator-specific `scheme(...)`, `port(...)`, and `seed_hosts(...)` settings for discovery and client-side routing.
+
+Advanced SDK knobs such as retry settings, timeout settings, HTTP clients, identity cache, and interceptors remain available as escape hatches. Interceptors run alongside the driver's routing, compression, decompression, and header optimization interceptors, so keep ordering effects in mind when using them.
+
+Operation builders are DynamoDB SDK passthroughs for source compatibility, but Alternator support is server-dependent. AWS-only surfaces such as backup/PITR/export/import, global tables, Kinesis streaming destinations, contributor insights, resource policies, tagging, `describe_endpoints`, `describe_limits`, PartiQL, and replica auto-scaling may fail against Alternator unless the server explicitly supports them.
 
 ## Load balancing
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,8 @@ use crate::*;
 
 /// Alternator driver's client
 ///
-/// A simple wrapper around [aws_sdk_dynamodb::Client], that adds hooks with alternator-specific optimizations.
+/// A client wrapper around [aws_sdk_dynamodb::Client] that adds Alternator
+/// routing, auth defaults, and request/response optimizations.
 ///
 /// By default:
 /// - enables round-robin load balancing
@@ -20,6 +21,14 @@ use crate::*;
 ///     .build();
 ///
 /// let client = AlternatorClient::from_conf(config);
+/// ```
+///
+/// Shared `aws_types::SdkConfig` imports are intentionally unsupported. Build
+/// an [`AlternatorConfig`] explicitly and pass it to [`from_conf`](Self::from_conf).
+///
+/// ```compile_fail
+/// let sdk_config = aws_types::SdkConfig::builder().build();
+/// let _ = alternator_driver::AlternatorClient::new(&sdk_config);
 /// ```
 #[derive(Clone, Debug)]
 pub struct AlternatorClient {
@@ -124,10 +133,6 @@ impl AlternatorClient {
         live_nodes: std::sync::Arc<LiveNodes>,
     ) -> Self {
         Self::from_conf(config.to_builder().live_nodes(live_nodes).build())
-    }
-
-    pub fn new(sdk_config: &aws_types::sdk_config::SdkConfig) -> Self {
-        Self::from_conf(AlternatorConfig::from(sdk_config))
     }
 
     pub fn config(&self) -> &AlternatorConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,13 +26,7 @@ pub(crate) struct AlternatorExtensions {
     pub(crate) key_route_affinity: Option<keyrouting::affinity_config::KeyRouteAffinityConfig>,
 }
 
-const UNSUPPORTED_AUTH_API_MESSAGE: &str = "Alternator supports only SigV4 with static credentials or no-auth. Use credentials_provider(...), per-request config_override(...credentials_provider(...)) with require_auth() for strict signed requests, or allow_no_auth() for unsigned requests. Custom AWS SDK auth schemes, auth scheme resolvers, and auth scheme preferences are not supported.";
-
 const INCOMPATIBLE_AUTH_OPTIONS_MESSAGE: &str = "require_auth() cannot be combined with allow_no_auth(): require_auth() makes missing credentials fail before sending an unsigned request, while allow_no_auth() explicitly permits unsigned requests.";
-
-fn unsupported_auth_api(api: &str) -> ! {
-    panic!("{api} is not supported by alternator-driver: {UNSUPPORTED_AUTH_API_MESSAGE}");
-}
 
 fn incompatible_auth_options() -> ! {
     panic!("{INCOMPATIBLE_AUTH_OPTIONS_MESSAGE}");
@@ -40,7 +34,15 @@ fn incompatible_auth_options() -> ! {
 
 /// [AlternatorClient]'s config
 ///
-/// A simple wrapper around [aws_sdk_dynamodb::Config], that also includes alternator-specific optimizations.
+/// Stores the AWS DynamoDB config used internally by the driver plus
+/// Alternator-specific routing, auth, and request/response settings.
+///
+/// Build this explicitly with [`AlternatorConfig::builder()`]. Shared
+/// `aws_types::SdkConfig` values are not imported wholesale because they can
+/// contain AWS auth and endpoint options that Alternator does not support.
+/// There is intentionally no `AlternatorConfig::new(&SdkConfig)` or
+/// `From<&SdkConfig>` conversion; copy only the supported SDK settings you need
+/// onto the builder.
 ///
 /// It is used to construct [AlternatorClient] like so:
 ///
@@ -53,6 +55,13 @@ fn incompatible_auth_options() -> ! {
 ///     .build();
 ///
 /// let client = AlternatorClient::from_conf(config);
+/// ```
+///
+/// Shared SDK config imports are intentionally unsupported:
+///
+/// ```compile_fail
+/// let sdk_config = aws_types::SdkConfig::builder().build();
+/// let _ = alternator_driver::AlternatorConfig::from(&sdk_config);
 /// ```
 #[derive(Clone, Debug)]
 pub struct AlternatorConfig {
@@ -73,10 +82,6 @@ impl AlternatorConfig {
             dynamodb_builder: self.dynamodb_config.to_builder(),
             alternator_ext: self.alternator_ext.clone(),
         }
-    }
-
-    pub fn new(config: &aws_types::sdk_config::SdkConfig) -> Self {
-        AlternatorBuilder::from(config).build()
     }
 
     /// Before sending each request, strip headers that Alternator does not use
@@ -302,7 +307,16 @@ impl AlternatorOperationBuilder {
 
 /// Builder for [AlternatorConfig]
 ///
-/// A simple wrapper around [aws_sdk_dynamodb::config::Builder], that also includes alternator-specific optimizations.
+/// Builder for the supported Alternator configuration surface.
+///
+/// This includes Alternator-specific options plus AWS SDK settings that remain
+/// meaningful for Alternator clients. AWS-specific auth schemes, auth scheme
+/// preferences, custom endpoint resolvers, FIPS endpoints, dual-stack
+/// endpoints, and account ID endpoint mode are intentionally not exposed.
+/// Use [`endpoint_url`](Self::endpoint_url) or the Alternator-specific
+/// [`scheme`](Self::scheme), [`port`](Self::port), and
+/// [`seed_hosts`](Self::seed_hosts) settings for discovery and client-side
+/// routing.
 ///
 /// It is used to construct [AlternatorClient] like so:
 ///
@@ -712,29 +726,7 @@ impl AlternatorBuilder {
     }
 }
 
-impl From<&aws_types::sdk_config::SdkConfig> for AlternatorBuilder {
-    fn from(sdk_config: &aws_types::sdk_config::SdkConfig) -> Self {
-        let has_credentials_provider = sdk_config.credentials_provider().is_some();
-        if sdk_config.auth_scheme_preference().is_some() {
-            unsupported_auth_api("auth_scheme_preference");
-        }
-        AlternatorBuilder {
-            dynamodb_builder: aws_sdk_dynamodb::config::Builder::from(sdk_config),
-            alternator_ext: AlternatorExtensions {
-                has_credentials_provider,
-                ..Default::default()
-            },
-        }
-    }
-}
-
-impl From<&aws_types::sdk_config::SdkConfig> for AlternatorConfig {
-    fn from(sdk_config: &aws_types::sdk_config::SdkConfig) -> Self {
-        AlternatorBuilder::from(sdk_config).build()
-    }
-}
-
-// All implementations below this point should only be simple wrappers around dynamodb methods
+// All implementations below this point are supported AWS SDK passthroughs.
 
 impl AlternatorConfig {
     pub fn stalled_stream_protection(
@@ -745,24 +737,6 @@ impl AlternatorConfig {
 
     pub fn http_client(&self) -> Option<aws_sdk_dynamodb::config::SharedHttpClient> {
         self.dynamodb_config.http_client()
-    }
-
-    pub fn auth_schemes(
-        &self,
-    ) -> impl Iterator<Item = aws_smithy_runtime_api::client::auth::SharedAuthScheme> {
-        self.dynamodb_config.auth_schemes()
-    }
-
-    pub fn auth_scheme_resolver(
-        &self,
-    ) -> Option<aws_smithy_runtime_api::client::auth::SharedAuthSchemeOptionResolver> {
-        self.dynamodb_config.auth_scheme_resolver()
-    }
-
-    pub fn endpoint_resolver(
-        &self,
-    ) -> aws_smithy_runtime_api::client::endpoint::SharedEndpointResolver {
-        self.dynamodb_config.endpoint_resolver()
     }
 
     pub fn retry_config(&self) -> Option<&aws_smithy_types::retry::RetryConfig> {
@@ -859,27 +833,6 @@ impl AlternatorBuilder {
         self
     }
 
-    pub fn push_auth_scheme(
-        self,
-        _auth_scheme: impl aws_smithy_runtime_api::client::auth::AuthScheme + 'static,
-    ) -> Self {
-        unsupported_auth_api("push_auth_scheme")
-    }
-
-    pub fn auth_scheme_resolver(
-        self,
-        _auth_scheme_resolver: impl aws_sdk_dynamodb::config::auth::ResolveAuthScheme + 'static,
-    ) -> Self {
-        unsupported_auth_api("auth_scheme_resolver")
-    }
-
-    pub fn set_auth_scheme_resolver(
-        &mut self,
-        _auth_scheme_resolver: impl aws_sdk_dynamodb::config::auth::ResolveAuthScheme + 'static,
-    ) -> &mut Self {
-        unsupported_auth_api("set_auth_scheme_resolver")
-    }
-
     /// Require every request made by a client built from this config to use credentials.
     ///
     /// By default, an Alternator client with no default credentials enables the AWS SDK's no-auth
@@ -932,23 +885,6 @@ impl AlternatorBuilder {
         }
         self.alternator_ext.allow_no_auth = true;
         self.dynamodb_builder.set_allow_no_auth();
-        self
-    }
-
-    pub fn endpoint_resolver(
-        mut self,
-        endpoint_resolver: impl aws_sdk_dynamodb::config::endpoint::ResolveEndpoint + 'static,
-    ) -> Self {
-        self.dynamodb_builder = self.dynamodb_builder.endpoint_resolver(endpoint_resolver);
-        self
-    }
-
-    pub fn set_endpoint_resolver(
-        &mut self,
-        endpoint_resolver: Option<aws_smithy_runtime_api::client::endpoint::SharedEndpointResolver>,
-    ) -> &mut Self {
-        self.dynamodb_builder
-            .set_endpoint_resolver(endpoint_resolver);
         self
     }
 
@@ -1122,25 +1058,6 @@ impl AlternatorBuilder {
         self
     }
 
-    pub fn account_id_endpoint_mode(
-        mut self,
-        account_id_endpoint_mode: aws_types::endpoint_config::AccountIdEndpointMode,
-    ) -> Self {
-        self.dynamodb_builder = self
-            .dynamodb_builder
-            .account_id_endpoint_mode(account_id_endpoint_mode);
-        self
-    }
-
-    pub fn set_account_id_endpoint_mode(
-        &mut self,
-        account_id_endpoint_mode: Option<aws_types::endpoint_config::AccountIdEndpointMode>,
-    ) -> &mut Self {
-        self.dynamodb_builder
-            .set_account_id_endpoint_mode(account_id_endpoint_mode);
-        self
-    }
-
     pub fn endpoint_url(mut self, endpoint_url: impl Into<String>) -> Self {
         self.set_endpoint_url(Some(endpoint_url.into()));
         self
@@ -1163,26 +1080,6 @@ impl AlternatorBuilder {
             }
         }
         self.dynamodb_builder.set_endpoint_url(endpoint_url);
-        self
-    }
-
-    pub fn use_dual_stack(mut self, use_dual_stack: impl Into<bool>) -> Self {
-        self.dynamodb_builder = self.dynamodb_builder.use_dual_stack(use_dual_stack);
-        self
-    }
-
-    pub fn set_use_dual_stack(&mut self, use_dual_stack: Option<bool>) -> &mut Self {
-        self.dynamodb_builder.set_use_dual_stack(use_dual_stack);
-        self
-    }
-
-    pub fn use_fips(mut self, use_fips: impl Into<bool>) -> Self {
-        self.dynamodb_builder = self.dynamodb_builder.use_fips(use_fips);
-        self
-    }
-
-    pub fn set_use_fips(&mut self, use_fips: Option<bool>) -> &mut Self {
-        self.dynamodb_builder.set_use_fips(use_fips);
         self
     }
 
@@ -1328,35 +1225,15 @@ mod test {
     }
 
     #[test]
-    fn shared_sdk_config_credentials_provider_is_remembered() {
-        let sdk_config = aws_types::SdkConfig::builder()
-            .credentials_provider(aws_sdk_dynamodb::config::SharedCredentialsProvider::new(
+    fn explicit_builder_credentials_provider_is_remembered() {
+        let config = AlternatorConfig::builder()
+            .credentials_provider(
                 aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
-            ))
+            )
+            .behavior_version_latest()
             .build();
-
-        let config = AlternatorConfig::from(&sdk_config);
 
         assert!(config.has_credentials_provider());
-    }
-
-    #[test]
-    fn shared_sdk_config_without_credentials_provider_is_no_auth() {
-        let sdk_config = aws_types::SdkConfig::builder().build();
-
-        let config = AlternatorConfig::from(&sdk_config);
-
-        assert!(!config.has_credentials_provider());
-    }
-
-    #[test]
-    #[should_panic(expected = "auth_scheme_preference is not supported by alternator-driver")]
-    fn shared_sdk_config_auth_scheme_preference_reports_unsupported_api() {
-        let sdk_config = aws_types::SdkConfig::builder()
-            .auth_scheme_preference([aws_runtime::auth::sigv4::SCHEME_ID])
-            .build();
-
-        let _ = AlternatorConfig::from(&sdk_config);
     }
 
     #[test]
@@ -1399,14 +1276,6 @@ mod test {
     #[should_panic(expected = "require_auth() cannot be combined with allow_no_auth()")]
     fn allow_no_auth_after_require_auth_panics() {
         let _ = AlternatorConfig::builder().require_auth().allow_no_auth();
-    }
-
-    #[test]
-    #[should_panic(expected = "Alternator supports only SigV4 with static credentials or no-auth")]
-    fn unsupported_auth_scheme_resolver_panics() {
-        let _ = AlternatorConfig::builder().auth_scheme_resolver(
-            aws_sdk_dynamodb::config::auth::DefaultAuthSchemeResolver::default(),
-        );
     }
 
     #[test]

--- a/tests/dynamodb_compatibility.rs
+++ b/tests/dynamodb_compatibility.rs
@@ -154,7 +154,10 @@ fn test_client() {
     let alternator_client_methods = collect_struct_methods(alternator_driver, "AlternatorClient");
     let dynamodb_client_methods = collect_struct_methods(dynamodb, "Client");
 
-    let unimplemented = dynamodb_client_methods.difference(&alternator_client_methods);
+    let mut with_exceptions = dynamodb_client_methods;
+    with_exceptions.remove(&(None, "new".into())); // use AlternatorClient::from_conf with explicit AlternatorConfig
+
+    let unimplemented = with_exceptions.difference(&alternator_client_methods);
     let all_implemented = unimplemented.clone().next().is_none();
     assert!(
         all_implemented,
@@ -175,8 +178,12 @@ fn test_config() {
 
     // allow exceptions
     let mut with_exceptions = dynamodb_config_methods;
+    with_exceptions.remove(&(None, "new".into())); // shared SdkConfig imports hide AWS settings that do not map to Alternator
     with_exceptions.remove(&(None, "credentials_provider".into())); // credentials_provider is deprecated and always returns None
     with_exceptions.remove(&(None, "auth_scheme_preference".into())); // use AlternatorBuilder::require_auth instead of AWS auth preference hints
+    with_exceptions.remove(&(None, "auth_schemes".into())); // custom AWS auth schemes are not supported by Alternator
+    with_exceptions.remove(&(None, "auth_scheme_resolver".into()));
+    with_exceptions.remove(&(None, "endpoint_resolver".into())); // custom endpoint resolution conflicts with client-side routing
 
     let unimplemented = with_exceptions.difference(&alternator_config_methods);
     let all_implemented = unimplemented.clone().next().is_none();
@@ -209,6 +216,17 @@ fn test_builder() {
     with_exceptions.remove(&(None, "idempotency_token_provider".into()));
     with_exceptions.remove(&(None, "auth_scheme_preference".into())); // use require_auth for strict signed requests
     with_exceptions.remove(&(None, "set_auth_scheme_preference".into()));
+    with_exceptions.remove(&(None, "push_auth_scheme".into())); // custom AWS auth schemes are not supported by Alternator
+    with_exceptions.remove(&(None, "auth_scheme_resolver".into()));
+    with_exceptions.remove(&(None, "set_auth_scheme_resolver".into()));
+    with_exceptions.remove(&(None, "endpoint_resolver".into())); // custom endpoint resolution conflicts with client-side routing
+    with_exceptions.remove(&(None, "set_endpoint_resolver".into()));
+    with_exceptions.remove(&(None, "account_id_endpoint_mode".into())); // AWS account/FIPS/dual-stack endpoint modes do not apply to Alternator
+    with_exceptions.remove(&(None, "set_account_id_endpoint_mode".into()));
+    with_exceptions.remove(&(None, "use_dual_stack".into()));
+    with_exceptions.remove(&(None, "set_use_dual_stack".into()));
+    with_exceptions.remove(&(None, "use_fips".into()));
+    with_exceptions.remove(&(None, "set_use_fips".into()));
 
     let unimplemented = with_exceptions.difference(&alternator_builder_methods);
     let all_implemented = unimplemented.clone().next().is_none();


### PR DESCRIPTION
## Summary
- remove shared `SdkConfig` import constructors and `From<&SdkConfig>` conversions in favor of explicit `AlternatorConfig::builder()` setup
- remove unsupported AWS auth/custom endpoint/FIPS/dual-stack/account endpoint passthroughs from the Alternator config surface
- document the supported auth/configuration boundary, server-dependent DynamoDB operation passthroughs, and narrowed per-operation override semantics
- update rustdoc compatibility tests with intentional AWS SDK parity exceptions

Refs #101

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib`
- `cargo test --test dynamodb_compatibility`
- `cargo test --doc`
- `make test`