### PR TITLE
fix: expose DynamoDB framework metadata config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-aws-sdk-dynamodb = "1.103.0"
+aws-sdk-dynamodb = "1.118.0"
 aws-smithy-async = "1.2.7"
 aws-smithy-runtime = "1.9.8"
 aws-smithy-runtime-api = "1.10.0"
@@ -28,7 +28,7 @@ http-body = "1.0"
 bytes = "1"
 
 [dev-dependencies]
-aws-sdk-dynamodb = { version = "1.103.0", features = ["test-util"] }
+aws-sdk-dynamodb = { version = "1.118.0", features = ["test-util"] }
 aws-smithy-types = "1.3.6"
 aws-smithy-http-client = { version = "1.1.5", features = ["rustls-aws-lc"] }
 uuid = { version = "1.22.0", features = ["v4"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -780,6 +780,10 @@ impl AlternatorConfig {
         self.dynamodb_config.app_name()
     }
 
+    pub fn framework_metadata(&self) -> Vec<&aws_sdk_dynamodb::config::FrameworkMetadata> {
+        self.dynamodb_config.framework_metadata()
+    }
+
     pub fn invocation_id_generator(
         &self,
     ) -> Option<aws_runtime::invocation_id::SharedInvocationIdGenerator> {
@@ -1039,6 +1043,23 @@ impl AlternatorBuilder {
 
     pub fn set_app_name(&mut self, app_name: Option<aws_types::app_name::AppName>) -> &mut Self {
         self.dynamodb_builder.set_app_name(app_name);
+        self
+    }
+
+    pub fn framework_metadata(
+        mut self,
+        framework_metadata: aws_sdk_dynamodb::config::FrameworkMetadata,
+    ) -> Self {
+        self.dynamodb_builder = self.dynamodb_builder.framework_metadata(framework_metadata);
+        self
+    }
+
+    pub fn push_framework_metadata(
+        &mut self,
+        framework_metadata: aws_sdk_dynamodb::config::FrameworkMetadata,
+    ) -> &mut Self {
+        self.dynamodb_builder
+            .push_framework_metadata(framework_metadata);
         self
     }
 


### PR DESCRIPTION
## Summary
Add passthrough support for the `framework_metadata` methods introduced by newer `aws-sdk-dynamodb` releases.

This keeps `AlternatorConfig` and `AlternatorBuilder` aligned with the DynamoDB config API surfaced by the compatibility test.

## Changes
- bump the DynamoDB dependency floor to `1.118.0`
- expose `AlternatorConfig::framework_metadata`
- expose `AlternatorBuilder::framework_metadata` and `push_framework_metadata`

## Testing
- `git diff --check origin/main..HEAD`
- `cargo +nightly test --test dynamodb_compatibility -- --nocapture`