### PR TITLE
Cover DNS entrypoint live-node routing

### DIFF
--- a/src/live_nodes.rs
+++ b/src/live_nodes.rs
@@ -410,12 +410,39 @@ impl Drop for LiveNodes {
 mod tests {
     use super::*;
     use crate::config::AlternatorConfig;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     fn test_config() -> AlternatorConfig {
         AlternatorConfig::builder()
             .behavior_version_latest()
             .endpoint_url("http://127.0.0.1:1".to_string())
             .build()
+    }
+
+    async fn start_localnodes_server(body: &'static str) -> (u16, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buffer = [0; 1024];
+            let n = stream.read(&mut buffer).await.unwrap();
+            let request = String::from_utf8_lossy(&buffer[..n]);
+            assert!(request.starts_with("GET /localnodes HTTP/1.1"));
+            assert!(
+                request.contains(&format!("host: localhost:{port}"))
+                    || request.contains(&format!("Host: localhost:{port}"))
+            );
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        (port, server)
     }
 
     #[test]
@@ -469,5 +496,60 @@ mod tests {
         assert_eq!(nodes.seed_urls[0].host_str(), Some("[::1]"));
         assert_eq!(nodes.seed_urls[0].port(), Some(8000));
         assert_eq!(nodes.seed_urls[0].to_string(), "http://[::1]:8000/");
+    }
+
+    #[tokio::test]
+    async fn dns_entrypoint_discovers_dns_node_records() {
+        let (port, server) = start_localnodes_server(r#"["localhost","node-a.internal"]"#).await;
+        let config = AlternatorConfig::builder()
+            .behavior_version_latest()
+            .scheme("http")
+            .port(port)
+            .seed_hosts(vec!["localhost".to_string()])
+            .active_interval(std::time::Duration::from_millis(10))
+            .idle_interval(std::time::Duration::from_secs(10))
+            .build();
+        let nodes = LiveNodes::new(&config).unwrap();
+
+        nodes.update_live_nodes().await;
+
+        server.await.unwrap();
+        let snapshot = nodes.live_nodes.load();
+        let hosts = snapshot
+            .iter()
+            .map(|url| url.host_str().unwrap().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(hosts, vec!["localhost", "node-a.internal"]);
+    }
+
+    #[tokio::test]
+    async fn dns_entrypoint_applies_configured_port_to_dns_node_records() {
+        let (port, server) =
+            start_localnodes_server(r#"["node-a.internal:9000","node-b.internal"]"#).await;
+        let config = AlternatorConfig::builder()
+            .behavior_version_latest()
+            .scheme("http")
+            .port(port)
+            .seed_hosts(vec!["localhost".to_string()])
+            .active_interval(std::time::Duration::from_millis(10))
+            .idle_interval(std::time::Duration::from_secs(10))
+            .build();
+        let nodes = LiveNodes::new(&config).unwrap();
+
+        nodes.update_live_nodes().await;
+
+        server.await.unwrap();
+        let snapshot = nodes.live_nodes.load();
+        let hosts_and_ports = snapshot
+            .iter()
+            .map(|url| (url.host_str().unwrap().to_string(), url.port()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            hosts_and_ports,
+            vec![
+                ("node-a.internal".to_string(), Some(port)),
+                ("node-b.internal".to_string(), Some(port)),
+            ]
+        );
     }
 }

--- a/tests/ccm_wrapper/cluster.rs
+++ b/tests/ccm_wrapper/cluster.rs
@@ -54,7 +54,7 @@ impl Node {
     }
 
     pub(crate) fn address(&self) -> String {
-        format!("http://{}:{}", &self.ip, &self.alternator_port)
+        format!("http://{}:{}", self.ip, self.alternator_port)
     }
 }
 

--- a/tests/load_balancing/load_balancing_tests.rs
+++ b/tests/load_balancing/load_balancing_tests.rs
@@ -1,6 +1,7 @@
 use crate::ccm_wrapper::ccm::*;
 use crate::ccm_wrapper::cluster::*;
 use crate::load_balancing::cluster_utils::*;
+use crate::load_balancing::proxy;
 use crate::load_balancing::scope_utils;
 
 use alternator_driver::AlternatorClient;
@@ -628,6 +629,58 @@ async fn calls_correct_cluster_scope_test() {
     make_n_calls(&client, live_node_ips.len()).await;
 
     assert_round_robin_counts(&request_counter, &live_node_ips, "cluster scope");
+}
+
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn dns_entrypoint_discovers_live_cluster_nodes_test() {
+    let mut guard = get_cluster().await;
+    let cluster = &mut *guard;
+    let request_counter = RequestCounter::from_cluster(cluster);
+    let target_ip = cluster
+        .nodes()
+        .into_iter()
+        .find(|node| node.is_up)
+        .unwrap()
+        .ip
+        .clone();
+    let dns_entrypoint_proxy = proxy::Proxy::start(
+        "localhost:0".to_string(),
+        format!("{target_ip}:{ALTERNATOR_PORT}"),
+        |request, send| async move { proxy::forward_on_request(request, send).await },
+        None,
+        None,
+    )
+    .await;
+    let proxy_port = dns_entrypoint_proxy.address().port();
+    tokio::spawn(async move {
+        dns_entrypoint_proxy.run().await;
+    });
+    start_proxies(cluster, proxy_port, &request_counter).await;
+
+    let client = AlternatorClient::from_conf(
+        minimal_builder()
+            .scheme("http")
+            .port(proxy_port)
+            .seed_hosts(vec!["localhost".to_string()])
+            .routing_scope(RoutingScope::from_cluster())
+            .build(),
+    );
+    let live_nodes = client.config().live_nodes().unwrap().clone();
+
+    live_nodes.update_live_nodes().await;
+
+    let discovered = live_nodes.get_live_nodes();
+    let hosts: Vec<&str> = discovered.iter().filter_map(|url| url.host_str()).collect();
+    assert!(!hosts.is_empty(), "DNS entrypoint should discover nodes");
+    assert!(
+        hosts.iter().all(|host| *host != "localhost"),
+        "DNS entrypoint should be replaced by live cluster node records, got {hosts:?}"
+    );
+
+    request_counter.reset();
+    make_n_calls(&client, hosts.len()).await;
+    assert_round_robin_counts(&request_counter, &hosts, "DNS entrypoint cluster scope");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #80.

DNS hostname seed entrypoints lacked coverage proving they are replaced by live cluster nodes returned from `/localnodes`, including port normalization for returned node records.

Added focused `LiveNodes` unit coverage for DNS record discovery and configured-port reuse, plus CCM coverage that verifies round-robin routing uses discovered live nodes instead of the original DNS entrypoint.