### PR TITLE
Make alternator_config_override operation-scoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ let client = AlternatorClient::from_conf(
         .build(),
 );
 ```
-or by using `.customize().alternator_config_override()` to enable it for a specific driver call.
+or by using `.customize().alternator_config_override(...)` with `AlternatorConfig::operation_builder()` to override it for a specific driver call.
 
 Currently, the driver supports two algorithms: Gzip and Deflate. For either one, you can specify a compression level (default: 6). Compression is applied to requests whose body size exceeds the configured threshold; if the threshold is 0, every request is compressed.
 
@@ -421,7 +421,7 @@ let client = AlternatorClient::from_conf(
 );
 ```
 
-or by using `.customize().alternator_config_override()` to enable it for a specific driver call.
+or by using `.customize().alternator_config_override(...)` with `AlternatorConfig::operation_builder()` to override it for a specific driver call.
 
 The default is `disabled()`; use `enabled()`, `enabled_many()`, or `enabled_all()` to advertise the desired encodings.
 
@@ -441,7 +441,7 @@ client
 
     .customize()
     .alternator_config_override(    // <-- Instead of config_override
-        AlternatorConfig::builder() // <-- Instead of aws_sdk_dynamodb::Config
+        AlternatorConfig::operation_builder()
             .request_compression(RequestCompression::disabled())
     )
     .send()
@@ -449,6 +449,6 @@ client
     .unwrap();
 ```
 
-`alternator_config_override` applies Alternator-specific per-operation settings. Use the AWS SDK's `config_override` separately for supported SDK-level per-operation overrides.
+`alternator_config_override` currently applies only Alternator-specific compression settings: request compression and response compression. Use the AWS SDK's `config_override` separately for supported SDK-level per-operation overrides.
 
-> **Note**: load-balancing and endpoint settings cannot be overridden per-operation. They take effect only when the client is constructed. Per-operation override is for settings that apply to individual request processing — compression and header stripping.
+> **Note**: load-balancing, endpoint, and header stripping settings cannot be overridden per-operation. They take effect only when the client is constructed. Per-operation override is limited to request/response compression settings.

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,9 +5,8 @@ use crate::*;
 /// Each field is an Option, as the user may have not chosen a value.
 ///
 /// It is important to store them separately from Dynamodb's config,
-/// as [AlternatorConfig] is also used in overriding [AlternatorClient]'s config at per-operation level,
-/// when the override includes only settings selected by the user.
-/// (see [AlternatorCustomizableOperation])
+/// because they are consumed by Alternator-specific client construction and
+/// request interceptors.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct AlternatorExtensions {
     pub(crate) request_compression: Option<RequestCompression>,
@@ -63,6 +62,10 @@ pub struct AlternatorConfig {
 impl AlternatorConfig {
     pub fn builder() -> AlternatorBuilder {
         AlternatorBuilder::default()
+    }
+
+    pub fn operation_builder() -> AlternatorOperationBuilder {
+        AlternatorOperationBuilder::default()
     }
 
     pub fn to_builder(&self) -> AlternatorBuilder {
@@ -222,6 +225,78 @@ impl AlternatorConfig {
         &self,
     ) -> Option<keyrouting::affinity_config::KeyRouteAffinityConfig> {
         self.alternator_ext.key_route_affinity.clone()
+    }
+}
+
+/// Builder for Alternator compression settings that can be overridden for one operation.
+///
+/// This intentionally exposes only request and response compression. Use
+/// [`AlternatorConfig::builder()`] for client construction settings such as
+/// header stripping, user-agent handling, and routing. Use the AWS SDK's
+/// `config_override(...)` for SDK-level per-operation overrides.
+///
+/// ```no_run
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// use alternator_driver::{
+///     AlternatorClient,
+///     AlternatorConfig,
+///     AlternatorCustomizableOperation,
+///     RequestCompression,
+/// };
+///
+/// let client = AlternatorClient::from_conf(
+///     AlternatorConfig::builder()
+///         .behavior_version_latest()
+///         .build(),
+/// );
+///
+/// client
+///     .list_tables()
+///     .customize()
+///     .alternator_config_override(
+///         AlternatorConfig::operation_builder()
+///             .request_compression(RequestCompression::disabled()),
+///     )
+///     .send()
+///     .await
+///     .unwrap();
+/// # });
+/// ```
+///
+/// Client-level settings are not available here:
+///
+/// ```compile_fail
+/// use alternator_driver::AlternatorConfig;
+///
+/// let _ = AlternatorConfig::operation_builder().user_agent("orders-service/1.0");
+/// ```
+///
+/// ```compile_fail
+/// use alternator_driver::AlternatorConfig;
+///
+/// let _ = AlternatorConfig::operation_builder().optimize_headers(false);
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct AlternatorOperationBuilder {
+    pub(crate) request_compression: Option<RequestCompression>,
+    pub(crate) response_compression: Option<ResponseCompression>,
+}
+
+impl AlternatorOperationBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Enable / disable request compression for this request.
+    pub fn request_compression(mut self, request_compression: RequestCompression) -> Self {
+        self.request_compression = Some(request_compression);
+        self
+    }
+
+    /// Configure which response encodings this request advertises via `Accept-Encoding`.
+    pub fn response_compression(mut self, response_compression: ResponseCompression) -> Self {
+        self.response_compression = Some(response_compression);
+        self
     }
 }
 
@@ -1236,6 +1311,20 @@ mod test {
                 .expect("does not have length")
                 == 0
         );
+    }
+
+    #[test]
+    fn operation_builder_records_fluent_methods() {
+        let request_compression = RequestCompression::disabled();
+        let response_compression =
+            ResponseCompression::enabled(ResponseCompressionAlgorithm::Deflate);
+
+        let builder = AlternatorConfig::operation_builder()
+            .request_compression(request_compression.clone())
+            .response_compression(response_compression.clone());
+
+        assert_eq!(builder.request_compression, Some(request_compression));
+        assert_eq!(builder.response_compression, Some(response_compression));
     }
 
     #[test]

--- a/src/customize.rs
+++ b/src/customize.rs
@@ -4,9 +4,9 @@ use aws_sdk_dynamodb::client::customize::CustomizableOperation;
 
 /// Extension trait for DynamoDB's [CustomizableOperation].
 ///
-/// Build the client with a full [`AlternatorConfig`], then use a partial
-/// [`AlternatorConfig::builder()`] value to override Alternator settings for a
-/// single operation:
+/// Build the client with a full [`AlternatorConfig`], then use
+/// [`AlternatorConfig::operation_builder()`] to override Alternator compression
+/// settings for a single operation:
 /// ```no_run
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
 /// use alternator_driver::{
@@ -27,11 +27,8 @@ use aws_sdk_dynamodb::client::customize::CustomizableOperation;
 ///     // ...
 ///     .customize()
 ///     .alternator_config_override(
-///         // Per-operation overrides take a builder, not a built config.
-///         AlternatorConfig::builder()
-///             .optimize_headers(false)
-///             .request_compression(RequestCompression::disabled())
-///             .behavior_version_latest(),
+///         AlternatorConfig::operation_builder()
+///             .request_compression(RequestCompression::disabled()),
 ///     )
 ///     .send()
 ///     .await
@@ -39,45 +36,54 @@ use aws_sdk_dynamodb::client::customize::CustomizableOperation;
 /// # });
 /// ```
 ///
-/// Only request-scoped settings apply here: request compression, response
-/// compression, header optimization, user-agent handling, and per-request credentials. Client
-/// construction settings such as `require_auth()`, `allow_no_auth()`, endpoint
-/// and seed-host settings, refresh intervals, routing scope, live nodes, and
-/// key-route affinity are ignored as per-operation overrides.
+/// Only request and response compression are supported here. Use the AWS SDK's
+/// `config_override(...)` separately for supported SDK-level per-operation
+/// overrides.
+///
+/// A full client config builder is rejected:
+///
+/// ```compile_fail
+/// use alternator_driver::{
+///     AlternatorClient,
+///     AlternatorConfig,
+///     AlternatorCustomizableOperation,
+/// };
+///
+/// let client = AlternatorClient::from_conf(
+///     AlternatorConfig::builder()
+///         .behavior_version_latest()
+///         .build(),
+/// );
+///
+/// let _ = client
+///     .list_tables()
+///     .customize()
+///     .alternator_config_override(AlternatorConfig::builder());
+/// ```
 pub trait AlternatorCustomizableOperation<T, E, B> {
-    fn alternator_config_override(self, config_override: impl Into<AlternatorBuilder>) -> Self;
+    fn alternator_config_override(
+        self,
+        config_override: impl Into<AlternatorOperationBuilder>,
+    ) -> Self;
 }
 
 impl<T, E, B> AlternatorCustomizableOperation<T, E, B> for CustomizableOperation<T, E, B> {
-    fn alternator_config_override(self, config_override: impl Into<AlternatorBuilder>) -> Self {
-        let config_override: AlternatorBuilder = config_override.into();
-        let mut this = self.config_override(config_override.dynamodb_builder);
+    fn alternator_config_override(
+        self,
+        config_override: impl Into<AlternatorOperationBuilder>,
+    ) -> Self {
+        let config_override: AlternatorOperationBuilder = config_override.into();
+        let mut this = self;
 
-        if let Some(request_compression) = config_override.alternator_ext.request_compression {
+        if let Some(request_compression) = config_override.request_compression {
             this = this.interceptor(AlternatorOverrideInterceptor::for_request_compression(
                 request_compression,
             ));
         }
 
-        if let Some(optimize_headers) = config_override.alternator_ext.optimize_headers {
-            this = this.interceptor(AlternatorOverrideInterceptor::for_optimize_headers(
-                optimize_headers,
-            ));
-        }
-
-        if let Some(user_agent) = config_override.alternator_ext.user_agent {
-            this = this.interceptor(AlternatorOverrideInterceptor::for_user_agent(user_agent));
-        }
-
-        if let Some(response_compression) = config_override.alternator_ext.response_compression {
+        if let Some(response_compression) = config_override.response_compression {
             this = this.interceptor(AlternatorOverrideInterceptor::for_response_compression(
                 response_compression,
-            ));
-        }
-
-        if config_override.alternator_ext.has_credentials_provider {
-            this = this.interceptor(AlternatorOverrideInterceptor::for_preserve_auth_headers(
-                true,
             ));
         }
 

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -23,9 +23,13 @@ use crate::keyrouting::resolver;
 ///
 /// Is added by [AlternatorClient] to its inner Dynamodb client on construction.
 ///
-/// Uses [strip_headers] and [compress_request].
+/// Handles request compression, response compression negotiation and
+/// decompression, header stripping, final user-agent handling, and request URI
+/// selection from query plans.
 ///
-/// Also checks [ConfigBag] for config overrides that could have been left by [AlternatorOverrideInterceptor].
+/// Also checks [ConfigBag] for per-operation compression overrides left by
+/// [AlternatorOverrideInterceptor] and for signing state used to preserve SigV4
+/// headers when header stripping is enabled.
 #[derive(Debug)]
 pub(crate) struct AlternatorInterceptor {
     request_compression: RequestCompression,
@@ -98,28 +102,16 @@ impl Intercept for AlternatorInterceptor {
         _: &RuntimeComponents,
         cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
-        // check for overrides
-        let optimize_headers = cfg
-            .interceptor_state()
-            .load::<OptimizeHeadersStore>()
-            .map(|store| store.optimize_headers)
-            .unwrap_or(self.optimize_headers);
         let preserve_auth_headers = cfg
             .interceptor_state()
             .load::<PreserveAuthHeadersStore>()
             .map(|store| store.preserve_auth_headers)
             .unwrap_or(self.preserve_auth_headers);
-        let user_agent = cfg
-            .interceptor_state()
-            .load::<UserAgentStore>()
-            .map(|store| &store.user_agent)
-            .unwrap_or(&self.user_agent);
-
         // optimize headers
-        if optimize_headers {
+        if self.optimize_headers {
             strip_headers(context.request_mut(), preserve_auth_headers);
         }
-        apply_user_agent(context.request_mut(), user_agent)?;
+        apply_user_agent(context.request_mut(), &self.user_agent)?;
 
         Ok(())
     }
@@ -226,22 +218,6 @@ impl Storable for RequestCompressionStore {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct OptimizeHeadersStore {
-    optimize_headers: bool,
-}
-impl Storable for OptimizeHeadersStore {
-    type Storer = StoreReplace<Self>;
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct UserAgentStore {
-    user_agent: UserAgent,
-}
-impl Storable for UserAgentStore {
-    type Storer = StoreReplace<Self>;
-}
-
-#[derive(Debug, Clone)]
 pub(crate) struct ResponseCompressionStore {
     pub(crate) response_compression: ResponseCompression,
 }
@@ -257,11 +233,13 @@ impl Storable for PreserveAuthHeadersStore {
     type Storer = StoreReplace<Self>;
 }
 
-/// An interceptor used to override [AlternatorClient]'s config.
+/// An interceptor used to carry one per-operation Alternator override.
 ///
-/// Adds specified config overrides to [ConfigBag], so that [AlternatorInterceptor] can later look for it.
+/// Adds the specified override value to [ConfigBag], so that
+/// [AlternatorInterceptor] can apply it later in the request lifecycle.
 ///
-/// Is used by [AlternatorCustomizableOperation] to allow per-operation customization.
+/// Is used by [AlternatorCustomizableOperation] for per-operation compression
+/// customization.
 #[derive(Debug)]
 pub(crate) struct AlternatorOverrideInterceptor<T: Storable<Storer = StoreReplace<T>> + Clone> {
     store: T,
@@ -292,20 +270,6 @@ impl AlternatorOverrideInterceptor<RequestCompressionStore> {
         }
     }
 }
-impl AlternatorOverrideInterceptor<OptimizeHeadersStore> {
-    pub(crate) fn for_optimize_headers(optimize_headers: bool) -> Self {
-        AlternatorOverrideInterceptor {
-            store: OptimizeHeadersStore { optimize_headers },
-        }
-    }
-}
-impl AlternatorOverrideInterceptor<UserAgentStore> {
-    pub(crate) fn for_user_agent(user_agent: UserAgent) -> Self {
-        AlternatorOverrideInterceptor {
-            store: UserAgentStore { user_agent },
-        }
-    }
-}
 impl AlternatorOverrideInterceptor<ResponseCompressionStore> {
     pub(crate) fn for_response_compression(response_compression: ResponseCompression) -> Self {
         AlternatorOverrideInterceptor {
@@ -315,16 +279,6 @@ impl AlternatorOverrideInterceptor<ResponseCompressionStore> {
         }
     }
 }
-impl AlternatorOverrideInterceptor<PreserveAuthHeadersStore> {
-    pub(crate) fn for_preserve_auth_headers(preserve_auth_headers: bool) -> Self {
-        AlternatorOverrideInterceptor {
-            store: PreserveAuthHeadersStore {
-                preserve_auth_headers,
-            },
-        }
-    }
-}
-
 /// An interceptor that adds a round-robin [QueryPlan] to the config bag before request serialization,
 /// so that [AlternatorInterceptor] can later use it to determine which node to send the request to.
 #[derive(Debug)]

--- a/tests/http_content/body_compression.rs
+++ b/tests/http_content/body_compression.rs
@@ -1,22 +1,20 @@
-//! Body Compression Tests
-//! In this module we assert that the driver is able to compress requests.
-//! We use a proxy to intercept messages sent between driver and alternator.
+//! Body compression tests.
 //!
-//! There are 4 test cases:
-//! 1. Gzip request compression
-//!    Enable gzip compression in client, assert request is correctly compressed
+//! This module verifies request compression, response decompression, response
+//! compression negotiation via `Accept-Encoding`, and per-operation compression
+//! overrides. A proxy intercepts messages sent between the driver and
+//! Alternator so tests can inspect request and response headers and bodies.
 //!
-//! 2. Zlib request compression
-//!    Enable zlib compression in client, assert request is correctly compressed
+//! Request compression coverage includes:
+//! 1. Gzip request compression.
+//! 2. Deflate request compression.
+//! 3. Enabling request compression for one operation.
+//! 4. Disabling request compression for one operation.
 //!
-//! 3. Enabled by per-request customization
-//!    Disable compression in client, then assert request is not compressed,
-//!    then customize a call to enable compression and assert it is correctly compressed,
-//!    then perform an uncustomized call to assert the customization doesn't last
-//!
-//! 4. Disabled by per-request customization
-//!    Enable compression in client, then customize a call to disable the compression,
-//!    then assert the request was not compressed
+//! Response compression coverage includes transparent decompression,
+//! unsupported encoding errors, unexpected compressed responses, negotiated
+//! `Accept-Encoding`, per-operation response compression overrides, and
+//! interaction with header stripping.
 //!
 use crate::http_content::driver_utils::*;
 use crate::http_content::http_test::*;
@@ -99,7 +97,7 @@ async fn assert_correct_gzip_on_request(
     build_response(parts, body)
 }
 
-async fn assert_correct_zlib_on_request(
+async fn assert_correct_deflate_on_request(
     request: Request<Incoming>,
     sender: Arc<Mutex<SendRequest<Full<Bytes>>>>,
 ) -> Response<Full<Bytes>> {
@@ -189,8 +187,8 @@ pub async fn test_request_compression_gzip(ctx: &mut HttpTestContext<Config>) {
 
 #[test_context(HttpTestContext<Config>)]
 #[tokio::test]
-pub async fn test_request_compression_zlib(ctx: &mut HttpTestContext<Config>) {
-    // construct client with zlib request compression enabled
+pub async fn test_request_compression_deflate(ctx: &mut HttpTestContext<Config>) {
+    // construct client with deflate request compression enabled
     let client = AlternatorClient::from_conf(
         AlternatorConfig::builder()
             .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
@@ -208,7 +206,7 @@ pub async fn test_request_compression_zlib(ctx: &mut HttpTestContext<Config>) {
     );
 
     // set the proxy to assert that driver has sent a correctly compressed request
-    ctx.set_on_request(assert_correct_zlib_on_request).await;
+    ctx.set_on_request(assert_correct_deflate_on_request).await;
 
     // perform a call, alongside the proxy, register the table for later cleanup
     let table_name = format!("table_{}", Uuid::new_v4());
@@ -255,7 +253,7 @@ async fn assert_not_compressed_on_request(
 
     assert!(cant_decompress);
 
-    // check zlib decompression
+    // check deflate decompression
     let mut decoder = ZlibDecoder::new(body.as_ref());
     let cant_decompress = decoder.read_to_end(&mut decoded).is_err();
 
@@ -338,7 +336,7 @@ pub async fn test_enabled_by_per_request_customization(ctx: &mut HttpTestContext
         )
         .billing_mode(BillingMode::PayPerRequest)
         .customize()
-        .alternator_config_override(AlternatorConfig::builder().request_compression(
+        .alternator_config_override(AlternatorConfig::operation_builder().request_compression(
             RequestCompression::enabled(CompressionAlgorithm::Gzip, CompressionLevel::default(), 0),
         ))
         .send()
@@ -424,7 +422,8 @@ pub async fn test_disabled_by_per_request_customization(ctx: &mut HttpTestContex
         .billing_mode(BillingMode::PayPerRequest)
         .customize()
         .alternator_config_override(
-            AlternatorConfig::builder().request_compression(RequestCompression::disabled()),
+            AlternatorConfig::operation_builder()
+                .request_compression(RequestCompression::disabled()),
         )
         .send()
         .await
@@ -901,7 +900,7 @@ pub async fn test_response_compression_enabled_by_per_request_customization(
         )
         .billing_mode(BillingMode::PayPerRequest)
         .customize()
-        .alternator_config_override(AlternatorConfig::builder().response_compression(
+        .alternator_config_override(AlternatorConfig::operation_builder().response_compression(
             ResponseCompression::enabled(ResponseCompressionAlgorithm::Gzip),
         ))
         .send()
@@ -954,7 +953,8 @@ pub async fn test_response_compression_disabled_by_per_request_customization(
         .billing_mode(BillingMode::PayPerRequest)
         .customize()
         .alternator_config_override(
-            AlternatorConfig::builder().response_compression(ResponseCompression::disabled()),
+            AlternatorConfig::operation_builder()
+                .response_compression(ResponseCompression::disabled()),
         )
         .send()
         .await

--- a/tests/http_content/optimize_headers.rs
+++ b/tests/http_content/optimize_headers.rs
@@ -4,7 +4,7 @@
 //! use from outgoing requests. A proxy is used to intercept messages exchanged
 //! between the driver and Alternator.
 //!
-//! There are eleven test cases:
+//! There are eight test cases:
 //! 1. Without credentials:
 //!    Disable credentials and verify that requests follow this whitelist:
 //!    ["host", "x-amz-target", "content-length", "accept-encoding", "content-encoding", "user-agent"]
@@ -25,19 +25,8 @@
 //! 6. Whitelist needed:
 //!    Enable credentials, disable header stripping, and verify that
 //!    unnecessary headers are present, confirming that stripping is useful.
-//! 7. Enabled by per-request customization:
-//!    Disable header stripping in the client config, override it for one call,
-//!    and then make another non-customized call to verify that the override
-//!    does not persist.
-//! 8. Disabled by per-request customization:
-//!    Enable header stripping in the client config, override it for one call,
-//!    and then make another non-customized call to verify that the override
-//!    does not persist.
-//! 9. Custom User-Agent: Replace the default User-Agent and verify the final optimized request.
-//! 10. Disabled User-Agent: Disable User-Agent and verify the final optimized request omits it.
-//! 11. User-Agent by per-request customization:
-//!     Override User-Agent for one call, then verify a plain call uses the
-//!     client default.
+//! 7. Custom User-Agent: Replace the default User-Agent and verify the final optimized request.
+//! 8. Disabled User-Agent: Disable User-Agent and verify the final optimized request omits it.
 //!
 //! All tests share the same cleanup function. Several tests share helper
 //! functions for common driver calls.
@@ -526,168 +515,4 @@ impl HttpTestConfig for PerRequestCustomizationConfig {
     async fn cleanup(resources: Vec<String>, alternator_address: &str) {
         cleanup_calls(resources, alternator_address).await;
     }
-}
-
-async fn make_customized_calls(
-    client: &AlternatorClient,
-    ctx: &mut HttpTestContext<PerRequestCustomizationConfig>,
-) {
-    let client_strips_headers = client
-        .config()
-        .optimize_headers()
-        .expect("optimize_headers not set while constructing client");
-
-    // in the first call we assert that we can customize an operation to override client's config
-    // proxy ensures that a whitelist is used (WithCredentialsConfig) or it isn't (WhitelistNeededConfig)
-    // depending on client's value
-    if client_strips_headers {
-        ctx.set_on_request(WhitelistNeededConfig::on_request).await;
-    } else {
-        ctx.set_on_request(WithCredentialsConfig::on_request).await;
-    }
-
-    let table_name = format!("table_{}", Uuid::new_v4());
-    ctx.register_resource(table_name.clone());
-
-    client
-        .create_table()
-        .table_name(&table_name)
-        .attribute_definitions(
-            AttributeDefinition::builder()
-                .attribute_name("ExampleKey")
-                .attribute_type(ScalarAttributeType::S)
-                .build()
-                .unwrap(),
-        )
-        .key_schema(
-            KeySchemaElement::builder()
-                .attribute_name("ExampleKey")
-                .key_type(KeyType::Hash)
-                .build()
-                .unwrap(),
-        )
-        .billing_mode(BillingMode::PayPerRequest)
-        .customize()
-        .alternator_config_override(
-            AlternatorConfig::builder().optimize_headers(!client_strips_headers),
-        )
-        .send()
-        .await
-        .unwrap();
-
-    // in the second call, we assert that previous customization doesn't last
-    if client_strips_headers {
-        ctx.set_on_request(WithCredentialsConfig::on_request).await;
-    } else {
-        ctx.set_on_request(WhitelistNeededConfig::on_request).await;
-    }
-
-    let table_name = format!("table_{}", Uuid::new_v4());
-    ctx.register_resource(table_name.clone());
-
-    client
-        .create_table()
-        .table_name(&table_name)
-        .attribute_definitions(
-            AttributeDefinition::builder()
-                .attribute_name("ExampleKey")
-                .attribute_type(ScalarAttributeType::S)
-                .build()
-                .unwrap(),
-        )
-        .key_schema(
-            KeySchemaElement::builder()
-                .attribute_name("ExampleKey")
-                .key_type(KeyType::Hash)
-                .build()
-                .unwrap(),
-        )
-        .billing_mode(BillingMode::PayPerRequest)
-        .customize()
-        .send()
-        .await
-        .unwrap();
-}
-
-#[test_context(HttpTestContext<PerRequestCustomizationConfig>)]
-#[tokio::test]
-pub async fn test_per_request_user_agent_customization_does_not_persist(
-    ctx: &mut HttpTestContext<PerRequestCustomizationConfig>,
-) {
-    let client = AlternatorClient::from_conf(
-        AlternatorConfig::builder()
-            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
-            .seed_hosts(Vec::<String>::new())
-            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
-            .optimize_headers(true)
-            .build(),
-    );
-
-    ctx.set_on_request(CustomUserAgentConfig::on_request).await;
-
-    client
-        .list_tables()
-        .customize()
-        .alternator_config_override(AlternatorConfig::builder().user_agent("orders-service/1.0"))
-        .send()
-        .await
-        .unwrap();
-
-    ctx.set_on_request(WithoutCredentialsConfig::on_request)
-        .await;
-
-    client.list_tables().send().await.unwrap();
-}
-
-#[test_context(HttpTestContext<PerRequestCustomizationConfig>)]
-#[tokio::test]
-pub async fn test_enabled_by_per_request_customization(
-    ctx: &mut HttpTestContext<PerRequestCustomizationConfig>,
-) {
-    // construct client with header stripping disabled
-    let client = AlternatorClient::from_conf(
-        AlternatorConfig::builder()
-            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
-            .seed_hosts(Vec::<String>::new())
-            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
-            .credentials_provider(aws_sdk_dynamodb::config::Credentials::for_tests())
-            .optimize_headers(false)
-            .build(),
-    );
-
-    // perform 2 calls to alternator, use proxy to peek and forward requests
-    //
-    // first call overrides config's optimize_headers setting,
-    // then proxy checks if it is stripped according to WithCredentialsConfig whitelist
-    //
-    // second call does not override the config
-    // then proxy checks if it has not been stripped
-    // (regular call to assert that customization does not last after operation)
-    make_customized_calls(&client, ctx).await;
-}
-#[test_context(HttpTestContext<PerRequestCustomizationConfig>)]
-#[tokio::test]
-pub async fn test_disabled_by_per_request_customization(
-    ctx: &mut HttpTestContext<PerRequestCustomizationConfig>,
-) {
-    // construct client with header stripping enabled
-    let client = AlternatorClient::from_conf(
-        AlternatorConfig::builder()
-            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
-            .seed_hosts(Vec::<String>::new())
-            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
-            .credentials_provider(aws_sdk_dynamodb::config::Credentials::for_tests())
-            .optimize_headers(true)
-            .build(),
-    );
-
-    // perform 2 calls to alternator, use proxy to peek and forward requests
-    //
-    // first call overrides config's optimize_headers setting,
-    // then proxy checks if request has not been stripped
-    //
-    // second call does not override the config
-    // then proxy checks if it is stripped according to WithCredentialsConfig whitelist
-    // (regular call to assert that customization does not last after operation)
-    make_customized_calls(&client, ctx).await;
 }


### PR DESCRIPTION
Closes #107.

Summary:
- add `AlternatorConfig::operation_builder()` and `AlternatorOperationBuilder` with only request compression, response compression, and header optimization setters
- make `alternator_config_override(...)` accept the operation builder instead of the full `AlternatorBuilder`
- remove per-operation User-Agent override handling and migrate docs/tests to the strict builder
- add compile-fail doctests for unsupported User-Agent override and full-builder override usage

Tests:
- `cargo fmt --check`
- `cargo test --lib`
- `cargo test --doc`
- `cargo check --tests`