### PR TITLE
DRIVER-563: add Alternator user-agent handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,14 +298,67 @@ let client = AlternatorClient::from_conf(
 
 `.key_route_affinity(...)` accepts either a `KeyRouteAffinityType` (for the simple case) or a full `KeyRouteAffinityConfig` (for pre-configured tables). The two forms are interchangeable at the call site — pick whichever matches your needs.
 
+## User-Agent
+
+By default, the client replaces the AWS SDK `User-Agent` header with an Alternator client token:
+
+```text
+scylladb-alternator-client-rust/<version>
+```
+
+You can replace it exactly:
+
+```rust
+use alternator_driver::{AlternatorConfig, AlternatorClient};
+
+let client = AlternatorClient::from_conf(
+    AlternatorConfig::builder()
+        .endpoint_url("http://10.0.0.1:8043")
+        .user_agent("orders-service/1.0")
+        .behavior_version_latest()
+        .build(),
+);
+```
+
+You can derive a value from the default:
+
+```rust
+use alternator_driver::{AlternatorConfig, AlternatorClient, UserAgent};
+
+let client = AlternatorClient::from_conf(
+    AlternatorConfig::builder()
+        .endpoint_url("http://10.0.0.1:8043")
+        .user_agent(UserAgent::transform(|default| {
+            format!("{default} orders-service/1.0")
+        }))
+        .behavior_version_latest()
+        .build(),
+);
+```
+
+Or disable it:
+
+```rust
+use alternator_driver::{AlternatorConfig, AlternatorClient};
+
+let client = AlternatorClient::from_conf(
+    AlternatorConfig::builder()
+        .endpoint_url("http://10.0.0.1:8043")
+        .without_user_agent()
+        .behavior_version_latest()
+        .build(),
+);
+```
+
 ## Header stripping
 
-By default, the AWS Rust SDK attaches a number of headers to every DynamoDB request — some are required for signed requests (`Host`, `Authorization`, `X-Amz-Date`, etc.), others are SDK metadata that Alternator doesn't use (`User-Agent` flavors, internal telemetry, retry information). For a small client-side optimization, this crate strips non-essential headers before transmission, keeping only the ones Alternator actually needs:
+By default, the AWS Rust SDK attaches a number of headers to every DynamoDB request — some are required for signed requests (`Host`, `Authorization`, `X-Amz-Date`, etc.), others are SDK metadata that Alternator doesn't use (`User-Agent` flavors, internal telemetry, retry information). For a small client-side optimization, this crate strips non-essential headers before transmission, then writes the configured final `User-Agent`. Optimized requests keep only:
 - `host`
 - `x-amz-target`
 - `content-length`
 - `accept-encoding`
 - `content-encoding`
+- `user-agent` unless disabled with `without_user_agent()`
 
 For signed requests, it also keeps:
 - `authorization`

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,6 +36,7 @@ impl AlternatorClient {
             .unwrap_or(RequestCompression::disabled());
         let response_compression = extensions.response_compression.unwrap_or_default();
         let optimize_headers = extensions.optimize_headers.unwrap_or(true);
+        let user_agent = extensions.user_agent.unwrap_or_default();
         let has_credentials_provider = config.has_credentials_provider();
         let has_region = dynamodb_config.region().is_some();
 
@@ -49,6 +50,7 @@ impl AlternatorClient {
             request_compression,
             response_compression,
             optimize_headers,
+            user_agent,
             has_credentials_provider,
         ));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub(crate) struct AlternatorExtensions {
     pub(crate) request_compression: Option<RequestCompression>,
     pub(crate) response_compression: Option<ResponseCompression>,
     pub(crate) optimize_headers: Option<bool>,
+    pub(crate) user_agent: Option<UserAgent>,
     pub(crate) has_credentials_provider: bool,
     pub(crate) require_auth: bool,
     pub(crate) allow_no_auth: bool,
@@ -86,6 +87,13 @@ impl AlternatorConfig {
     /// Turned on by default.
     pub fn optimize_headers(&self) -> Option<bool> {
         self.alternator_ext.optimize_headers
+    }
+
+    /// Gets the configured final `User-Agent` behavior.
+    ///
+    /// If this is [`None`], the client sends [`DEFAULT_USER_AGENT`].
+    pub fn user_agent(&self) -> Option<&UserAgent> {
+        self.alternator_ext.user_agent.as_ref()
     }
 
     /// Enable / disable request compression.
@@ -273,6 +281,37 @@ impl AlternatorBuilder {
     /// Turned on by default.
     pub fn set_optimize_headers(&mut self, optimize: bool) -> &mut Self {
         self.alternator_ext.optimize_headers = Some(optimize);
+        self
+    }
+
+    /// Configure the final `User-Agent` header sent by the client.
+    ///
+    /// By default, the client sends [`DEFAULT_USER_AGENT`]. Passing a string
+    /// replaces it exactly. Use [`UserAgent::transform`] to derive a custom
+    /// value from the default, or [`UserAgent::disabled`] to send no
+    /// `User-Agent` header.
+    pub fn user_agent(mut self, user_agent: impl Into<UserAgent>) -> Self {
+        self.set_user_agent(Some(user_agent.into()));
+        self
+    }
+
+    /// Configure the final `User-Agent` header sent by the client.
+    ///
+    /// Setting this to [`None`] restores the default behavior.
+    pub fn set_user_agent(&mut self, user_agent: Option<UserAgent>) -> &mut Self {
+        self.alternator_ext.user_agent = user_agent;
+        self
+    }
+
+    /// Disable the final `User-Agent` header sent by the client.
+    pub fn without_user_agent(mut self) -> Self {
+        self.set_without_user_agent();
+        self
+    }
+
+    /// Disable the final `User-Agent` header sent by the client.
+    pub fn set_without_user_agent(&mut self) -> &mut Self {
+        self.alternator_ext.user_agent = Some(UserAgent::disabled());
         self
     }
 
@@ -1142,6 +1181,7 @@ mod test {
                 CompressionLevel::default(),
                 0,
             ))
+            .user_agent("custom-client/1.2.3")
             .behavior_version_latest()
             .build();
 
@@ -1157,6 +1197,10 @@ mod test {
                 0
             )
         );
+        assert!(matches!(
+            config.user_agent().expect("user agent is not set"),
+            UserAgent::Value(value) if value == "custom-client/1.2.3"
+        ));
 
         let config = config.to_builder().build();
 
@@ -1172,6 +1216,10 @@ mod test {
                 0
             )
         );
+        assert!(matches!(
+            config.user_agent().expect("user agent is not set"),
+            UserAgent::Value(value) if value == "custom-client/1.2.3"
+        ));
     }
 
     #[test]

--- a/src/customize.rs
+++ b/src/customize.rs
@@ -38,6 +38,12 @@ use aws_sdk_dynamodb::client::customize::CustomizableOperation;
 ///     .unwrap();
 /// # });
 /// ```
+///
+/// Only request-scoped settings apply here: request compression, response
+/// compression, header optimization, user-agent handling, and per-request credentials. Client
+/// construction settings such as `require_auth()`, `allow_no_auth()`, endpoint
+/// and seed-host settings, refresh intervals, routing scope, live nodes, and
+/// key-route affinity are ignored as per-operation overrides.
 pub trait AlternatorCustomizableOperation<T, E, B> {
     fn alternator_config_override(self, config_override: impl Into<AlternatorBuilder>) -> Self;
 }
@@ -57,6 +63,10 @@ impl<T, E, B> AlternatorCustomizableOperation<T, E, B> for CustomizableOperation
             this = this.interceptor(AlternatorOverrideInterceptor::for_optimize_headers(
                 optimize_headers,
             ));
+        }
+
+        if let Some(user_agent) = config_override.alternator_ext.user_agent {
+            this = this.interceptor(AlternatorOverrideInterceptor::for_user_agent(user_agent));
         }
 
         if let Some(response_compression) = config_override.alternator_ext.response_compression {

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -31,6 +31,7 @@ pub(crate) struct AlternatorInterceptor {
     request_compression: RequestCompression,
     response_compression: ResponseCompression,
     optimize_headers: bool,
+    user_agent: UserAgent,
     preserve_auth_headers: bool,
 }
 impl AlternatorInterceptor {
@@ -38,12 +39,14 @@ impl AlternatorInterceptor {
         request_compression: RequestCompression,
         response_compression: ResponseCompression,
         optimize_headers: bool,
+        user_agent: UserAgent,
         preserve_auth_headers: bool,
     ) -> Self {
         Self {
             request_compression,
             response_compression,
             optimize_headers,
+            user_agent,
             preserve_auth_headers,
         }
     }
@@ -106,11 +109,17 @@ impl Intercept for AlternatorInterceptor {
             .load::<PreserveAuthHeadersStore>()
             .map(|store| store.preserve_auth_headers)
             .unwrap_or(self.preserve_auth_headers);
+        let user_agent = cfg
+            .interceptor_state()
+            .load::<UserAgentStore>()
+            .map(|store| &store.user_agent)
+            .unwrap_or(&self.user_agent);
 
         // optimize headers
         if optimize_headers {
             strip_headers(context.request_mut(), preserve_auth_headers);
         }
+        apply_user_agent(context.request_mut(), user_agent)?;
 
         Ok(())
     }
@@ -225,6 +234,14 @@ impl Storable for OptimizeHeadersStore {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct UserAgentStore {
+    user_agent: UserAgent,
+}
+impl Storable for UserAgentStore {
+    type Storer = StoreReplace<Self>;
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct ResponseCompressionStore {
     pub(crate) response_compression: ResponseCompression,
 }
@@ -279,6 +296,13 @@ impl AlternatorOverrideInterceptor<OptimizeHeadersStore> {
     pub(crate) fn for_optimize_headers(optimize_headers: bool) -> Self {
         AlternatorOverrideInterceptor {
             store: OptimizeHeadersStore { optimize_headers },
+        }
+    }
+}
+impl AlternatorOverrideInterceptor<UserAgentStore> {
+    pub(crate) fn for_user_agent(user_agent: UserAgent) -> Self {
+        AlternatorOverrideInterceptor {
+            store: UserAgentStore { user_agent },
         }
     }
 }

--- a/src/keyrouting/resolver.rs
+++ b/src/keyrouting/resolver.rs
@@ -248,6 +248,7 @@ mod tests {
     use crate::{
         AffinityQueryPlanInterceptor, AlternatorClient, AlternatorConfig, AlternatorInterceptor,
         LiveNodes, RequestCompression, ResponseCompression, RoundRobinQueryPlanInterceptor,
+        UserAgent,
     };
     use aws_sdk_dynamodb::config::{BehaviorVersion, Credentials, Region};
     use aws_sdk_dynamodb::types::AttributeValue;
@@ -419,6 +420,7 @@ mod tests {
                 RequestCompression::disabled(),
                 ResponseCompression::disabled(),
                 true,
+                UserAgent::default(),
                 true,
             ));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod live_nodes;
 mod optimize_headers;
 mod query_plan;
 mod routing_scope;
+mod user_agent;
 
 pub use crate::client::*;
 pub use crate::compression::*;
@@ -20,3 +21,4 @@ pub(crate) use crate::live_nodes::*;
 pub(crate) use crate::optimize_headers::*;
 pub(crate) use crate::query_plan::*;
 pub use crate::routing_scope::*;
+pub use crate::user_agent::*;

--- a/src/user_agent.rs
+++ b/src/user_agent.rs
@@ -1,0 +1,152 @@
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::http::Request;
+use std::fmt;
+use std::sync::Arc;
+
+pub const DEFAULT_USER_AGENT: &str = concat!(
+    "scylladb-alternator-client-rust/",
+    env!("CARGO_PKG_VERSION")
+);
+
+type UserAgentTransform = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
+
+#[derive(Clone, Default)]
+pub enum UserAgent {
+    #[default]
+    Default,
+    Disabled,
+    Value(String),
+    Transform(UserAgentTransform),
+}
+
+impl UserAgent {
+    pub fn disabled() -> Self {
+        Self::Disabled
+    }
+
+    pub fn value(user_agent: impl Into<String>) -> Self {
+        Self::Value(user_agent.into())
+    }
+
+    pub fn transform<F>(transform: F) -> Self
+    where
+        F: Fn(&str) -> String + Send + Sync + 'static,
+    {
+        Self::Transform(Arc::new(move |default_user_agent| {
+            Some(transform(default_user_agent))
+        }))
+    }
+
+    pub fn transform_optional<F>(transform: F) -> Self
+    where
+        F: Fn(&str) -> Option<String> + Send + Sync + 'static,
+    {
+        Self::Transform(Arc::new(transform))
+    }
+
+    pub(crate) fn resolve(&self) -> Option<String> {
+        match self {
+            Self::Default => Some(DEFAULT_USER_AGENT.to_string()),
+            Self::Disabled => None,
+            Self::Value(user_agent) => Some(user_agent.clone()),
+            Self::Transform(transform) => transform(DEFAULT_USER_AGENT),
+        }
+    }
+}
+
+impl From<String> for UserAgent {
+    fn from(user_agent: String) -> Self {
+        Self::Value(user_agent)
+    }
+}
+
+impl From<&str> for UserAgent {
+    fn from(user_agent: &str) -> Self {
+        Self::Value(user_agent.to_string())
+    }
+}
+
+impl fmt::Debug for UserAgent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Default => f.write_str("UserAgent::Default"),
+            Self::Disabled => f.write_str("UserAgent::Disabled"),
+            Self::Value(value) => f.debug_tuple("UserAgent::Value").field(value).finish(),
+            Self::Transform(_) => f.write_str("UserAgent::Transform(<callback>)"),
+        }
+    }
+}
+
+pub(crate) fn apply_user_agent(
+    request: &mut Request,
+    user_agent: &UserAgent,
+) -> Result<(), BoxError> {
+    let headers = request.headers_mut();
+    headers.remove("user-agent");
+
+    if let Some(user_agent) = user_agent.resolve() {
+        headers.try_insert("user-agent", user_agent)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_user_agent_uses_crate_version() {
+        assert_eq!(
+            DEFAULT_USER_AGENT,
+            concat!(
+                "scylladb-alternator-client-rust/",
+                env!("CARGO_PKG_VERSION")
+            )
+        );
+    }
+
+    #[test]
+    fn user_agent_variants_resolve_final_header_value() {
+        assert_eq!(
+            UserAgent::default().resolve().as_deref(),
+            Some(DEFAULT_USER_AGENT)
+        );
+        assert_eq!(UserAgent::disabled().resolve(), None);
+        assert_eq!(
+            UserAgent::value("my-client/1.2.3").resolve().as_deref(),
+            Some("my-client/1.2.3")
+        );
+        assert_eq!(
+            UserAgent::transform(|default| format!("{default} my-app/4.5.6"))
+                .resolve()
+                .as_deref(),
+            Some(concat!(
+                "scylladb-alternator-client-rust/",
+                env!("CARGO_PKG_VERSION"),
+                " my-app/4.5.6"
+            ))
+        );
+        assert_eq!(UserAgent::transform_optional(|_| None).resolve(), None);
+    }
+
+    #[test]
+    fn apply_user_agent_replaces_existing_user_agent() {
+        let mut request = Request::empty();
+        request.headers_mut().insert("user-agent", "aws-sdk-rust/1");
+
+        apply_user_agent(&mut request, &UserAgent::value("custom/1")).unwrap();
+
+        assert_eq!(request.headers().get("user-agent"), Some("custom/1"));
+    }
+
+    #[test]
+    fn apply_user_agent_removes_existing_user_agent_when_disabled() {
+        let mut request = Request::empty();
+        request.headers_mut().insert("user-agent", "aws-sdk-rust/1");
+
+        apply_user_agent(&mut request, &UserAgent::disabled()).unwrap();
+
+        assert!(!request.headers().contains_key("user-agent"));
+    }
+}

--- a/tests/http_content/optimize_headers.rs
+++ b/tests/http_content/optimize_headers.rs
@@ -4,10 +4,10 @@
 //! use from outgoing requests. A proxy is used to intercept messages exchanged
 //! between the driver and Alternator.
 //!
-//! There are eight test cases:
+//! There are eleven test cases:
 //! 1. Without credentials:
 //!    Disable credentials and verify that requests follow this whitelist:
-//!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding"]
+//!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding", "user-agent"]
 //! 2. Without credentials, with injected auth headers:
 //!    Disable credentials, inject auth headers before header stripping, and
 //!    verify that requests still follow the no-auth whitelist.
@@ -21,7 +21,7 @@
 //!    unsigned.
 //! 5. With credentials:
 //!    Enable credentials and verify that requests follow this whitelist:
-//!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding", "authorization", "x-amz-date"]
+//!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding", "user-agent", "authorization", "x-amz-date"]
 //! 6. Whitelist needed:
 //!    Enable credentials, disable header stripping, and verify that
 //!    unnecessary headers are present, confirming that stripping is useful.
@@ -33,10 +33,14 @@
 //!    Enable header stripping in the client config, override it for one call,
 //!    and then make another non-customized call to verify that the override
 //!    does not persist.
+//! 9. Custom User-Agent: Replace the default User-Agent and verify the final optimized request.
+//! 10. Disabled User-Agent: Disable User-Agent and verify the final optimized request omits it.
+//! 11. User-Agent by per-request customization:
+//!     Override User-Agent for one call, then verify a plain call uses the
+//!     client default.
 //!
-//! All tests share the same cleanup function. The first three also share the
-//! same set of driver calls, and the last two share another set of driver
-//! calls.
+//! All tests share the same cleanup function. Several tests share helper
+//! functions for common driver calls.
 //!
 use crate::http_content::driver_utils::*;
 use crate::http_content::http_test::*;
@@ -202,6 +206,7 @@ impl HttpTestConfig for WithoutCredentialsConfig {
             "content-length",
             "accept-encoding",
             "content-encoding",
+            "user-agent",
         ];
 
         let rogue = parts
@@ -215,6 +220,7 @@ impl HttpTestConfig for WithoutCredentialsConfig {
             rogue.unwrap(),
             whitelist
         );
+        assert_eq!(parts.headers.get("user-agent").unwrap(), DEFAULT_USER_AGENT);
         assert!(!parts.headers.contains_key("authorization"));
         assert!(!parts.headers.contains_key("x-amz-date"));
 
@@ -226,6 +232,79 @@ impl HttpTestConfig for WithoutCredentialsConfig {
     async fn cleanup(resources: Vec<String>, alternator_address: &str) {
         cleanup_calls(resources, alternator_address).await;
     }
+}
+
+struct CustomUserAgentConfig;
+impl HttpTestConfig for CustomUserAgentConfig {
+    async fn on_request(
+        request: Request<Incoming>,
+        sender: Arc<Mutex<SendRequest<Full<Bytes>>>>,
+    ) -> Response<Full<Bytes>> {
+        let (parts, body) = collect_request(request).await;
+
+        assert_eq!(
+            parts.headers.get("user-agent").unwrap(),
+            "orders-service/1.0"
+        );
+
+        let (parts, body) = collect_received_response(parts, body, sender).await;
+        build_response(parts, body)
+    }
+
+    async fn cleanup(resources: Vec<String>, alternator_address: &str) {
+        cleanup_calls(resources, alternator_address).await;
+    }
+}
+
+#[test_context(HttpTestContext<CustomUserAgentConfig>)]
+#[tokio::test]
+pub async fn test_custom_user_agent(ctx: &mut HttpTestContext<CustomUserAgentConfig>) {
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .optimize_headers(true)
+            .user_agent("orders-service/1.0")
+            .build(),
+    );
+
+    make_calls(&client, ctx).await;
+}
+
+struct DisabledUserAgentConfig;
+impl HttpTestConfig for DisabledUserAgentConfig {
+    async fn on_request(
+        request: Request<Incoming>,
+        sender: Arc<Mutex<SendRequest<Full<Bytes>>>>,
+    ) -> Response<Full<Bytes>> {
+        let (parts, body) = collect_request(request).await;
+
+        assert!(!parts.headers.contains_key("user-agent"));
+
+        let (parts, body) = collect_received_response(parts, body, sender).await;
+        build_response(parts, body)
+    }
+
+    async fn cleanup(resources: Vec<String>, alternator_address: &str) {
+        cleanup_calls(resources, alternator_address).await;
+    }
+}
+
+#[test_context(HttpTestContext<DisabledUserAgentConfig>)]
+#[tokio::test]
+pub async fn test_without_user_agent(ctx: &mut HttpTestContext<DisabledUserAgentConfig>) {
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .optimize_headers(true)
+            .without_user_agent()
+            .build(),
+    );
+
+    make_calls(&client, ctx).await;
 }
 
 #[test_context(HttpTestContext<WithoutCredentialsConfig>)]
@@ -335,6 +414,7 @@ impl HttpTestConfig for WithCredentialsConfig {
             "content-encoding",
             "authorization",
             "x-amz-date",
+            "user-agent",
         ];
 
         let rogue = parts
@@ -350,6 +430,7 @@ impl HttpTestConfig for WithCredentialsConfig {
         );
         assert!(parts.headers.contains_key("authorization"));
         assert!(parts.headers.contains_key("x-amz-date"));
+        assert_eq!(parts.headers.get("user-agent").unwrap(), DEFAULT_USER_AGENT);
 
         // forward
         let (parts, body) = collect_received_response(parts, body, sender).await;
@@ -397,6 +478,7 @@ impl HttpTestConfig for WhitelistNeededConfig {
             "content-encoding",
             "authorization",
             "x-amz-date",
+            "user-agent",
         ];
 
         let rogue = parts
@@ -525,6 +607,36 @@ async fn make_customized_calls(
         .send()
         .await
         .unwrap();
+}
+
+#[test_context(HttpTestContext<PerRequestCustomizationConfig>)]
+#[tokio::test]
+pub async fn test_per_request_user_agent_customization_does_not_persist(
+    ctx: &mut HttpTestContext<PerRequestCustomizationConfig>,
+) {
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .optimize_headers(true)
+            .build(),
+    );
+
+    ctx.set_on_request(CustomUserAgentConfig::on_request).await;
+
+    client
+        .list_tables()
+        .customize()
+        .alternator_config_override(AlternatorConfig::builder().user_agent("orders-service/1.0"))
+        .send()
+        .await
+        .unwrap();
+
+    ctx.set_on_request(WithoutCredentialsConfig::on_request)
+        .await;
+
+    client.list_tables().send().await.unwrap();
 }
 
 #[test_context(HttpTestContext<PerRequestCustomizationConfig>)]


### PR DESCRIPTION
Jira: https://scylladb.atlassian.net/browse/DRIVER-563
Closes #87

## Summary
- Add deterministic final `User-Agent` handling for the Rust Alternator client: `scylladb-alternator-client-rust/<version>`.
- Add a small configuration API for replacing, deriving, disabling, and overriding the final header.
- Rewrite the final `User-Agent` after AWS SDK header insertion and optional optimized header stripping, so Alternator config wins consistently.

## Configuration API

Default client behavior sends the crate/version marker automatically:

```rust
let client = AlternatorClient::from_conf(
    AlternatorConfig::builder()
        .endpoint_url("http://10.0.0.1:8043")
        .behavior_version_latest()
        .build(),
);
```

Exact replacement for applications that want to own the whole header:

```rust
let client = AlternatorClient::from_conf(
    AlternatorConfig::builder()
        .endpoint_url("http://10.0.0.1:8043")
        .user_agent("orders-service/1.0")
        .behavior_version_latest()
        .build(),
);
```

Default-based transformation for applications that want to keep the driver marker and append their own token:

```rust
let client = AlternatorClient::from_conf(
    AlternatorConfig::builder()
        .endpoint_url("http://10.0.0.1:8043")
        .user_agent(UserAgent::transform(|default| {
            format!("{default} orders-service/1.0")
        }))
        .behavior_version_latest()
        .build(),
);
```

Disable the final header when required by a deployment or test harness:

```rust
let client = AlternatorClient::from_conf(
    AlternatorConfig::builder()
        .endpoint_url("http://10.0.0.1:8043")
        .without_user_agent()
        .behavior_version_latest()
        .build(),
);
```

The same API also works as a per-operation override through `AlternatorCustomizableOperation`:

```rust
client
    .get_item()
    .customize()
    .alternator_config_override(
        AlternatorConfig::builder()
            .user_agent("batch-repair/1.0")
            .behavior_version_latest(),
    )
    .send()
    .await?;
```

Additional knobs:
- `UserAgent::value(...)` mirrors string replacement.
- `UserAgent::disabled()` mirrors `without_user_agent()`.
- `UserAgent::transform_optional(...)` can derive a value from the default or return `None` to suppress the header.
- `set_user_agent(None)` restores default behavior on mutable config builders.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo check --all-targets`
- `cargo test --lib`
- `make up`
- `cargo test --test http_content_tests user_agent -- --nocapture`
- `cargo test --test http_content_tests credentials -- --nocapture`
- `make down`
