### PR TITLE
build: align Makefile with Alternator clients

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Static analysis
-      run: make static
+      run: make lint
 
   tests:
     runs-on: ubuntu-latest
@@ -25,7 +25,5 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Install scylla-ccm
       run: pip3 install https://github.com/scylladb/scylla-ccm/archive/master.zip
-    - name: CCM tests
-      run: make ccm-tests
     - name: Tests
-      run: make test
+      run: make test-all

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target/
 Cargo.lock
 .vscode
+/bin/docker-compose
+/.docker-cache/

--- a/Makefile
+++ b/Makefile
@@ -1,71 +1,163 @@
-COMPOSE := docker compose
+SHELL := bash
+.ONESHELL:
+.SHELLFLAGS := -eo pipefail -c
 
-.PHONY: all
-all: static test down
+CARGO ?= cargo
+RUSTFLAGS_CCM ?= --cfg ccm_tests
 
-.PHONY: static
-static: fmt-check check clippy
+MAKEFILE_PATH := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+BIN := $(MAKEFILE_PATH)/bin
+OS := $(shell uname | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m)
+DOCKER_COMPOSE_ARCH := $(ARCH)
+DOCKER_COMPOSE_VERSION := 2.34.0
+REPO_DOCKER_COMPOSE := $(BIN)/docker-compose
+SYSTEM_DOCKER_COMPOSE := $(shell \
+	if docker compose version >/dev/null 2>&1; then \
+		printf 'docker compose'; \
+	elif command -v docker-compose >/dev/null 2>&1; then \
+		printf 'docker-compose'; \
+	fi)
 
-.PHONY: fmt
-fmt:
-	cargo fmt --all
+ifeq ($(ARCH),arm64)
+	DOCKER_COMPOSE_ARCH := aarch64
+else ifeq ($(ARCH),amd64)
+	DOCKER_COMPOSE_ARCH := x86_64
+endif
 
-.PHONY: fmt-check
-fmt-check:
-	cargo fmt --all -- --check
+ifeq ($(DOCKER_COMPOSE_ARCH),aarch64)
+	DOCKER_COMPOSE_DOWNLOAD_URL := https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-$(OS)-aarch64
+else ifeq ($(DOCKER_COMPOSE_ARCH),x86_64)
+	DOCKER_COMPOSE_DOWNLOAD_URL := https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-$(OS)-x86_64
+endif
 
-.PHONY: check
-check:
-	cargo check --all-targets
+DOCKER_COMPOSE ?= $(if $(SYSTEM_DOCKER_COMPOSE),$(SYSTEM_DOCKER_COMPOSE),$(REPO_DOCKER_COMPOSE))
+COMPOSE = $(DOCKER_COMPOSE) -f $(MAKEFILE_PATH)/docker-compose.yml
+SCYLLA_IMAGE := scylladb/scylla
+DOCKER_CACHE_DIR := $(MAKEFILE_PATH)/.docker-cache
+DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/scylla-image.tar
 
-.PHONY: clippy
-clippy:
-	cargo clippy --all-targets -- -D warnings
-	
-.PHONY: test
-test: up
-	cargo test
+.PHONY: clean verify lint lint-docs lint-fix compile compile-test
+.PHONY: test-unit test-integration test-all
+.PHONY: wait-for-alternator scylla-start scylla-stop scylla-kill scylla-rm
+.PHONY: docker-pull docker-cache-save docker-cache-load
+.PHONY: logs cqlsh shell volumes prune
 
-.PHONY: ccm-wrapper-tests load-balancing-tests ccm-tests
-ccm-wrapper-tests:
-	RUSTFLAGS="--cfg ccm_tests" cargo test --test ccm_wrapper_tests -- --nocapture
+lint:
+	$(CARGO) fmt --all -- --check
+	$(CARGO) check --all-targets
+	$(CARGO) clippy --all-targets -- -D warnings
+	$(CARGO) doc --no-deps
 
-load-balancing-tests:
-	RUSTFLAGS="--cfg ccm_tests" cargo test --test load_balancing_tests -- --nocapture
+clean:
+	$(CARGO) clean
 
-ccm-tests: ccm-wrapper-tests load-balancing-tests
+verify: lint test-all
 
-.PHONY: up
-up:
+lint-docs:
+	$(CARGO) doc --no-deps
+
+lint-fix:
+	$(CARGO) fmt --all
+
+compile:
+	$(CARGO) build
+
+compile-test:
+	$(CARGO) test --no-run --all-targets
+
+test-unit:
+	$(CARGO) test --lib
+
+test-integration: scylla-start wait-for-alternator
+	trap '$(COMPOSE) down --remove-orphans -v' EXIT
+	$(CARGO) test --tests
+
+test-all: scylla-start wait-for-alternator
+	trap '$(COMPOSE) down --remove-orphans -v' EXIT
+	$(CARGO) test
+	$(COMPOSE) down --remove-orphans -v
+	trap - EXIT
+	RUSTFLAGS="$(RUSTFLAGS_CCM)" $(CARGO) test --test ccm_wrapper_tests -- --nocapture
+	RUSTFLAGS="$(RUSTFLAGS_CCM)" $(CARGO) test --test load_balancing_tests -- --nocapture
+
+wait-for-alternator:
+	echo "Waiting for Alternator to be ready..."
+	for i in $$(seq 1 60); do
+		if curl -sf http://localhost:8000/localnodes >/dev/null 2>&1; then
+			echo "Alternator is ready (waited $${i}s)"
+			exit 0
+		fi
+		sleep 1
+	done
+	echo "Timed out waiting for Alternator"
+	exit 1
+
+.prepare-environment-update-aio-max-nr:
+	@if [[ -r /proc/sys/fs/aio-max-nr ]] && (( $$(< /proc/sys/fs/aio-max-nr) < 2097152 )); then
+		echo 2097152 | sudo tee /proc/sys/fs/aio-max-nr >/dev/null
+	fi
+
+.prepare-docker-compose:
+	@if [[ "$(DOCKER_COMPOSE)" != "$(REPO_DOCKER_COMPOSE)" ]]; then
+		echo "Using docker compose: $(DOCKER_COMPOSE)"
+		exit 0
+	fi
+	if [[ -z "$(DOCKER_COMPOSE_DOWNLOAD_URL)" ]]; then
+		echo "Unable to download docker-compose for unsupported architecture \"$(ARCH)\""
+		exit 69
+	fi
+	[ -d "$(BIN)" ] || mkdir "$(BIN)"
+	if [[ -f "$(REPO_DOCKER_COMPOSE)" ]] && "$(REPO_DOCKER_COMPOSE)" version 2>/dev/null | grep "$(DOCKER_COMPOSE_VERSION)" >/dev/null; then
+		echo "docker-compose $(DOCKER_COMPOSE_VERSION) is already installed"
+	else
+		echo "Downloading $(REPO_DOCKER_COMPOSE)"
+		curl --fail --show-error --progress-bar -L "$(DOCKER_COMPOSE_DOWNLOAD_URL)" --output "$(REPO_DOCKER_COMPOSE)"
+		chmod +x "$(REPO_DOCKER_COMPOSE)"
+	fi
+
+.prepare-bin:
+	@[ -d "$(BIN)" ] || mkdir "$(BIN)"
+
+scylla-start: .prepare-docker-compose .prepare-environment-update-aio-max-nr docker-cache-load
 	$(COMPOSE) up -d --wait
-	@echo
-	@echo "1 scylla node is running in the background. Use 'make down' to stop it and remove its volume."
-	@echo
 
-.PHONY: down
-down:
+scylla-stop: .prepare-docker-compose
 	$(COMPOSE) down --remove-orphans -v
 
-.PHONY: logs
-logs:
+scylla-kill: .prepare-docker-compose
+	$(COMPOSE) kill
+
+scylla-rm: .prepare-docker-compose
+	$(COMPOSE) rm -f
+
+docker-pull:
+	docker pull $(SCYLLA_IMAGE)
+
+docker-cache-save: docker-pull
+	@mkdir -p $(DOCKER_CACHE_DIR)
+	docker save $(SCYLLA_IMAGE) -o $(DOCKER_CACHE_FILE)
+
+docker-cache-load:
+	@if [ -f "$(DOCKER_CACHE_FILE)" ]; then
+		echo "Loading Docker image from cache..."
+		docker load -i $(DOCKER_CACHE_FILE)
+	else
+		echo "Cache file not found, pulling image..."
+		docker pull $(SCYLLA_IMAGE)
+	fi
+
+logs: .prepare-docker-compose
 	$(COMPOSE) logs -f
 
-.PHONY: cqlsh
-cqlsh:
+cqlsh: .prepare-docker-compose
 	$(COMPOSE) exec scylla_node cqlsh -u cassandra -p cassandra
 
-.PHONY: shell
-shell:
+shell: .prepare-docker-compose
 	$(COMPOSE) exec scylla_node bash
 
-.PHONY: volumes
 volumes:
 	docker volume ls
 
-.PHONY: prune
 prune:
 	docker system prune -a --volumes
-
-.PHONY: clean
-clean: down
-	cargo clean

--- a/src/config.rs
+++ b/src/config.rs
@@ -780,6 +780,10 @@ impl AlternatorConfig {
         self.dynamodb_config.app_name()
     }
 
+    pub fn framework_metadata(&self) -> Vec<&aws_sdk_dynamodb::config::FrameworkMetadata> {
+        self.dynamodb_config.framework_metadata()
+    }
+
     pub fn invocation_id_generator(
         &self,
     ) -> Option<aws_runtime::invocation_id::SharedInvocationIdGenerator> {
@@ -1039,6 +1043,23 @@ impl AlternatorBuilder {
 
     pub fn set_app_name(&mut self, app_name: Option<aws_types::app_name::AppName>) -> &mut Self {
         self.dynamodb_builder.set_app_name(app_name);
+        self
+    }
+
+    pub fn framework_metadata(
+        mut self,
+        framework_metadata: aws_sdk_dynamodb::config::FrameworkMetadata,
+    ) -> Self {
+        self.dynamodb_builder = self.dynamodb_builder.framework_metadata(framework_metadata);
+        self
+    }
+
+    pub fn push_framework_metadata(
+        &mut self,
+        framework_metadata: aws_sdk_dynamodb::config::FrameworkMetadata,
+    ) -> &mut Self {
+        self.dynamodb_builder
+            .push_framework_metadata(framework_metadata);
         self
     }
 


### PR DESCRIPTION
## Summary
Re-applies the Makefile/workflow alignment from #66 to `main`. PR #66 was merged to `master` after the repository default branch had moved to `main`, so its changes were not reachable from `main`.

This cherry-picks commit 2a0883e26629951d794aee255f5acf34fb0ce353 from #66.

The DynamoDB framework metadata compatibility fix that was temporarily in this branch has been moved to #112.

## Changes
- replace old Rust-specific Makefile aliases with Java-style Alternator client stage targets
- update Rust CI workflow commands to use `make lint` and `make test-all`
- ignore generated Docker Compose/cache artifacts

## Testing
- `git diff --check origin/main..HEAD`
- `make -n test-all`
- `make lint`
- `make test-unit`

## Dependency
This PR may need #112 merged first for CI to stay green with the latest resolved AWS SDK.