### PR TITLE
add Alternator vector search API support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,12 @@ tokio-util = { version = "0.7", features = ["io"] }
 futures-util = "0.3"
 http-body = "1.0"
 bytes = "1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 aws-sdk-dynamodb = { version = "1.103.0", features = ["test-util"] }
+aws-smithy-runtime = { version = "1.9.8", features = ["test-util"] }
 aws-smithy-types = "1.3.6"
 aws-smithy-http-client = { version = "1.1.5", features = ["rustls-aws-lc"] }
 uuid = { version = "1.22.0", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ dashmap = "6.1.0"
 async-compression = { version = "0.4", features = ["tokio", "gzip", "zlib"] }
 tokio-util = { version = "0.7", features = ["io"] }
 futures-util = "0.3"
+base64 = "0.22"
 http-body = "1.0"
 bytes = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clippy:
 test: up
 	cargo test
 
-.PHONY: ccm-wrapper-tests load-balancing-tests ccm-tests
+.PHONY: ccm-wrapper-tests load-balancing-tests ccm-tests vector-store-e2e
 ccm-wrapper-tests:
 	RUSTFLAGS="--cfg ccm_tests" cargo test --test ccm_wrapper_tests -- --nocapture
 
@@ -34,6 +34,14 @@ load-balancing-tests:
 	RUSTFLAGS="--cfg ccm_tests" cargo test --test load_balancing_tests -- --nocapture
 
 ccm-tests: ccm-wrapper-tests load-balancing-tests
+
+# Opt-in Vector Store E2E test. Requires Docker (for Vector Store only) plus
+# SCYLLA_VECTOR_STORE_IMAGE, SCYLLA_VECTOR_STORE_PORT,
+# SCYLLA_VECTOR_STORE_SCYLLA_VERSION, and SCYLLA_VECTOR_STORE_SCYLLA_CONFIG.
+# Not part of `ccm-tests`/CI: no default Vector Store environment contract is
+# provided.
+vector-store-e2e:
+	RUSTFLAGS="--cfg ccm_tests" cargo test --test vector_store_e2e -- --nocapture
 
 .PHONY: up
 up:

--- a/README.md
+++ b/README.md
@@ -466,6 +466,318 @@ client
     .unwrap();
 ```
 
-`alternator_config_override` currently applies only Alternator-specific compression settings: request compression and response compression. Use the AWS SDK's `config_override` separately for supported SDK-level per-operation overrides.
+`alternator_config_override` currently applies only Alternator-specific settings: request compression, response compression, and `preserve_float32_vectors`. Use the AWS SDK's `config_override` separately for supported SDK-level per-operation overrides.
 
-> **Note**: load-balancing, endpoint, and header stripping settings cannot be overridden per-operation. They take effect only when the client is constructed. Per-operation override is limited to request/response compression settings.
+> **Note**: load-balancing, endpoint, and header stripping settings cannot be overridden per-operation. They take effect only when the client is constructed. Per-operation override is limited to request/response compression and `preserve_float32_vectors` settings.
+
+## Vector search
+
+Alternator's vector-search extensions (`VectorIndexes`, `VectorIndexUpdates`, `VectorSearch`, `Scores`, `FLOAT32VECTOR`) are exposed through extension traits (`CreateTableVectorExt`, `UpdateTableVectorExt`, `QueryVectorExt`, `DescribeTableVectorExt`) implemented directly on the ordinary AWS SDK fluent builders, without forking or patching `aws-sdk-dynamodb`. `FLOAT32VECTOR` response conversion applies to every successful operation performed through [`AlternatorClient`], regardless of whether a vector extension is used. The extension methods are needed only to inject Alternator-specific request fields (`VectorIndexes`, `VectorIndexUpdates`, `VectorSearch`) or to obtain non-SDK response metadata (`Scores`, parsed `VectorIndexes`).
+
+Ordinary AWS SDK request setters (`.table_name(...)`, `.key_condition_expression(...)`, etc.) must precede the vector extension method call: the extension is the boundary after which normal generated builder configuration ends. After that point, `.send()` returns a small response-aware wrapper for `CreateTable`, `Query`, and `DescribeTable` (`UpdateTable` has no extended response and keeps returning the generated `UpdateTableOutput`).
+
+### Creating and describing a table with vector indexes
+
+```rust
+use alternator_driver::*;
+use aws_sdk_dynamodb::types::{AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType};
+
+# async fn example(client: AlternatorClient) -> Result<(), Box<dyn std::error::Error>> {
+let vector_attribute = VectorAttribute::builder()
+    .attribute_name("embedding")
+    .dimensions(128)
+    .build()?;
+
+let index = VectorIndex::builder()
+    .index_name("embedding_idx")
+    .vector_attribute(vector_attribute)
+    .similarity_function(SimilarityFunction::Cosine)
+    .build()?;
+
+let created = client
+    .create_table()
+    .table_name("Documents")
+    .attribute_definitions(
+        AttributeDefinition::builder()
+            .attribute_name("pk")
+            .attribute_type(ScalarAttributeType::S)
+            .build()?,
+    )
+    .key_schema(
+        KeySchemaElement::builder()
+            .attribute_name("pk")
+            .key_type(KeyType::Hash)
+            .build()?,
+    )
+    .billing_mode(BillingMode::PayPerRequest)
+    .vector_indexes(vec![index])   // <-- vector extension boundary
+    .send()
+    .await?;
+
+println!("created indexes: {:?}", created.vector_indexes);
+
+let described = client
+    .describe_table()
+    .table_name("Documents")
+    .with_vector_indexes()
+    .send()
+    .await?;
+for index in &described.vector_indexes {
+    println!("{}: status={:?}", index.index_name, index.index_status);
+}
+# Ok(())
+# }
+```
+
+A `VectorIndex` with no `.projection(...)` configured omits the `Projection` field entirely, so the server applies its own default; this is distinct from explicitly requesting `Projection::keys_only()`.
+
+### Adding or deleting indexes with UpdateTable
+
+`UpdateTable.VectorIndexUpdates` must contain exactly one update per request; an empty list or more than one update fails locally before a request is sent. Vector-index updates also cannot be combined with generated `GlobalSecondaryIndexUpdates` in the same request (and should not be combined with Alternator Streams changes, though the driver cannot always detect that combination locally; the server enforces it). Issue a separate `UpdateTable` call for each index change:
+
+```rust
+use alternator_driver::*;
+
+# async fn example(client: AlternatorClient) -> Result<(), Box<dyn std::error::Error>> {
+let new_index = VectorIndex::builder()
+    .index_name("summary_idx")
+    .vector_attribute(
+        VectorAttribute::builder()
+            .attribute_name("summary_embedding")
+            .dimensions(64)
+            .build()?,
+    )
+    .build()?;
+
+client
+    .update_table()
+    .table_name("Documents")
+    .vector_index_updates(vec![VectorIndexUpdate::Create(new_index)])
+    .send()
+    .await?;
+
+client
+    .update_table()
+    .table_name("Documents")
+    .vector_index_updates(vec![VectorIndexUpdate::Delete { index_name: "old_idx".to_string() }])
+    .send()
+    .await?;
+# Ok(())
+# }
+```
+
+Wait for a newly created index's `index_status` to become `IndexStatus::Active` (via `.describe_table().with_vector_indexes()`) before querying it; the driver does not wait for this automatically.
+
+### Querying by vector similarity
+
+```rust
+use alternator_driver::*;
+
+# async fn example(client: AlternatorClient) -> Result<(), Box<dyn std::error::Error>> {
+let search = VectorSearch::new(vec![0.1, 0.2, 0.3, /* ... */])?
+    .with_return_scores(ReturnScores::Similarity);
+
+let result = client
+    .query()
+    .table_name("Documents")
+    .index_name("embedding_idx")
+    .limit(10)
+    .vector_search(search)
+    .send()
+    .await?;
+
+if let Some(scores) = &result.scores {
+    println!("scores: {:?}", scores);
+}
+for item in result.as_inner().items() {
+    println!("{:?}", item);
+}
+
+// Extended output types do not convert implicitly to their generated
+// counterparts; use `.as_inner()`/`.into_inner()` (or `.into()`, where
+// `From` is implemented) to obtain the plain generated type explicitly.
+let plain_output: aws_sdk_dynamodb::operation::query::QueryOutput = result.into_inner();
+# let _ = plain_output;
+# Ok(())
+# }
+```
+
+`VectorQueryOutput` always contains the normal `QueryOutput` plus `scores: Option<Vec<f64>>`; there is no separate overload for score/no-score queries. `client.query().send()`, without `.vector_search(...)`, is unaffected and continues to return the AWS SDK's own `QueryOutput`.
+
+On the wire, the query vector is nested under `VectorSearch.QueryVector`, alongside `ReturnScores` when requested:
+
+```json
+{ "VectorSearch": { "QueryVector": { "FLOAT32VECTOR": [0.1, 0.2, 0.3] }, "ReturnScores": "SIMILARITY" } }
+```
+
+`VectorSearch::new` builds the compact `FLOAT32VECTOR` form shown above. To send a standard DynamoDB list query vector (`{"L": [{"N": "..."}, ...]}`) instead, use `VectorSearch::from_query_vector` with `AttributeValue::N` values:
+
+```rust
+use alternator_driver::*;
+use aws_sdk_dynamodb::types::AttributeValue;
+
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
+let search = VectorSearch::from_query_vector(vec![
+    AttributeValue::N("0.1".to_string()),
+    AttributeValue::N("0.2".to_string()),
+    AttributeValue::N("0.3".to_string()),
+])?;
+# let _ = search;
+# Ok(())
+# }
+```
+
+A vector-search query is validated locally before it is ever sent, and fails with a local error (no request reaches the server) when:
+
+- `IndexName` is missing.
+- `Limit` is missing, `0`, or greater than `1000` (vector-search queries always require an explicit `Limit` in `1..=1000`).
+- `ConsistentRead(true)` is set.
+- `ExclusiveStartKey` is set.
+- `ScanIndexForward` is set.
+- The legacy `QueryFilter` is set.
+- `ReturnScores::Similarity` is combined with `Select::Count`.
+
+Schema-dependent validation, such as whether the named index actually exists or query-vector dimensionality matches the index, remains server-owned: the driver only rejects combinations it can determine are invalid without contacting the server. `Projection = INCLUDE` and `KeyConditionExpression` support (as a projected-attribute pre-filter) are server-version-dependent; consult your Alternator/Vector Store version's capabilities.
+
+The driver never waits for an index to become ready on your behalf: after `CreateTable`/`UpdateTable`, poll `.describe_table().with_vector_indexes()` yourself until `index_status` is `IndexStatus::Active` before querying it.
+
+### Per-request configuration with `.customize()`
+
+The direct form shown above is equivalent to calling `.customize()` first. Use the `.customize()` form only when you also need a per-operation override, such as `alternator_config_override(...)`:
+
+```rust
+use alternator_driver::*;
+
+# async fn example(client: AlternatorClient) -> Result<(), Box<dyn std::error::Error>> {
+let search = VectorSearch::new(vec![0.1, 0.2, 0.3])?;
+
+let result = client
+    .query()
+    .table_name("Documents")
+    .customize()
+    .vector_search(search)
+    .alternator_config_override(
+        AlternatorConfig::operation_builder().preserve_float32_vectors(true),
+    )
+    .send()
+    .await?;
+# let _ = result;
+# Ok(())
+# }
+```
+
+`preserve_float32_vectors` is set through the general `alternator_config_override(...)` mechanism (see [Per-operation override](#per-operation-override)) rather than a vector-specific setter, and the response-aware wrappers (`VectorQueryOperation`, `VectorCreateTableOperation`, `VectorDescribeTableOperation`) expose it too, so it composes with the direct form:
+
+```rust
+use alternator_driver::*;
+
+# async fn example(client: AlternatorClient) -> Result<(), Box<dyn std::error::Error>> {
+let search = VectorSearch::new(vec![0.1, 0.2, 0.3])?;
+
+let result = client
+    .query()
+    .table_name("Documents")
+    .vector_search(search)
+    .alternator_config_override(
+        AlternatorConfig::operation_builder().preserve_float32_vectors(true),
+    )
+    .send()
+    .await?;
+# let _ = result;
+# Ok(())
+# }
+```
+
+### Writing and reading `FLOAT32VECTOR` attributes
+
+Write compact vectors with `Float32Vector::to_attribute_value`, which produces an ordinary `AttributeValue::B` that the driver recognizes and rewrites to `FLOAT32VECTOR` on the wire. It returns an error if any value is not finite (NaN or infinity), since Alternator serializes vector elements as JSON numbers:
+
+```rust
+use alternator_driver::*;
+use aws_sdk_dynamodb::types::AttributeValue;
+
+# async fn example(client: AlternatorClient) -> Result<(), Box<dyn std::error::Error>> {
+client
+    .put_item()
+    .table_name("Documents")
+    .item("pk", AttributeValue::S("doc-1".into()))
+    .item(
+        "embedding",
+        Float32Vector::to_attribute_value(vec![0.1, 0.2, 0.3])?,
+    )
+    .send()
+    .await?;
+# Ok(())
+# }
+```
+
+By default, reading a `FLOAT32VECTOR` attribute back gives you an ordinary `AttributeValue::L` of `AttributeValue::N` values, matching the Java driver's default and requiring no Alternator-specific types. This conversion applies to every successful operation through `AlternatorClient`, whether or not a vector extension was used to build the request:
+
+```rust
+use alternator_driver::*;
+use aws_sdk_dynamodb::types::AttributeValue;
+
+# async fn example(client: AlternatorClient) -> Result<(), Box<dyn std::error::Error>> {
+let output = client
+    .get_item()
+    .table_name("Documents")
+    .key("pk", AttributeValue::S("doc-1".into()))
+    .send()
+    .await?;
+
+// `embedding` is AttributeValue::L([N("0.1"), N("0.2"), N("0.3")])
+let embedding = output.item().unwrap().get("embedding").unwrap();
+# let _ = embedding;
+# Ok(())
+# }
+```
+
+Ordinary DynamoDB `L` lists of `N` values are never inferred to be vectors: a caller who inserts a plain decimal list gets ordinary DynamoDB list behavior back, never a `FLOAT32VECTOR` conversion.
+
+### Preserving compact storage for read-modify-write
+
+If your application understands optimized vectors and needs a lossless read-modify-write round trip, enable `preserve_float32_vectors`:
+
+```rust
+use alternator_driver::{AlternatorClient, AlternatorConfig};
+
+let client = AlternatorClient::from_conf(
+    AlternatorConfig::builder()
+        .endpoint_url("http://10.0.0.1:8043")
+        .preserve_float32_vectors(true)
+        .behavior_version_latest()
+        .build(),
+);
+```
+
+With this enabled, `FLOAT32VECTOR` responses are decoded into a marker `AttributeValue::B` instead of `L`/`N`. Read it with the `Float32VectorExt` extension trait:
+
+```rust
+use alternator_driver::*;
+use aws_sdk_dynamodb::types::AttributeValue;
+
+# fn example(embedding: &AttributeValue) -> Result<(), Box<dyn std::error::Error>> {
+if embedding.is_float32_vector() {
+    let values: Vec<f32> = embedding.float32_vector()?;
+    println!("{:?}", values);
+}
+# Ok(())
+# }
+```
+
+An item fetched this way can be written back unchanged (e.g. via `PutItem`, `UpdateItem`, or `BatchWriteItem`) and will retain compact `FLOAT32VECTOR` storage, because the marker binary round-trips through the same rewrite the driver applies to values built with `Float32Vector::to_attribute_value`. Without `preserve_float32_vectors`, the default `L`/`N` conversion is not reversible into compact storage: writing back a converted list stores an ordinary DynamoDB list, not a vector.
+
+### Index and vector limits
+
+`VectorAttribute::builder().dimensions(...)` accepts `1..=16000`; values above `16000` are rejected locally when the index is built, before any request is sent.
+
+### Real Vector Store end-to-end tests
+
+`tests/vector_store_e2e.rs` exercises vector search against a real Vector Store instance provisioned through CCM. It is gated behind `--cfg ccm_tests` and is not part of the default `make test`/CI run: it requires Docker (Vector Store itself runs in a container with `--network host`) plus the environment variables `SCYLLA_VECTOR_STORE_IMAGE`, `SCYLLA_VECTOR_STORE_PORT`, `SCYLLA_VECTOR_STORE_SCYLLA_VERSION` (a CCM-resolvable Scylla version with native Vector/Scores support, e.g. `unstable/master:latest`; standard `release:*` versions do not have it yet), and `SCYLLA_VECTOR_STORE_SCYLLA_CONFIG`. Run it with:
+
+```bash
+make vector-store-e2e
+```
+
+See the module doc comment at the top of `tests/vector_store_e2e.rs` for full setup details.
+

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,6 +46,7 @@ impl AlternatorClient {
         let response_compression = extensions.response_compression.unwrap_or_default();
         let optimize_headers = extensions.optimize_headers.unwrap_or(true);
         let user_agent = extensions.user_agent.unwrap_or_default();
+        let preserve_float32_vectors = extensions.preserve_float32_vectors.unwrap_or(false);
         let has_credentials_provider = config.has_credentials_provider();
         let has_region = dynamodb_config.region().is_some();
 
@@ -61,6 +62,7 @@ impl AlternatorClient {
             optimize_headers,
             user_agent,
             has_credentials_provider,
+            preserve_float32_vectors,
         ));
 
         // If live nodes are not in config - create new config with live nodes.

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ pub(crate) struct AlternatorExtensions {
     pub(crate) seed_hosts: Option<Vec<String>>,
     pub(crate) live_nodes: Option<std::sync::Arc<LiveNodes>>,
     pub(crate) key_route_affinity: Option<keyrouting::affinity_config::KeyRouteAffinityConfig>,
+    pub(crate) preserve_float32_vectors: Option<bool>,
 }
 
 const INCOMPATIBLE_AUTH_OPTIONS_MESSAGE: &str = "require_auth() cannot be combined with allow_no_auth(): require_auth() makes missing credentials fail before sending an unsigned request, while allow_no_auth() explicitly permits unsigned requests.";
@@ -95,6 +96,15 @@ impl AlternatorConfig {
     /// Turned on by default.
     pub fn optimize_headers(&self) -> Option<bool> {
         self.alternator_ext.optimize_headers
+    }
+
+    /// Whether `FLOAT32VECTOR` response attributes are preserved as compact
+    /// marker binary values instead of the default DynamoDB `L`/`N`
+    /// conversion.
+    ///
+    /// Defaults to `false` when unset.
+    pub fn preserve_float32_vectors(&self) -> Option<bool> {
+        self.alternator_ext.preserve_float32_vectors
     }
 
     /// Gets the configured final `User-Agent` behavior.
@@ -285,6 +295,7 @@ impl AlternatorConfig {
 pub struct AlternatorOperationBuilder {
     pub(crate) request_compression: Option<RequestCompression>,
     pub(crate) response_compression: Option<ResponseCompression>,
+    pub(crate) preserve_float32_vectors: Option<bool>,
 }
 
 impl AlternatorOperationBuilder {
@@ -301,6 +312,16 @@ impl AlternatorOperationBuilder {
     /// Configure which response encodings this request advertises via `Accept-Encoding`.
     pub fn response_compression(mut self, response_compression: ResponseCompression) -> Self {
         self.response_compression = Some(response_compression);
+        self
+    }
+
+    /// Override whether `FLOAT32VECTOR` response attributes are preserved as
+    /// compact marker binary values for this request only.
+    ///
+    /// Takes precedence over the client-level
+    /// [`AlternatorBuilder::preserve_float32_vectors`] setting.
+    pub fn preserve_float32_vectors(mut self, preserve: bool) -> Self {
+        self.preserve_float32_vectors = Some(preserve);
         self
     }
 }
@@ -370,6 +391,26 @@ impl AlternatorBuilder {
     /// Turned on by default.
     pub fn set_optimize_headers(&mut self, optimize: bool) -> &mut Self {
         self.alternator_ext.optimize_headers = Some(optimize);
+        self
+    }
+
+    /// Whether `FLOAT32VECTOR` response attributes should be preserved as
+    /// compact marker binary values (readable via
+    /// [`Float32VectorExt`](crate::Float32VectorExt)) instead of the
+    /// default DynamoDB `L`/`N` conversion.
+    ///
+    /// Defaults to `false`: responses convert `FLOAT32VECTOR` attributes to
+    /// ordinary `AttributeValue::L` lists of `AttributeValue::N`, matching
+    /// the Java driver's default and requiring no Alternator-specific types
+    /// to read vector data.
+    pub fn preserve_float32_vectors(mut self, preserve: bool) -> Self {
+        self.set_preserve_float32_vectors(preserve);
+        self
+    }
+
+    /// Same as [`Self::preserve_float32_vectors`], but by mutable reference.
+    pub fn set_preserve_float32_vectors(&mut self, preserve: bool) -> &mut Self {
+        self.alternator_ext.preserve_float32_vectors = Some(preserve);
         self
     }
 

--- a/src/customize.rs
+++ b/src/customize.rs
@@ -36,7 +36,8 @@ use aws_sdk_dynamodb::client::customize::CustomizableOperation;
 /// # });
 /// ```
 ///
-/// Only request and response compression are supported here. Use the AWS SDK's
+/// Only request compression, response compression, and
+/// `preserve_float32_vectors` are supported here. Use the AWS SDK's
 /// `config_override(...)` separately for supported SDK-level per-operation
 /// overrides.
 ///
@@ -84,6 +85,12 @@ impl<T, E, B> AlternatorCustomizableOperation<T, E, B> for CustomizableOperation
         if let Some(response_compression) = config_override.response_compression {
             this = this.interceptor(AlternatorOverrideInterceptor::for_response_compression(
                 response_compression,
+            ));
+        }
+
+        if let Some(preserve_float32_vectors) = config_override.preserve_float32_vectors {
+            this = this.interceptor(AlternatorOverrideInterceptor::for_preserve_float32_vectors(
+                preserve_float32_vectors,
             ));
         }
 

--- a/src/float32_vector.rs
+++ b/src/float32_vector.rs
@@ -159,6 +159,21 @@ pub(crate) fn rewrite_request_json_markers(value: &mut serde_json::Value) {
     }
 }
 
+/// Converts the generated SDK's attribute-value representation into its wire
+/// JSON shape so extension fields can embed an attribute value directly.
+pub(crate) fn attribute_value_to_json(value: &AttributeValue) -> serde_json::Value {
+    match value {
+        AttributeValue::B(blob) => serde_json::json!({
+            "B": base64::engine::general_purpose::STANDARD.encode(blob.as_ref())
+        }),
+        AttributeValue::N(number) => serde_json::json!({ "N": number }),
+        AttributeValue::L(values) => serde_json::json!({
+            "L": values.iter().map(attribute_value_to_json).collect::<Vec<_>>()
+        }),
+        _ => unreachable!("VectorSearch accepts only FLOAT32VECTOR markers or numeric lists"),
+    }
+}
+
 /// Extension trait providing read access to `FLOAT32VECTOR` marker values
 /// without mutating the received `AttributeValue`.
 pub trait Float32VectorExt {
@@ -263,45 +278,6 @@ pub(crate) fn rewrite_response_json_markers(value: &mut serde_json::Value, prese
 /// in scientific notation for the magnitudes vectors use.
 fn format_n(v: f64) -> String {
     v.to_string()
-}
-
-/// Converts a generated [`AttributeValue`] into the DynamoDB/Alternator
-/// wire-format JSON object it would be serialized as, e.g.
-/// `{"N": "1"}` or `{"L": [...]}`. Used for driver-constructed request
-/// extras (such as `VectorSearch.QueryVector`) that the generated SDK does
-/// not know how to serialize on its own.
-pub(crate) fn attribute_value_to_json(av: &AttributeValue) -> serde_json::Value {
-    match av {
-        AttributeValue::B(blob) => {
-            let b64 = base64::engine::general_purpose::STANDARD.encode(blob.as_ref());
-            serde_json::json!({ "B": b64 })
-        }
-        AttributeValue::Bool(b) => serde_json::json!({ "BOOL": b }),
-        AttributeValue::Bs(blobs) => {
-            let items: Vec<String> = blobs
-                .iter()
-                .map(|b| base64::engine::general_purpose::STANDARD.encode(b.as_ref()))
-                .collect();
-            serde_json::json!({ "BS": items })
-        }
-        AttributeValue::L(items) => {
-            let items: Vec<serde_json::Value> = items.iter().map(attribute_value_to_json).collect();
-            serde_json::json!({ "L": items })
-        }
-        AttributeValue::M(map) => {
-            let obj: serde_json::Map<String, serde_json::Value> = map
-                .iter()
-                .map(|(k, v)| (k.clone(), attribute_value_to_json(v)))
-                .collect();
-            serde_json::json!({ "M": obj })
-        }
-        AttributeValue::N(n) => serde_json::json!({ "N": n }),
-        AttributeValue::Ns(ns) => serde_json::json!({ "NS": ns }),
-        AttributeValue::Null(n) => serde_json::json!({ "NULL": n }),
-        AttributeValue::S(s) => serde_json::json!({ "S": s }),
-        AttributeValue::Ss(ss) => serde_json::json!({ "SS": ss }),
-        _ => serde_json::Value::Null,
-    }
 }
 
 #[cfg(test)]

--- a/src/float32_vector.rs
+++ b/src/float32_vector.rs
@@ -1,0 +1,421 @@
+//! Compact `FLOAT32VECTOR` transport marker encoding.
+//!
+//! Alternator's `FLOAT32VECTOR` attribute type has no equivalent in the
+//! generated AWS SDK's `AttributeValue` union. To let callers construct and
+//! (optionally) preserve compact vector values using only standard SDK
+//! types, this module encodes a `FLOAT32VECTOR` payload as an ordinary
+//! `AttributeValue::B` binary value carrying a private magic prefix followed
+//! by big-endian IEEE-754 `f32` values.
+//!
+//! This marker is purely an internal transport representation:
+//! [`AlternatorInterceptor`](crate) rewrites marker binaries into
+//! `{"FLOAT32VECTOR": [...]}` in outgoing request JSON, and can rewrite
+//! `FLOAT32VECTOR` response fields back into marker binaries when
+//! `preserve_float32_vectors` is enabled. Ordinary binary values that do not
+//! match the exact magic prefix and a payload length divisible by
+//! `size_of::<f32>()` are left untouched and are never misinterpreted as
+//! vectors.
+
+use aws_sdk_dynamodb::primitives::Blob;
+use aws_sdk_dynamodb::types::AttributeValue;
+use base64::Engine as _;
+use std::fmt;
+use std::sync::OnceLock;
+
+/// Private magic prefix identifying a `FLOAT32VECTOR` marker binary.
+///
+/// Chosen to be exceedingly unlikely to collide with real-world binary
+/// attribute values: 8 bytes, non-printable, versioned.
+const MAGIC_PREFIX: &[u8; 8] = &[0xAC, b'A', b'V', b'1', 0xF3, 0x2E, 0x00, 0x7F];
+
+/// Error returned when decoding a value as a `FLOAT32VECTOR` marker fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Float32VectorError {
+    /// The value is not an `AttributeValue::B` at all.
+    NotBinary,
+    /// The binary value does not start with the marker's magic prefix.
+    NotAMarker,
+    /// The marker payload length is not a multiple of `size_of::<f32>()`.
+    InvalidPayloadLength { len: usize },
+    /// A value to be encoded was not finite (NaN or +/-infinity). Alternator
+    /// serializes `FLOAT32VECTOR` elements as JSON numbers, which cannot
+    /// represent non-finite values (they would be emitted as `null`).
+    NonFiniteValue,
+}
+
+impl fmt::Display for Float32VectorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Float32VectorError::NotBinary => write!(f, "value is not an AttributeValue::B"),
+            Float32VectorError::NotAMarker => {
+                write!(f, "binary value is not a FLOAT32VECTOR marker")
+            }
+            Float32VectorError::InvalidPayloadLength { len } => write!(
+                f,
+                "FLOAT32VECTOR marker payload length {len} is not a multiple of 4 bytes"
+            ),
+            Float32VectorError::NonFiniteValue => write!(
+                f,
+                "FLOAT32VECTOR values must be finite (no NaN or infinity)"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Float32VectorError {}
+
+/// Constructs `FLOAT32VECTOR` marker attribute values.
+///
+/// This is a namespace type; use [`Float32Vector::to_attribute_value`] to
+/// build a marker `AttributeValue::B` from `f32` values, and
+/// [`Float32VectorExt`] to read one back.
+#[derive(Debug, Clone, Copy)]
+pub struct Float32Vector;
+
+impl Float32Vector {
+    /// Encodes `values` as a marker `AttributeValue::B`. Returns
+    /// [`Float32VectorError::NonFiniteValue`] if any value is NaN or
+    /// infinite, since Alternator serializes `FLOAT32VECTOR` elements as
+    /// JSON numbers, which cannot represent non-finite values (they would
+    /// be emitted as `null`).
+    ///
+    /// The result should only be sent as part of a request: the driver's
+    /// interceptor recognizes the marker and rewrites it to
+    /// `{"FLOAT32VECTOR": [...]}` in the serialized JSON body immediately
+    /// before compression.
+    pub fn to_attribute_value(
+        values: impl IntoIterator<Item = f32>,
+    ) -> Result<AttributeValue, Float32VectorError> {
+        let mut bytes = Vec::with_capacity(MAGIC_PREFIX.len());
+        bytes.extend_from_slice(MAGIC_PREFIX);
+        for v in values {
+            if !v.is_finite() {
+                return Err(Float32VectorError::NonFiniteValue);
+            }
+            bytes.extend_from_slice(&v.to_be_bytes());
+        }
+        Ok(AttributeValue::B(Blob::new(bytes)))
+    }
+
+    /// Returns whether `bytes` is a validly-formed marker payload (correct
+    /// prefix and a length divisible by `size_of::<f32>()`).
+    pub(crate) fn is_marker_bytes(bytes: &[u8]) -> bool {
+        bytes.len() >= MAGIC_PREFIX.len()
+            && &bytes[..MAGIC_PREFIX.len()] == MAGIC_PREFIX
+            && (bytes.len() - MAGIC_PREFIX.len()).is_multiple_of(std::mem::size_of::<f32>())
+    }
+
+    /// Decodes marker `bytes` (prefix included) into `f32` values.
+    ///
+    /// Panics-free: callers must have already validated the bytes with
+    /// [`Float32Vector::is_marker_bytes`], as done internally by
+    /// [`Float32VectorExt`].
+    pub(crate) fn decode_marker_bytes(bytes: &[u8]) -> Vec<f32> {
+        bytes[MAGIC_PREFIX.len()..]
+            .chunks_exact(std::mem::size_of::<f32>())
+            .map(|chunk| f32::from_be_bytes(chunk.try_into().expect("chunk is exactly 4 bytes")))
+            .collect()
+    }
+}
+
+/// A base64 substring guaranteed to be present whenever a marker binary
+/// value's raw bytes are base64-encoded into JSON, used as a fast
+/// pre-check before paying the cost of a full JSON parse + recursive scan.
+///
+/// Only the first 6 bytes of the 8-byte magic prefix are used, since
+/// base64 3-byte group boundaries guarantee those 6 bytes always encode
+/// to the same 8 leading base64 characters regardless of what follows.
+pub(crate) fn quick_base64_signature() -> &'static str {
+    static SIG: OnceLock<String> = OnceLock::new();
+    SIG.get_or_init(|| base64::engine::general_purpose::STANDARD.encode(&MAGIC_PREFIX[..6]))
+}
+
+/// Recursively rewrites marker `{"B": "<base64>"}` attribute-value JSON
+/// objects into `{"FLOAT32VECTOR": [...]}` throughout `value`, including
+/// nested maps, lists, and batch/transaction payloads. Non-marker binary
+/// values and all other JSON are left unchanged.
+pub(crate) fn rewrite_request_json_markers(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.len() == 1
+                && let Some(serde_json::Value::String(b64)) = map.get("B")
+                && let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(b64)
+                && Float32Vector::is_marker_bytes(&bytes)
+            {
+                let values = Float32Vector::decode_marker_bytes(&bytes);
+                *value = serde_json::json!({ "FLOAT32VECTOR": values });
+                return;
+            }
+            for v in map.values_mut() {
+                rewrite_request_json_markers(v);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                rewrite_request_json_markers(v);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Extension trait providing read access to `FLOAT32VECTOR` marker values
+/// without mutating the received `AttributeValue`.
+pub trait Float32VectorExt {
+    /// Returns whether this value is a valid `FLOAT32VECTOR` marker binary.
+    fn is_float32_vector(&self) -> bool;
+
+    /// Decodes this value as a `FLOAT32VECTOR` marker, returning its `f32`
+    /// components. This is the inverse of
+    /// [`Float32Vector::to_attribute_value`].
+    fn float32_vector(&self) -> Result<Vec<f32>, Float32VectorError>;
+
+    /// Decodes this value as a `FLOAT32VECTOR` marker and returns its
+    /// components as a standard DynamoDB list of `AttributeValue::N`,
+    /// matching the shape of a default (non-preserving) response.
+    fn float32_vector_list(&self) -> Result<Vec<AttributeValue>, Float32VectorError>;
+}
+
+impl Float32VectorExt for AttributeValue {
+    fn is_float32_vector(&self) -> bool {
+        matches!(self, AttributeValue::B(blob) if Float32Vector::is_marker_bytes(blob.as_ref()))
+    }
+
+    fn float32_vector(&self) -> Result<Vec<f32>, Float32VectorError> {
+        let AttributeValue::B(blob) = self else {
+            return Err(Float32VectorError::NotBinary);
+        };
+        let bytes = blob.as_ref();
+        if !Float32Vector::is_marker_bytes(bytes) {
+            if bytes.len() < MAGIC_PREFIX.len() || &bytes[..MAGIC_PREFIX.len()] != MAGIC_PREFIX {
+                return Err(Float32VectorError::NotAMarker);
+            }
+            return Err(Float32VectorError::InvalidPayloadLength {
+                len: bytes.len() - MAGIC_PREFIX.len(),
+            });
+        }
+        Ok(Float32Vector::decode_marker_bytes(bytes))
+    }
+
+    fn float32_vector_list(&self) -> Result<Vec<AttributeValue>, Float32VectorError> {
+        Ok(self
+            .float32_vector()?
+            .into_iter()
+            .map(|v| AttributeValue::N(v.to_string()))
+            .collect())
+    }
+}
+
+/// Recursively rewrites `{"FLOAT32VECTOR": [...]}` response JSON objects
+/// throughout `value` before generated SDK deserialization.
+///
+/// By default (`preserve == false`) each match becomes a standard
+/// `{"L": [{"N": "..."}, ...]}` DynamoDB list, matching the Java driver's
+/// default and requiring no Alternator-specific types to read vector data.
+/// When `preserve == true`, each match instead becomes a marker
+/// `{"B": "<base64>"}` binary value that can be written back unchanged to
+/// retain compact storage.
+///
+/// Ordinary `L` and `B` values elsewhere in the document are never
+/// inferred to be vectors and are left unchanged.
+pub(crate) fn rewrite_response_json_markers(value: &mut serde_json::Value, preserve: bool) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.len() == 1
+                && let Some(serde_json::Value::Array(nums)) = map.get("FLOAT32VECTOR")
+                && let Some(values) = nums.iter().map(|n| n.as_f64()).collect::<Option<Vec<_>>>()
+            {
+                *value = if preserve {
+                    // `serde_json::Value` numbers are always finite (JSON
+                    // has no NaN/infinity), so encoding cannot fail here.
+                    let marker =
+                        Float32Vector::to_attribute_value(values.into_iter().map(|v| v as f32))
+                            .expect("response FLOAT32VECTOR values are always finite JSON numbers");
+                    let AttributeValue::B(blob) = &marker else {
+                        unreachable!()
+                    };
+                    let b64 = base64::engine::general_purpose::STANDARD.encode(blob.as_ref());
+                    serde_json::json!({ "B": b64 })
+                } else {
+                    let list: Vec<serde_json::Value> = values
+                        .into_iter()
+                        .map(|v| serde_json::json!({ "N": format_n(v) }))
+                        .collect();
+                    serde_json::json!({ "L": list })
+                };
+                return;
+            }
+            for v in map.values_mut() {
+                rewrite_response_json_markers(v, preserve);
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for v in arr.iter_mut() {
+                rewrite_response_json_markers(v, preserve);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Formats an f64 (originally an f32) the way DynamoDB `N` values are
+/// conventionally rendered: without unnecessary trailing zeros, but never
+/// in scientific notation for the magnitudes vectors use.
+fn format_n(v: f64) -> String {
+    v.to_string()
+}
+
+/// Converts a generated [`AttributeValue`] into the DynamoDB/Alternator
+/// wire-format JSON object it would be serialized as, e.g.
+/// `{"N": "1"}` or `{"L": [...]}`. Used for driver-constructed request
+/// extras (such as `VectorSearch.QueryVector`) that the generated SDK does
+/// not know how to serialize on its own.
+pub(crate) fn attribute_value_to_json(av: &AttributeValue) -> serde_json::Value {
+    match av {
+        AttributeValue::B(blob) => {
+            let b64 = base64::engine::general_purpose::STANDARD.encode(blob.as_ref());
+            serde_json::json!({ "B": b64 })
+        }
+        AttributeValue::Bool(b) => serde_json::json!({ "BOOL": b }),
+        AttributeValue::Bs(blobs) => {
+            let items: Vec<String> = blobs
+                .iter()
+                .map(|b| base64::engine::general_purpose::STANDARD.encode(b.as_ref()))
+                .collect();
+            serde_json::json!({ "BS": items })
+        }
+        AttributeValue::L(items) => {
+            let items: Vec<serde_json::Value> = items.iter().map(attribute_value_to_json).collect();
+            serde_json::json!({ "L": items })
+        }
+        AttributeValue::M(map) => {
+            let obj: serde_json::Map<String, serde_json::Value> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), attribute_value_to_json(v)))
+                .collect();
+            serde_json::json!({ "M": obj })
+        }
+        AttributeValue::N(n) => serde_json::json!({ "N": n }),
+        AttributeValue::Ns(ns) => serde_json::json!({ "NS": ns }),
+        AttributeValue::Null(n) => serde_json::json!({ "NULL": n }),
+        AttributeValue::S(s) => serde_json::json!({ "S": s }),
+        AttributeValue::Ss(ss) => serde_json::json!({ "SS": ss }),
+        _ => serde_json::Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_values() {
+        let values = vec![1.0f32, -2.5, 0.0, f32::MAX, f32::MIN];
+        let av = Float32Vector::to_attribute_value(values.clone()).unwrap();
+        assert!(av.is_float32_vector());
+        assert_eq!(av.float32_vector().unwrap(), values);
+    }
+
+    #[test]
+    fn empty_vector_round_trips() {
+        let av = Float32Vector::to_attribute_value(Vec::<f32>::new()).unwrap();
+        assert!(av.is_float32_vector());
+        assert_eq!(av.float32_vector().unwrap(), Vec::<f32>::new());
+    }
+
+    #[test]
+    fn float32_vector_list_converts_to_n_values() {
+        let av = Float32Vector::to_attribute_value(vec![1.0, 2.0]).unwrap();
+        let list = av.float32_vector_list().unwrap();
+        assert_eq!(
+            list,
+            vec![AttributeValue::N("1".into()), AttributeValue::N("2".into())]
+        );
+    }
+
+    #[test]
+    fn rejects_non_binary_values() {
+        let av = AttributeValue::S("hello".into());
+        assert!(!av.is_float32_vector());
+        assert_eq!(av.float32_vector(), Err(Float32VectorError::NotBinary));
+    }
+
+    #[test]
+    fn rejects_ordinary_binary_without_prefix() {
+        let av = AttributeValue::B(Blob::new(vec![1, 2, 3, 4]));
+        assert!(!av.is_float32_vector());
+        assert_eq!(av.float32_vector(), Err(Float32VectorError::NotAMarker));
+    }
+
+    #[test]
+    fn rejects_marker_prefix_with_invalid_payload_length() {
+        let mut bytes = MAGIC_PREFIX.to_vec();
+        bytes.extend_from_slice(&[1, 2, 3]); // not a multiple of 4
+        let av = AttributeValue::B(Blob::new(bytes));
+        assert!(!av.is_float32_vector());
+        assert_eq!(
+            av.float32_vector(),
+            Err(Float32VectorError::InvalidPayloadLength { len: 3 })
+        );
+    }
+
+    #[test]
+    fn to_attribute_value_rejects_non_finite_values() {
+        assert_eq!(
+            Float32Vector::to_attribute_value(vec![1.0, f32::NAN]),
+            Err(Float32VectorError::NonFiniteValue)
+        );
+        assert_eq!(
+            Float32Vector::to_attribute_value(vec![f32::INFINITY]),
+            Err(Float32VectorError::NonFiniteValue)
+        );
+        assert_eq!(
+            Float32Vector::to_attribute_value(vec![f32::NEG_INFINITY]),
+            Err(Float32VectorError::NonFiniteValue)
+        );
+    }
+
+    #[test]
+    fn is_marker_bytes_accepts_prefix_only() {
+        assert!(Float32Vector::is_marker_bytes(MAGIC_PREFIX));
+    }
+
+    #[test]
+    fn rewrite_request_json_markers_replaces_marker_binary() {
+        let av = Float32Vector::to_attribute_value(vec![1.0, 2.0]).unwrap();
+        let AttributeValue::B(blob) = &av else {
+            unreachable!()
+        };
+        let b64 = base64::engine::general_purpose::STANDARD.encode(blob.as_ref());
+        let mut json = serde_json::json!({
+            "Item": {
+                "embedding": { "B": b64 },
+                "name": { "S": "hello" }
+            }
+        });
+        rewrite_request_json_markers(&mut json);
+        assert_eq!(
+            json["Item"]["embedding"],
+            serde_json::json!({ "FLOAT32VECTOR": [1.0, 2.0] })
+        );
+        assert_eq!(json["Item"]["name"], serde_json::json!({ "S": "hello" }));
+    }
+
+    #[test]
+    fn rewrite_request_json_markers_leaves_ordinary_binary_unchanged() {
+        let b64 = base64::engine::general_purpose::STANDARD.encode([1, 2, 3, 4]);
+        let mut json = serde_json::json!({ "attr": { "B": b64.clone() } });
+        rewrite_request_json_markers(&mut json);
+        assert_eq!(json["attr"], serde_json::json!({ "B": b64 }));
+    }
+
+    #[test]
+    fn quick_base64_signature_matches_encoded_marker() {
+        let av = Float32Vector::to_attribute_value(vec![1.0]).unwrap();
+        let AttributeValue::B(blob) = &av else {
+            unreachable!()
+        };
+        let b64 = base64::engine::general_purpose::STANDARD.encode(blob.as_ref());
+        assert!(b64.starts_with(quick_base64_signature()));
+    }
+}

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -37,6 +37,7 @@ pub(crate) struct AlternatorInterceptor {
     optimize_headers: bool,
     user_agent: UserAgent,
     preserve_auth_headers: bool,
+    preserve_float32_vectors: bool,
 }
 impl AlternatorInterceptor {
     pub fn new(
@@ -45,6 +46,7 @@ impl AlternatorInterceptor {
         optimize_headers: bool,
         user_agent: UserAgent,
         preserve_auth_headers: bool,
+        preserve_float32_vectors: bool,
     ) -> Self {
         Self {
             request_compression,
@@ -52,6 +54,7 @@ impl AlternatorInterceptor {
             optimize_headers,
             user_agent,
             preserve_auth_headers,
+            preserve_float32_vectors,
         }
     }
 }
@@ -186,7 +189,7 @@ impl Intercept for AlternatorInterceptor {
         &self,
         context: &mut BeforeDeserializationInterceptorContextMut<'_>,
         _: &RuntimeComponents,
-        _cfg: &mut ConfigBag,
+        cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
         let response = context.response_mut();
 
@@ -211,21 +214,66 @@ impl Intercept for AlternatorInterceptor {
             }
         }
 
-        if algorithms.is_empty() {
-            return Ok(());
+        let was_compressed = !algorithms.is_empty();
+
+        if was_compressed {
+            // Take the body and wrap it with decompression
+            let body = std::mem::replace(
+                response.body_mut(),
+                aws_smithy_types::body::SdkBody::empty(),
+            );
+            let decompressed_body = crate::decompression::wrap_decompressed_body(body, algorithms)?;
+            *response.body_mut() = decompressed_body;
+
+            // Strip Content-Encoding and Content-Length headers
+            response.headers_mut().remove("content-encoding");
+            response.headers_mut().remove("content-length");
         }
 
-        // Take the body and wrap it with decompression
-        let body = std::mem::replace(
-            response.body_mut(),
-            aws_smithy_types::body::SdkBody::empty(),
-        );
-        let decompressed_body = crate::decompression::wrap_decompressed_body(body, algorithms)?;
-        *response.body_mut() = decompressed_body;
+        // Vector response transformation: rewrite FLOAT32VECTOR attributes
+        // (to L/N by default, or marker B when preserving) and extract
+        // Scores/VectorIndexes into any registered per-request response
+        // holder. Only successful responses are eligible; error bodies are
+        // left untouched so a service error is never turned into a local
+        // JSON error.
+        if response.status().is_success() {
+            let holder = cfg
+                .interceptor_state()
+                .load::<VectorResponseStore>()
+                .map(|store| store.0.clone());
 
-        // Strip Content-Encoding and Content-Length headers
-        response.headers_mut().remove("content-encoding");
-        response.headers_mut().remove("content-length");
+            // Precedence: per-operation override, then client configuration,
+            // then `false`.
+            let preserve_float32_vectors = cfg
+                .interceptor_state()
+                .load::<PreserveFloat32VectorsStore>()
+                .map(|store| store.preserve_float32_vectors)
+                .unwrap_or(self.preserve_float32_vectors);
+
+            let body = std::mem::replace(
+                response.body_mut(),
+                aws_smithy_types::body::SdkBody::empty(),
+            );
+            let transformed = crate::vector_response::wrap_vector_response_body(
+                body,
+                preserve_float32_vectors,
+                holder,
+            );
+            *response.body_mut() = transformed;
+
+            // The transformed body's byte length (and thus any prior
+            // Content-Length) and checksums are now stale regardless of
+            // whether a rewrite actually occurred, since that is only
+            // known once the body is fully buffered.
+            response.headers_mut().remove("content-length");
+            response.headers_mut().remove("x-amz-crc32");
+            response.headers_mut().remove("x-amz-crc32c");
+            response.headers_mut().remove("x-amz-checksum-crc32");
+            response.headers_mut().remove("x-amz-checksum-crc32c");
+            response.headers_mut().remove("x-amz-checksum-sha1");
+            response.headers_mut().remove("x-amz-checksum-sha256");
+            response.headers_mut().remove("x-amz-checksum-crc64nvme");
+        }
 
         Ok(())
     }
@@ -453,6 +501,14 @@ impl Storable for PreserveAuthHeadersStore {
     type Storer = StoreReplace<Self>;
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct PreserveFloat32VectorsStore {
+    pub(crate) preserve_float32_vectors: bool,
+}
+impl Storable for PreserveFloat32VectorsStore {
+    type Storer = StoreReplace<Self>;
+}
+
 /// An interceptor used to carry one per-operation Alternator override.
 ///
 /// Adds the specified override value to [ConfigBag], so that
@@ -495,6 +551,15 @@ impl AlternatorOverrideInterceptor<ResponseCompressionStore> {
         AlternatorOverrideInterceptor {
             store: ResponseCompressionStore {
                 response_compression,
+            },
+        }
+    }
+}
+impl AlternatorOverrideInterceptor<PreserveFloat32VectorsStore> {
+    pub(crate) fn for_preserve_float32_vectors(preserve_float32_vectors: bool) -> Self {
+        AlternatorOverrideInterceptor {
+            store: PreserveFloat32VectorsStore {
+                preserve_float32_vectors,
             },
         }
     }
@@ -723,6 +788,7 @@ mod tests {
                 false,
                 UserAgent::default(),
                 true,
+                false,
             ))
             .build();
         let client = aws_sdk_dynamodb::Client::from_conf(config);
@@ -826,6 +892,7 @@ mod tests {
                 false,
                 UserAgent::default(),
                 true,
+                false,
             ))
             .build();
         (aws_sdk_dynamodb::Client::from_conf(config), http_client)
@@ -863,6 +930,12 @@ mod tests {
             "vec_idx"
         );
     }
+
+    // `vector_index_updates()` is only available on `UpdateTable`'s
+    // `customize()` (see the operation-specific traits in
+    // `vector_interceptor.rs`), so calling it on `CreateTable` is a compile
+    // error. See the compile-fail doctest on `UpdateTableVectorExt` for
+    // coverage.
 
     #[tokio::test]
     async fn vector_search_is_injected_on_query() {

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -67,15 +67,25 @@ impl Intercept for AlternatorInterceptor {
         cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
         // Inject any vector-search request extras (e.g. CreateTable's
-        // VectorIndexes) into the serialized JSON body. This must happen
-        // before compression, so the order is always:
+        // VectorIndexes) into the serialized JSON body, and rewrite any
+        // FLOAT32VECTOR marker binaries into `{"FLOAT32VECTOR": [...]}`.
+        // This must happen before compression, so the order is always:
         // serialized JSON -> vector rewrite -> optional compression -> signing.
-        if let Some(vector_request) = cfg
+        let vector_request = cfg
             .interceptor_state()
             .load::<VectorRequestStore>()
-            .cloned()
-        {
-            inject_vector_request_extras(context, &vector_request)?;
+            .cloned();
+        let body_may_have_marker = context
+            .request()
+            .body()
+            .bytes()
+            .map(|b| {
+                let s = String::from_utf8_lossy(b);
+                s.contains(crate::float32_vector::quick_base64_signature())
+            })
+            .unwrap_or(false);
+        if vector_request.is_some() || body_may_have_marker {
+            rewrite_vector_request_body(context, vector_request.as_ref(), body_may_have_marker)?;
         }
 
         // check for overrides
@@ -227,35 +237,29 @@ fn operation_name_from_target(target: &str) -> Option<&str> {
     target.split('.').next_back()
 }
 
-/// Injects vector-search request extras (currently only CreateTable's
-/// `VectorIndexes`) into the serialized JSON request body.
+/// Injects vector-search request extras (`CreateTable.VectorIndexes`,
+/// `UpdateTable.VectorIndexUpdates`, `Query.VectorSearch`) into the
+/// serialized JSON request body, and recursively rewrites any
+/// `FLOAT32VECTOR` marker binaries into `{"FLOAT32VECTOR": [...]}`.
 ///
-/// If vector state is attached to an operation that does not support it,
-/// this returns a clear local error instead of silently ignoring caller
-/// intent. If no vector state applies to this operation's extras, the body
-/// is left byte-for-byte unchanged.
-fn inject_vector_request_extras(
+/// If vector extras are attached to an operation that does not support
+/// them, this returns a clear local error instead of silently ignoring
+/// caller intent. If neither extras nor marker binaries apply, the body is
+/// left byte-for-byte unchanged.
+fn rewrite_vector_request_body(
     context: &mut BeforeTransmitInterceptorContextMut,
-    vector_request: &VectorRequestStore,
+    vector_request: Option<&VectorRequestStore>,
+    body_may_have_marker: bool,
 ) -> Result<(), BoxError> {
     let target = context
         .request()
         .headers()
         .get("x-amz-target")
-        .unwrap_or_default();
-    let operation = operation_name_from_target(target).unwrap_or_default();
-
-    let Some(vector_indexes) = vector_request.vector_indexes.as_ref() else {
-        return Ok(());
-    };
-
-    if operation != "CreateTable" {
-        return Err(format!(
-            "vector_indexes() was set on a customize() call for operation '{operation}', \
-             but VectorIndexes is only supported on CreateTable requests"
-        )
-        .into());
-    }
+        .unwrap_or_default()
+        .to_string();
+    let operation = operation_name_from_target(&target)
+        .unwrap_or_default()
+        .to_string();
 
     let body = context
         .request_mut()
@@ -267,15 +271,103 @@ fn inject_vector_request_extras(
     let mut json: serde_json::Value =
         serde_json::from_slice(&body).map_err(|e| format!("failed to parse JSON body: {e}"))?;
 
-    let indexes: Vec<serde_json::Value> = vector_indexes
-        .iter()
-        .map(|idx| {
-            let json_idx: crate::vector::VectorIndexJson = idx.into();
-            serde_json::to_value(&json_idx).expect("VectorIndexJson serialization should not fail")
-        })
-        .collect();
+    let mut changed = false;
 
-    json["VectorIndexes"] = serde_json::Value::Array(indexes);
+    if let Some(vector_request) = vector_request {
+        if let Some(vector_indexes) = vector_request.vector_indexes.as_ref() {
+            if operation != "CreateTable" {
+                return Err(format!(
+                    "vector_indexes() was set on a customize() call for operation '{operation}', \
+                     but VectorIndexes is only supported on CreateTable requests"
+                )
+                .into());
+            }
+            let indexes: Vec<serde_json::Value> = vector_indexes
+                .iter()
+                .map(|idx| {
+                    let json_idx: crate::vector::VectorIndexJson = idx.into();
+                    serde_json::to_value(&json_idx)
+                        .expect("VectorIndexJson serialization should not fail")
+                })
+                .collect();
+            json["VectorIndexes"] = serde_json::Value::Array(indexes);
+            changed = true;
+        }
+
+        if let Some(updates) = vector_request.vector_index_updates.as_ref() {
+            if operation != "UpdateTable" {
+                return Err(format!(
+                    "vector_index_updates() was set on a customize() call for operation \
+                     '{operation}', but VectorIndexUpdates is only supported on UpdateTable requests"
+                )
+                .into());
+            }
+            if updates.len() != 1 {
+                return Err(format!(
+                    "UpdateTable.VectorIndexUpdates must contain exactly one update per \
+                     request, got {}",
+                    updates.len()
+                )
+                .into());
+            }
+            if json
+                .get("GlobalSecondaryIndexUpdates")
+                .and_then(|v| v.as_array())
+                .is_some_and(|arr| !arr.is_empty())
+            {
+                return Err(
+                    "vector-index updates cannot be combined with GlobalSecondaryIndexUpdates \
+                     in the same UpdateTable request"
+                        .into(),
+                );
+            }
+            let updates: Vec<serde_json::Value> = updates
+                .iter()
+                .map(|u| {
+                    let json_u: crate::vector::VectorIndexUpdateJson = u.into();
+                    serde_json::to_value(&json_u)
+                        .expect("VectorIndexUpdateJson serialization should not fail")
+                })
+                .collect();
+            json["VectorIndexUpdates"] = serde_json::Value::Array(updates);
+            changed = true;
+        }
+
+        if let Some(search) = vector_request.vector_search.as_ref() {
+            if operation != "Query" {
+                return Err(format!(
+                    "vector_search() was set on a customize() call for operation '{operation}', \
+                     but VectorSearch is only supported on Query requests"
+                )
+                .into());
+            }
+            let json_search: crate::vector::VectorSearchJson = search.into();
+            json["VectorSearch"] = serde_json::to_value(&json_search)
+                .expect("VectorSearchJson serialization should not fail");
+            changed = true;
+
+            validate_vector_query_request(&json, search.return_scores.is_some())?;
+        }
+    }
+
+    // The compact query-vector form injects its own marker binary (see
+    // `VectorSearch::new`) as part of `json` above, which the initial
+    // `body_may_have_marker` scan (taken before that insertion) cannot have
+    // seen, so it must also trigger the marker rewrite pass.
+    let vector_search_may_have_marker =
+        vector_request.is_some_and(|vector_request| vector_request.vector_search.is_some());
+
+    if body_may_have_marker || vector_search_may_have_marker {
+        let before = json.clone();
+        crate::float32_vector::rewrite_request_json_markers(&mut json);
+        if json != before {
+            changed = true;
+        }
+    }
+
+    if !changed {
+        return Ok(());
+    }
 
     let new_body =
         serde_json::to_vec(&json).map_err(|e| format!("failed to serialize JSON body: {e}"))?;
@@ -285,6 +377,54 @@ fn inject_vector_request_extras(
         .headers_mut()
         .insert("content-length", new_body.len().to_string());
     *context.request_mut().body_mut() = new_body.into();
+
+    Ok(())
+}
+
+/// Validates a generated `Query` request body when `VectorSearch` is
+/// present, returning a descriptive local error instead of letting an
+/// unsupported combination reach the server. Schema-dependent validation
+/// (index existence, dimensionality) remains server-owned.
+fn validate_vector_query_request(
+    json: &serde_json::Value,
+    has_return_scores: bool,
+) -> Result<(), BoxError> {
+    let index_name = json.get("IndexName").and_then(|v| v.as_str());
+    if index_name.is_none_or(str::is_empty) {
+        return Err("vector-search queries require IndexName".into());
+    }
+
+    let limit = json.get("Limit").and_then(|v| v.as_i64());
+    match limit {
+        None => return Err("vector-search queries require Limit".into()),
+        Some(limit) if !(1..=1000).contains(&limit) => {
+            return Err(format!(
+                "vector-search queries require Limit between 1 and 1000, got {limit}"
+            )
+            .into());
+        }
+        _ => {}
+    }
+
+    if json.get("ConsistentRead").and_then(|v| v.as_bool()) == Some(true) {
+        return Err("vector-search queries do not support ConsistentRead(true)".into());
+    }
+
+    if json.get("ExclusiveStartKey").is_some_and(|v| !v.is_null()) {
+        return Err("vector-search queries do not support ExclusiveStartKey".into());
+    }
+
+    if json.get("ScanIndexForward").is_some() {
+        return Err("vector-search queries do not support ScanIndexForward".into());
+    }
+
+    if json.get("QueryFilter").is_some_and(|v| !v.is_null()) {
+        return Err("vector-search queries do not support the legacy QueryFilter".into());
+    }
+
+    if has_return_scores && json.get("Select").and_then(|v| v.as_str()) == Some("COUNT") {
+        return Err("ReturnScores::Similarity is not supported with Select::Count".into());
+    }
 
     Ok(())
 }
@@ -650,6 +790,362 @@ mod tests {
             "embedding"
         );
         assert_eq!(json["TableName"], "test_table");
+    }
+
+    fn make_replay_client(
+        response_body: &str,
+    ) -> (
+        aws_sdk_dynamodb::Client,
+        aws_smithy_runtime::client::http::test_util::StaticReplayClient,
+    ) {
+        use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClient};
+        use aws_smithy_types::body::SdkBody;
+
+        let http_client = StaticReplayClient::new(vec![ReplayEvent::new(
+            http::Request::builder()
+                .uri("http://127.0.0.1:1/")
+                .body(SdkBody::empty())
+                .unwrap(),
+            http::Response::builder()
+                .status(200)
+                .body(SdkBody::from(response_body))
+                .unwrap(),
+        )]);
+
+        let config = aws_sdk_dynamodb::Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new("us-east-1"))
+            .endpoint_url("http://127.0.0.1:1")
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .http_client(http_client.clone())
+            .interceptor(AlternatorInterceptor::new(
+                RequestCompression::disabled(),
+                ResponseCompression::disabled(),
+                false,
+                UserAgent::default(),
+                true,
+            ))
+            .build();
+        (aws_sdk_dynamodb::Client::from_conf(config), http_client)
+    }
+
+    #[tokio::test]
+    async fn vector_index_updates_are_injected_on_update_table() {
+        let (client, http_client) = make_replay_client("{\"TableDescription\":{}}");
+
+        let va = crate::vector::VectorAttribute::builder()
+            .attribute_name("embedding")
+            .dimensions(128)
+            .build()
+            .unwrap();
+        let vi = crate::vector::VectorIndex::builder()
+            .index_name("vec_idx")
+            .vector_attribute(va)
+            .build()
+            .unwrap();
+
+        client
+            .update_table()
+            .table_name("test_table")
+            .customize()
+            .vector_index_updates(vec![crate::vector::VectorIndexUpdate::Create(vi)])
+            .send()
+            .await
+            .expect("request should succeed against the replay client");
+
+        let requests = http_client.actual_requests().collect::<Vec<_>>();
+        let json: serde_json::Value =
+            serde_json::from_slice(requests[0].body().bytes().unwrap()).unwrap();
+        assert_eq!(
+            json["VectorIndexUpdates"][0]["Create"]["IndexName"],
+            "vec_idx"
+        );
+    }
+
+    #[tokio::test]
+    async fn vector_search_is_injected_on_query() {
+        let (client, http_client) = make_replay_client("{\"Items\":[],\"Count\":0}");
+
+        let search = crate::vector::VectorSearch::new(vec![1.0, 2.0, 3.0])
+            .unwrap()
+            .with_return_scores(crate::vector::ReturnScores::Similarity);
+
+        client
+            .query()
+            .table_name("test_table")
+            .index_name("embedding_idx")
+            .limit(10)
+            .customize()
+            .vector_search(search)
+            .send()
+            .await
+            .expect("request should succeed against the replay client");
+
+        let requests = http_client.actual_requests().collect::<Vec<_>>();
+        let json: serde_json::Value =
+            serde_json::from_slice(requests[0].body().bytes().unwrap()).unwrap();
+        assert_eq!(
+            json["VectorSearch"]["QueryVector"]["FLOAT32VECTOR"],
+            serde_json::json!([1.0, 2.0, 3.0])
+        );
+        assert_eq!(json["VectorSearch"]["ReturnScores"], "SIMILARITY");
+    }
+
+    #[tokio::test]
+    async fn vector_index_delete_is_injected_on_update_table() {
+        let (client, http_client) = make_replay_client("{\"TableDescription\":{}}");
+
+        client
+            .update_table()
+            .table_name("test_table")
+            .customize()
+            .vector_index_updates(vec![crate::vector::VectorIndexUpdate::Delete {
+                index_name: "vec_idx".to_string(),
+            }])
+            .send()
+            .await
+            .expect("request should succeed against the replay client");
+
+        let requests = http_client.actual_requests().collect::<Vec<_>>();
+        let json: serde_json::Value =
+            serde_json::from_slice(requests[0].body().bytes().unwrap()).unwrap();
+        assert_eq!(
+            json["VectorIndexUpdates"][0]["Delete"]["IndexName"],
+            "vec_idx"
+        );
+        assert!(json["VectorIndexUpdates"][0].get("Create").is_none());
+    }
+
+    #[tokio::test]
+    async fn vector_search_from_query_vector_uses_standard_list_on_wire() {
+        let (client, http_client) = make_replay_client("{\"Items\":[],\"Count\":0}");
+
+        let search = crate::vector::VectorSearch::from_query_vector(vec![
+            AttributeValue::N("1".to_string()),
+            AttributeValue::N("2".to_string()),
+            AttributeValue::N("3".to_string()),
+        ])
+        .unwrap();
+
+        client
+            .query()
+            .table_name("test_table")
+            .index_name("embedding_idx")
+            .limit(10)
+            .customize()
+            .vector_search(search)
+            .send()
+            .await
+            .expect("request should succeed against the replay client");
+
+        let requests = http_client.actual_requests().collect::<Vec<_>>();
+        let json: serde_json::Value =
+            serde_json::from_slice(requests[0].body().bytes().unwrap()).unwrap();
+        assert_eq!(
+            json["VectorSearch"]["QueryVector"]["L"],
+            serde_json::json!([{ "N": "1" }, { "N": "2" }, { "N": "3" }])
+        );
+        assert!(
+            json["VectorSearch"]["QueryVector"]
+                .get("FLOAT32VECTOR")
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn vector_query_rejects_missing_index_name() {
+        let (client, http_client) = make_replay_client("{\"Items\":[],\"Count\":0}");
+        let search = crate::vector::VectorSearch::new(vec![1.0]).unwrap();
+
+        let err = client
+            .query()
+            .table_name("test_table")
+            .limit(10)
+            .customize()
+            .vector_search(search)
+            .send()
+            .await
+            .expect_err("request should be rejected locally");
+        assert!(format!("{err:?}").contains("require IndexName"));
+        assert!(http_client.actual_requests().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn vector_query_rejects_missing_limit() {
+        let (client, http_client) = make_replay_client("{\"Items\":[],\"Count\":0}");
+        let search = crate::vector::VectorSearch::new(vec![1.0]).unwrap();
+
+        let err = client
+            .query()
+            .table_name("test_table")
+            .index_name("embedding_idx")
+            .customize()
+            .vector_search(search)
+            .send()
+            .await
+            .expect_err("request should be rejected locally");
+        assert!(format!("{err:?}").contains("require Limit"));
+        assert!(http_client.actual_requests().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn vector_query_rejects_limit_out_of_range() {
+        for limit in [0i32, 1001i32] {
+            let (client, http_client) = make_replay_client("{\"Items\":[],\"Count\":0}");
+            let search = crate::vector::VectorSearch::new(vec![1.0]).unwrap();
+
+            let err = client
+                .query()
+                .table_name("test_table")
+                .index_name("embedding_idx")
+                .limit(limit)
+                .customize()
+                .vector_search(search)
+                .send()
+                .await
+                .expect_err("request should be rejected locally");
+            assert!(
+                format!("{err:?}").contains("require Limit between 1 and 1000"),
+                "limit {limit} should be rejected, got: {err:?}"
+            );
+            assert!(http_client.actual_requests().next().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn vector_query_rejects_consistent_read_true() {
+        let (client, http_client) = make_replay_client("{\"Items\":[],\"Count\":0}");
+        let search = crate::vector::VectorSearch::new(vec![1.0]).unwrap();
+
+        let err = client
+            .query()
+            .table_name("test_table")
+            .index_name("embedding_idx")
+            .limit(10)
+            .consistent_read(true)
+            .customize()
+            .vector_search(search)
+            .send()
+            .await
+            .expect_err("request should be rejected locally");
+        assert!(format!("{err:?}").contains("ConsistentRead(true)"));
+        assert!(http_client.actual_requests().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn vector_query_rejects_exclusive_start_key() {
+        let (client, http_client) = make_replay_client("{\"Items\":[],\"Count\":0}");
+        let search = crate::vector::VectorSearch::new(vec![1.0]).unwrap();
+
+        let err = client
+            .query()
+            .table_name("test_table")
+            .index_name("embedding_idx")
+            .limit(10)
+            .exclusive_start_key("pk", s("row1"))
+            .customize()
+            .vector_search(search)
+            .send()
+            .await
+            .expect_err("request should be rejected locally");
+        assert!(format!("{err:?}").contains("ExclusiveStartKey"));
+        assert!(http_client.actual_requests().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn vector_query_rejects_scan_index_forward() {
+        let (client, http_client) = make_replay_client("{\"Items\":[],\"Count\":0}");
+        let search = crate::vector::VectorSearch::new(vec![1.0]).unwrap();
+
+        let err = client
+            .query()
+            .table_name("test_table")
+            .index_name("embedding_idx")
+            .limit(10)
+            .scan_index_forward(false)
+            .customize()
+            .vector_search(search)
+            .send()
+            .await
+            .expect_err("request should be rejected locally");
+        assert!(format!("{err:?}").contains("ScanIndexForward"));
+        assert!(http_client.actual_requests().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn vector_query_rejects_return_scores_similarity_with_select_count() {
+        let (client, http_client) = make_replay_client("{\"Items\":[],\"Count\":0}");
+        let search = crate::vector::VectorSearch::new(vec![1.0])
+            .unwrap()
+            .with_return_scores(crate::vector::ReturnScores::Similarity);
+
+        let err = client
+            .query()
+            .table_name("test_table")
+            .index_name("embedding_idx")
+            .limit(10)
+            .select(aws_sdk_dynamodb::types::Select::Count)
+            .customize()
+            .vector_search(search)
+            .send()
+            .await
+            .expect_err("request should be rejected locally");
+        assert!(
+            format!("{err:?}")
+                .contains("ReturnScores::Similarity is not supported with Select::Count")
+        );
+        assert!(http_client.actual_requests().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn marker_binaries_are_rewritten_to_float32vector_in_put_item() {
+        let (client, http_client) = make_replay_client("{}");
+
+        let av =
+            crate::float32_vector::Float32Vector::to_attribute_value(vec![1.0, 2.0, 3.0]).unwrap();
+
+        client
+            .put_item()
+            .table_name("test_table")
+            .item("pk", s("row1"))
+            .item("embedding", av)
+            .send()
+            .await
+            .expect("request should succeed against the replay client");
+
+        let requests = http_client.actual_requests().collect::<Vec<_>>();
+        let json: serde_json::Value =
+            serde_json::from_slice(requests[0].body().bytes().unwrap()).unwrap();
+        assert_eq!(
+            json["Item"]["embedding"]["FLOAT32VECTOR"],
+            serde_json::json!([1.0, 2.0, 3.0])
+        );
+        assert_eq!(json["Item"]["pk"]["S"], "row1");
+    }
+
+    #[tokio::test]
+    async fn ordinary_binary_values_are_left_unchanged_in_put_item() {
+        let (client, http_client) = make_replay_client("{}");
+
+        client
+            .put_item()
+            .table_name("test_table")
+            .item("pk", s("row1"))
+            .item(
+                "blob",
+                AttributeValue::B(aws_sdk_dynamodb::primitives::Blob::new(vec![1, 2, 3, 4])),
+            )
+            .send()
+            .await
+            .expect("request should succeed against the replay client");
+
+        let requests = http_client.actual_requests().collect::<Vec<_>>();
+        let json: serde_json::Value =
+            serde_json::from_slice(requests[0].body().bytes().unwrap()).unwrap();
+        assert!(json["Item"]["blob"].get("FLOAT32VECTOR").is_none());
+        assert!(json["Item"]["blob"].get("B").is_some());
     }
 
     #[test]

--- a/src/interceptors.rs
+++ b/src/interceptors.rs
@@ -66,6 +66,18 @@ impl Intercept for AlternatorInterceptor {
         _: &RuntimeComponents,
         cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
+        // Inject any vector-search request extras (e.g. CreateTable's
+        // VectorIndexes) into the serialized JSON body. This must happen
+        // before compression, so the order is always:
+        // serialized JSON -> vector rewrite -> optional compression -> signing.
+        if let Some(vector_request) = cfg
+            .interceptor_state()
+            .load::<VectorRequestStore>()
+            .cloned()
+        {
+            inject_vector_request_extras(context, &vector_request)?;
+        }
+
         // check for overrides
         let request_compression = cfg
             .interceptor_state()
@@ -207,6 +219,74 @@ impl Intercept for AlternatorInterceptor {
 
         Ok(())
     }
+}
+
+/// Identifies the DynamoDB/Alternator operation for a request from its
+/// `x-amz-target` header, e.g. `DynamoDB_20120810.CreateTable`.
+fn operation_name_from_target(target: &str) -> Option<&str> {
+    target.split('.').next_back()
+}
+
+/// Injects vector-search request extras (currently only CreateTable's
+/// `VectorIndexes`) into the serialized JSON request body.
+///
+/// If vector state is attached to an operation that does not support it,
+/// this returns a clear local error instead of silently ignoring caller
+/// intent. If no vector state applies to this operation's extras, the body
+/// is left byte-for-byte unchanged.
+fn inject_vector_request_extras(
+    context: &mut BeforeTransmitInterceptorContextMut,
+    vector_request: &VectorRequestStore,
+) -> Result<(), BoxError> {
+    let target = context
+        .request()
+        .headers()
+        .get("x-amz-target")
+        .unwrap_or_default();
+    let operation = operation_name_from_target(target).unwrap_or_default();
+
+    let Some(vector_indexes) = vector_request.vector_indexes.as_ref() else {
+        return Ok(());
+    };
+
+    if operation != "CreateTable" {
+        return Err(format!(
+            "vector_indexes() was set on a customize() call for operation '{operation}', \
+             but VectorIndexes is only supported on CreateTable requests"
+        )
+        .into());
+    }
+
+    let body = context
+        .request_mut()
+        .body_mut()
+        .bytes()
+        .ok_or("body not collected")?
+        .to_vec();
+
+    let mut json: serde_json::Value =
+        serde_json::from_slice(&body).map_err(|e| format!("failed to parse JSON body: {e}"))?;
+
+    let indexes: Vec<serde_json::Value> = vector_indexes
+        .iter()
+        .map(|idx| {
+            let json_idx: crate::vector::VectorIndexJson = idx.into();
+            serde_json::to_value(&json_idx).expect("VectorIndexJson serialization should not fail")
+        })
+        .collect();
+
+    json["VectorIndexes"] = serde_json::Value::Array(indexes);
+
+    let new_body =
+        serde_json::to_vec(&json).map_err(|e| format!("failed to serialize JSON body: {e}"))?;
+
+    context
+        .request_mut()
+        .headers_mut()
+        .insert("content-length", new_body.len().to_string());
+    *context.request_mut().body_mut() = new_body.into();
+
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -464,6 +544,126 @@ mod tests {
     use aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemInput;
     use aws_sdk_dynamodb::types::{AttributeValue, DeleteRequest, PutRequest, WriteRequest};
     use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn vector_indexes_are_injected_before_compression_on_create_table() {
+        use aws_sdk_dynamodb::types::{
+            AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType,
+        };
+        use aws_smithy_runtime::client::http::test_util::{ReplayEvent, StaticReplayClient};
+        use aws_smithy_types::body::SdkBody;
+        use std::io::Read;
+
+        let http_client = StaticReplayClient::new(vec![ReplayEvent::new(
+            http::Request::builder()
+                .uri("http://127.0.0.1:1/")
+                .body(SdkBody::empty())
+                .unwrap(),
+            http::Response::builder()
+                .status(200)
+                .body(SdkBody::from("{\"TableDescription\":{}}"))
+                .unwrap(),
+        )]);
+
+        let config = aws_sdk_dynamodb::Config::builder()
+            .behavior_version(BehaviorVersion::latest())
+            .region(Region::new("us-east-1"))
+            .endpoint_url("http://127.0.0.1:1")
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .http_client(http_client.clone())
+            .interceptor(AlternatorInterceptor::new(
+                RequestCompression::enabled(
+                    crate::compression::CompressionAlgorithm::Gzip,
+                    crate::compression::CompressionLevel::default(),
+                    0,
+                ),
+                ResponseCompression::disabled(),
+                false,
+                UserAgent::default(),
+                true,
+            ))
+            .build();
+        let client = aws_sdk_dynamodb::Client::from_conf(config);
+
+        let va = crate::vector::VectorAttribute::builder()
+            .attribute_name("embedding")
+            .dimensions(128)
+            .build()
+            .unwrap();
+        let vi = crate::vector::VectorIndex::builder()
+            .index_name("vec_idx")
+            .vector_attribute(va)
+            .build()
+            .unwrap();
+
+        client
+            .create_table()
+            .table_name("test_table")
+            .attribute_definitions(
+                AttributeDefinition::builder()
+                    .attribute_name("pk")
+                    .attribute_type(ScalarAttributeType::S)
+                    .build()
+                    .unwrap(),
+            )
+            .key_schema(
+                KeySchemaElement::builder()
+                    .attribute_name("pk")
+                    .key_type(KeyType::Hash)
+                    .build()
+                    .unwrap(),
+            )
+            .billing_mode(BillingMode::PayPerRequest)
+            .customize()
+            .vector_indexes(vec![vi])
+            .send()
+            .await
+            .expect("request should succeed against the replay client");
+
+        let requests = http_client.actual_requests().collect::<Vec<_>>();
+        assert_eq!(requests.len(), 1, "exactly one request should be sent");
+        let sent_request = &requests[0];
+
+        // Request compression must have applied: content-encoding is set and
+        // the body bytes are actually gzip-compressed.
+        assert_eq!(
+            sent_request.headers().get("content-encoding").unwrap(),
+            "gzip"
+        );
+
+        let compressed = sent_request.body().bytes().expect("body collected");
+        let mut decompressed = Vec::new();
+        flate2::read::GzDecoder::new(compressed)
+            .read_to_end(&mut decompressed)
+            .expect("valid gzip body");
+
+        let json: serde_json::Value =
+            serde_json::from_slice(&decompressed).expect("decompressed body should be valid JSON");
+
+        // The vector rewrite happened before compression: VectorIndexes is
+        // present in the *decompressed* body.
+        assert_eq!(json["VectorIndexes"][0]["IndexName"], "vec_idx");
+        assert_eq!(
+            json["VectorIndexes"][0]["VectorAttribute"]["AttributeName"],
+            "embedding"
+        );
+        assert_eq!(json["TableName"], "test_table");
+    }
+
+    #[test]
+    fn operation_name_from_target_extracts_operation() {
+        assert_eq!(
+            operation_name_from_target("DynamoDB_20120810.CreateTable"),
+            Some("CreateTable")
+        );
+        assert_eq!(
+            operation_name_from_target("DynamoDB_20120810.PutItem"),
+            Some("PutItem")
+        );
+        assert_eq!(operation_name_from_target(""), Some(""));
+    }
 
     fn s(value: &str) -> AttributeValue {
         AttributeValue::S(value.to_string())

--- a/src/keyrouting/resolver.rs
+++ b/src/keyrouting/resolver.rs
@@ -422,6 +422,7 @@ mod tests {
                 true,
                 UserAgent::default(),
                 true,
+                false,
             ));
 
         let discovery_client = aws_sdk_dynamodb::Client::from_conf(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ mod optimize_headers;
 mod query_plan;
 mod routing_scope;
 mod user_agent;
+pub mod vector;
+mod vector_interceptor;
 
 pub use crate::client::*;
 pub use crate::compression::*;
@@ -22,3 +24,6 @@ pub(crate) use crate::optimize_headers::*;
 pub(crate) use crate::query_plan::*;
 pub use crate::routing_scope::*;
 pub use crate::user_agent::*;
+pub use crate::vector::{Projection, SimilarityFunction, VectorAttribute, VectorIndex};
+pub(crate) use crate::vector_interceptor::VectorRequestStore;
+pub use crate::vector_interceptor::VectorSearchExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod routing_scope;
 mod user_agent;
 pub mod vector;
 mod vector_interceptor;
+mod vector_response;
 
 pub use crate::client::*;
 pub use crate::compression::*;
@@ -27,8 +28,13 @@ pub(crate) use crate::query_plan::*;
 pub use crate::routing_scope::*;
 pub use crate::user_agent::*;
 pub use crate::vector::{
-    IndexStatus, Projection, ProjectionType, ReturnScores, SimilarityFunction, VectorAttribute,
-    VectorIndex, VectorIndexUpdate, VectorSearch,
+    CreateTableWithVectorIndexes, DescribeTableWithVectorIndexes, IndexStatus, Projection,
+    ProjectionType, ReturnScores, SimilarityFunction, VectorAttribute, VectorIndex,
+    VectorIndexUpdate, VectorSearch,
 };
 pub(crate) use crate::vector_interceptor::VectorRequestStore;
-pub use crate::vector_interceptor::{CreateTableVectorExt, QueryVectorExt, UpdateTableVectorExt};
+pub(crate) use crate::vector_interceptor::VectorResponseStore;
+pub use crate::vector_interceptor::{
+    CreateTableVectorExt, DescribeTableVectorExt, QueryVectorExt, UpdateTableVectorExt,
+    VectorCreateTableOperation, VectorDescribeTableOperation,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod compression;
 mod config;
 mod customize;
 mod decompression;
+pub mod float32_vector;
 mod interceptors;
 pub mod keyrouting;
 mod live_nodes;
@@ -17,6 +18,7 @@ pub use crate::client::*;
 pub use crate::compression::*;
 pub use crate::config::*;
 pub use crate::customize::*;
+pub use crate::float32_vector::{Float32Vector, Float32VectorError, Float32VectorExt};
 pub(crate) use crate::interceptors::*;
 pub use crate::keyrouting::{KeyRouteAffinityConfig, KeyRouteAffinityType};
 pub(crate) use crate::live_nodes::*;
@@ -24,6 +26,9 @@ pub(crate) use crate::optimize_headers::*;
 pub(crate) use crate::query_plan::*;
 pub use crate::routing_scope::*;
 pub use crate::user_agent::*;
-pub use crate::vector::{Projection, SimilarityFunction, VectorAttribute, VectorIndex};
+pub use crate::vector::{
+    IndexStatus, Projection, ProjectionType, ReturnScores, SimilarityFunction, VectorAttribute,
+    VectorIndex, VectorIndexUpdate, VectorSearch,
+};
 pub(crate) use crate::vector_interceptor::VectorRequestStore;
-pub use crate::vector_interceptor::VectorSearchExt;
+pub use crate::vector_interceptor::{CreateTableVectorExt, QueryVectorExt, UpdateTableVectorExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,11 @@ pub use crate::user_agent::*;
 pub use crate::vector::{
     CreateTableWithVectorIndexes, DescribeTableWithVectorIndexes, IndexStatus, Projection,
     ProjectionType, ReturnScores, SimilarityFunction, VectorAttribute, VectorIndex,
-    VectorIndexUpdate, VectorSearch,
+    VectorIndexUpdate, VectorQueryOutput, VectorSearch,
 };
 pub(crate) use crate::vector_interceptor::VectorRequestStore;
 pub(crate) use crate::vector_interceptor::VectorResponseStore;
 pub use crate::vector_interceptor::{
     CreateTableVectorExt, DescribeTableVectorExt, QueryVectorExt, UpdateTableVectorExt,
-    VectorCreateTableOperation, VectorDescribeTableOperation,
+    VectorCreateTableOperation, VectorDescribeTableOperation, VectorQueryOperation,
 };

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -528,6 +528,41 @@ impl From<&VectorSearch> for VectorSearchJson {
 
 use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
 use aws_sdk_dynamodb::operation::describe_table::DescribeTableOutput;
+use aws_sdk_dynamodb::operation::query::QueryOutput;
+
+/// Wraps a generated [QueryOutput], adding similarity scores extracted from
+/// the response's `Scores` field when [`VectorSearch::with_return_scores`]
+/// requested them.
+#[derive(Debug, Clone)]
+pub struct VectorQueryOutput {
+    output: QueryOutput,
+    /// Present when the query requested [ReturnScores::Similarity]; absent
+    /// (not a stale empty `Vec`) otherwise.
+    pub scores: Option<Vec<f64>>,
+}
+
+impl VectorQueryOutput {
+    pub(crate) fn new(output: QueryOutput, scores: Option<Vec<f64>>) -> Self {
+        Self { output, scores }
+    }
+
+    /// Consumes this value, returning the generated [QueryOutput]. Rust does
+    /// not perform this conversion implicitly.
+    pub fn into_inner(self) -> QueryOutput {
+        self.output
+    }
+
+    /// Borrows the generated [QueryOutput].
+    pub fn as_inner(&self) -> &QueryOutput {
+        &self.output
+    }
+}
+
+impl From<VectorQueryOutput> for QueryOutput {
+    fn from(value: VectorQueryOutput) -> Self {
+        value.output
+    }
+}
 
 /// Wraps a generated [DescribeTableOutput], adding parsed
 /// `Table.VectorIndexes` metadata.

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -303,52 +303,87 @@ impl From<&VectorIndex> for VectorIndexJson {
 /// Parses a `VectorIndex` response entry (as found under `Table.VectorIndexes`
 /// or `TableDescription.VectorIndexes`) from raw JSON, including
 /// response-only `IndexStatus` and `Backfilling` fields.
-pub(crate) fn vector_index_from_json(value: &serde_json::Value) -> Option<VectorIndex> {
-    let index_name = value.get("IndexName")?.as_str()?.to_string();
-    let va = value.get("VectorAttribute")?;
-    let attribute_name = va.get("AttributeName")?.as_str()?.to_string();
-    let dimensions_raw = va.get("Dimensions")?.as_u64()?;
-    let dimensions = u32::try_from(dimensions_raw).ok()?;
+pub(crate) fn vector_index_from_json(value: &serde_json::Value) -> Result<VectorIndex, String> {
+    let index_name = value
+        .get("IndexName")
+        .and_then(|value| value.as_str())
+        .ok_or("VectorIndexes entry is missing a string IndexName")?
+        .to_string();
+    let va = value
+        .get("VectorAttribute")
+        .ok_or("VectorIndexes entry is missing VectorAttribute")?;
+    let attribute_name = va
+        .get("AttributeName")
+        .and_then(|value| value.as_str())
+        .ok_or("VectorAttribute is missing a string AttributeName")?
+        .to_string();
+    let dimensions_raw = va
+        .get("Dimensions")
+        .and_then(|value| value.as_u64())
+        .ok_or("VectorAttribute is missing an unsigned Dimensions")?;
+    let dimensions =
+        u32::try_from(dimensions_raw).map_err(|_| "VectorAttribute.Dimensions exceeds u32::MAX")?;
 
-    let projection = value.get("Projection").and_then(|p| {
-        let projection_type = p.get("ProjectionType")?.as_str()?;
-        Some(match projection_type {
-            "ALL" => Projection::all(),
-            "KEYS_ONLY" => Projection::keys_only(),
-            "INCLUDE" => {
-                let attrs = p
-                    .get("NonKeyAttributes")
-                    .and_then(|a| a.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|v| v.as_str().map(String::from))
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default();
-                Projection::include(attrs)
-            }
-            _ => return None,
-        })
-    });
+    let projection = match value.get("Projection") {
+        Some(projection) => {
+            let projection_type = projection
+                .get("ProjectionType")
+                .and_then(|value| value.as_str())
+                .ok_or("Projection is missing a string ProjectionType")?;
+            Some(match projection_type {
+                "ALL" => Projection::all(),
+                "KEYS_ONLY" => Projection::keys_only(),
+                "INCLUDE" => {
+                    let attributes = projection
+                        .get("NonKeyAttributes")
+                        .and_then(|a| a.as_array())
+                        .ok_or("INCLUDE Projection is missing NonKeyAttributes")?
+                        .iter()
+                        .map(|value| {
+                            value
+                                .as_str()
+                                .map(String::from)
+                                .ok_or("NonKeyAttributes must contain only strings")
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    Projection::include(attributes)
+                }
+                _ => return Err("unsupported ProjectionType in VectorIndexes entry".to_string()),
+            })
+        }
+        None => None,
+    };
 
-    let similarity_function = value
-        .get("SimilarityFunction")
-        .and_then(|s| s.as_str())
-        .and_then(|s| match s {
-            "COSINE" => Some(SimilarityFunction::Cosine),
-            "EUCLIDEAN" => Some(SimilarityFunction::Euclidean),
-            "DOT_PRODUCT" => Some(SimilarityFunction::DotProduct),
-            _ => None,
-        });
+    let similarity_function = match value.get("SimilarityFunction") {
+        Some(value) => Some(match value.as_str() {
+            Some("COSINE") => SimilarityFunction::Cosine,
+            Some("EUCLIDEAN") => SimilarityFunction::Euclidean,
+            Some("DOT_PRODUCT") => SimilarityFunction::DotProduct,
+            _ => return Err("unsupported SimilarityFunction in VectorIndexes entry".to_string()),
+        }),
+        None => None,
+    };
 
-    let index_status = value
-        .get("IndexStatus")
-        .and_then(|s| s.as_str())
-        .and_then(IndexStatus::from_str);
+    let index_status = match value.get("IndexStatus") {
+        Some(value) => Some(
+            value
+                .as_str()
+                .and_then(IndexStatus::from_str)
+                .ok_or("unsupported IndexStatus in VectorIndexes entry")?,
+        ),
+        None => None,
+    };
 
-    let backfilling = value.get("Backfilling").and_then(|b| b.as_bool());
+    let backfilling = match value.get("Backfilling") {
+        Some(value) => Some(
+            value
+                .as_bool()
+                .ok_or("Backfilling in VectorIndexes entry must be a boolean")?,
+        ),
+        None => None,
+    };
 
-    Some(VectorIndex {
+    Ok(VectorIndex {
         index_name,
         vector_attribute: VectorAttribute {
             attribute_name,
@@ -416,11 +451,6 @@ impl ReturnScores {
 }
 
 /// Vector-search extras for `Query.VectorSearch`.
-///
-/// The query vector is stored as a validated DynamoDB [`AttributeValue`]:
-/// either a compact `FLOAT32VECTOR` marker built by [`VectorSearch::new`],
-/// or a standard `AttributeValue::L` of numeric (`N`) values built by
-/// [`VectorSearch::from_query_vector`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct VectorSearch {
     pub(crate) query_vector: AttributeValue,
@@ -428,9 +458,9 @@ pub struct VectorSearch {
 }
 
 impl VectorSearch {
-    /// Creates a [VectorSearch] with a compact `FLOAT32VECTOR` query vector
-    /// and no score reporting. Returns an error if `vector` is empty or
-    /// contains non-finite values.
+    /// Creates a [VectorSearch] with the given query vector and no score
+    /// reporting. Returns an error if `vector` is empty or contains
+    /// non-finite values.
     pub fn new(vector: impl IntoIterator<Item = f32>) -> Result<Self, &'static str> {
         let vector: Vec<f32> = vector.into_iter().collect();
         if vector.is_empty() {
@@ -439,18 +469,14 @@ impl VectorSearch {
         if vector.iter().any(|v| !v.is_finite()) {
             return Err("query vector must contain only finite values");
         }
-        let query_vector = crate::float32_vector::Float32Vector::to_attribute_value(vector)
-            .expect("finiteness already validated above");
         Ok(Self {
-            query_vector,
+            query_vector: crate::float32_vector::Float32Vector::to_attribute_value(vector)
+                .expect("finiteness was validated above"),
             return_scores: None,
         })
     }
 
-    /// Creates a [VectorSearch] with a standard DynamoDB `AttributeValue::L`
-    /// query vector, i.e. a list of `AttributeValue::N` values, matching the
-    /// shape a non-preserving read returns. Returns an error if `values` is
-    /// empty or contains a non-numeric member.
+    /// Creates a vector search using a standard DynamoDB list of numeric values.
     pub fn from_query_vector(
         values: impl IntoIterator<Item = AttributeValue>,
     ) -> Result<Self, &'static str> {
@@ -458,7 +484,10 @@ impl VectorSearch {
         if values.is_empty() {
             return Err("query vector must not be empty");
         }
-        if !values.iter().all(|v| matches!(v, AttributeValue::N(_))) {
+        if !values
+            .iter()
+            .all(|value| matches!(value, AttributeValue::N(_)))
+        {
             return Err("query vector list must contain only numeric (N) values");
         }
         Ok(Self {
@@ -499,41 +528,6 @@ impl From<&VectorSearch> for VectorSearchJson {
 
 use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
 use aws_sdk_dynamodb::operation::describe_table::DescribeTableOutput;
-use aws_sdk_dynamodb::operation::query::QueryOutput;
-
-/// Wraps a generated [QueryOutput], adding similarity scores extracted from
-/// the response's `Scores` field when [`VectorSearch::with_return_scores`]
-/// requested them.
-#[derive(Debug, Clone)]
-pub struct VectorQueryOutput {
-    output: QueryOutput,
-    /// Present when the query requested [ReturnScores::Similarity]; absent
-    /// (not a stale empty `Vec`) otherwise.
-    pub scores: Option<Vec<f64>>,
-}
-
-impl VectorQueryOutput {
-    pub(crate) fn new(output: QueryOutput, scores: Option<Vec<f64>>) -> Self {
-        Self { output, scores }
-    }
-
-    /// Consumes this value, returning the generated [QueryOutput]. Rust does
-    /// not perform this conversion implicitly.
-    pub fn into_inner(self) -> QueryOutput {
-        self.output
-    }
-
-    /// Borrows the generated [QueryOutput].
-    pub fn as_inner(&self) -> &QueryOutput {
-        &self.output
-    }
-}
-
-impl From<VectorQueryOutput> for QueryOutput {
-    fn from(value: VectorQueryOutput) -> Self {
-        value.output
-    }
-}
 
 /// Wraps a generated [DescribeTableOutput], adding parsed
 /// `Table.VectorIndexes` metadata.
@@ -812,12 +806,22 @@ mod tests {
         let search = VectorSearch::new(vec![1.0, 2.0, 3.0]).unwrap();
         let json: VectorSearchJson = (&search).into();
         let serialized = serde_json::to_value(&json).unwrap();
-        // The compact form serializes as a marker `AttributeValue::B`; the
-        // driver's request interceptor rewrites it into
-        // `{"FLOAT32VECTOR": [...]}` in the serialized wire body (see
-        // `interceptors::tests::vector_search_is_injected_on_query`).
         assert!(serialized["QueryVector"].get("B").is_some());
         assert!(serialized.get("ReturnScores").is_none());
+    }
+
+    #[test]
+    fn test_vector_search_from_query_vector_uses_standard_list() {
+        let search = VectorSearch::from_query_vector([
+            AttributeValue::N("1".into()),
+            AttributeValue::N("2".into()),
+        ])
+        .unwrap();
+        let json: VectorSearchJson = (&search).into();
+        assert_eq!(
+            serde_json::to_value(json).unwrap()["QueryVector"]["L"],
+            serde_json::json!([{ "N": "1" }, { "N": "2" }])
+        );
     }
 
     #[test]
@@ -842,34 +846,8 @@ mod tests {
     }
 
     #[test]
-    fn test_vector_search_from_query_vector_json_uses_standard_list() {
-        let search = VectorSearch::from_query_vector(vec![
-            AttributeValue::N("1".to_string()),
-            AttributeValue::N("2".to_string()),
-            AttributeValue::N("3".to_string()),
-        ])
-        .unwrap();
-        let json: VectorSearchJson = (&search).into();
-        let serialized = serde_json::to_value(&json).unwrap();
-        assert_eq!(
-            serialized["QueryVector"]["L"],
-            serde_json::json!([{ "N": "1" }, { "N": "2" }, { "N": "3" }])
-        );
-    }
-
-    #[test]
-    fn test_vector_search_from_query_vector_rejects_empty_and_non_numeric() {
-        assert!(VectorSearch::from_query_vector(Vec::<AttributeValue>::new()).is_err());
-        assert!(VectorSearch::from_query_vector(vec![AttributeValue::S("x".to_string())]).is_err());
-    }
-
-    #[test]
     fn test_vector_index_from_json_rejects_dimensions_over_u32_max() {
-        // Phase 1 (VECTOR_5.md): Dimensions > u32::MAX must be rejected
-        // rather than truncated by `as u32`. Currently
-        // `vector_index_from_json` truncates via `as_u64()? as u32`, so
-        // this fails: it returns `Some` with a truncated value instead of
-        // `None`.
+        // Dimensions must fit in the public `u32` representation.
         let value = serde_json::json!({
             "IndexName": "vec_idx",
             "VectorAttribute": {
@@ -878,7 +856,7 @@ mod tests {
             }
         });
         assert!(
-            vector_index_from_json(&value).is_none(),
+            vector_index_from_json(&value).is_err(),
             "Dimensions overflowing u32 must be rejected, not truncated"
         );
     }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,3 +1,25 @@
+//! Alternator vector-search extensions: typed request/response models and
+//! extension traits for `VectorIndexes`, `VectorIndexUpdates`,
+//! `VectorSearch`, and `Scores`, none of which the generated AWS SDK types
+//! can express.
+//!
+//! Use [`crate::CreateTableVectorExt`], [`crate::QueryVectorExt`],
+//! [`crate::UpdateTableVectorExt`], and [`crate::DescribeTableVectorExt`]
+//! directly on the ordinary AWS SDK fluent builders returned by
+//! [`crate::AlternatorClient::create_table`],
+//! [`crate::AlternatorClient::query`],
+//! [`crate::AlternatorClient::update_table`], and
+//! [`crate::AlternatorClient::describe_table`]. Ordinary AWS SDK request
+//! setters must precede the vector extension method; it is the boundary
+//! after which only vector-specific and
+//! [`crate::AlternatorCustomizableOperation::alternator_config_override`]
+//! configuration remain available.
+//!
+//! See the crate README's "Vector search" section for end-to-end examples.
+//! `FLOAT32VECTOR` attribute encoding lives in
+//! [`crate::float32_vector`].
+
+use aws_sdk_dynamodb::types::AttributeValue;
 use serde::Serialize;
 
 /// Similarity functions for vector search.
@@ -108,6 +130,29 @@ impl Projection {
     }
 }
 
+/// Status of a vector index, as reported in responses. Absent from
+/// request JSON.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexStatus {
+    Creating,
+    Updating,
+    Deleting,
+    Active,
+}
+
+#[allow(dead_code)]
+impl IndexStatus {
+    pub(crate) fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "CREATING" => Some(IndexStatus::Creating),
+            "UPDATING" => Some(IndexStatus::Updating),
+            "DELETING" => Some(IndexStatus::Deleting),
+            "ACTIVE" => Some(IndexStatus::Active),
+            _ => None,
+        }
+    }
+}
+
 /// A vector index configuration for Alternator Vector Search.
 ///
 /// The index automatically uses the base table's primary key schema
@@ -120,6 +165,13 @@ pub struct VectorIndex {
     /// entirely and the server applies its own default projection.
     pub projection: Option<Projection>,
     pub similarity_function: Option<SimilarityFunction>,
+    /// Response-only: the index's current status. Absent (`None`) for
+    /// locally-built request values; populated when parsed from a
+    /// `CreateTable`/`DescribeTable`/`UpdateTable` response.
+    pub index_status: Option<IndexStatus>,
+    /// Response-only: whether the index is still backfilling. Absent
+    /// (`None`) for locally-built request values.
+    pub backfilling: Option<bool>,
 }
 
 impl VectorIndex {
@@ -172,6 +224,8 @@ impl VectorIndexBuilder {
             vector_attribute,
             projection: self.projection,
             similarity_function: self.similarity_function,
+            index_status: None,
+            backfilling: None,
         })
     }
 }
@@ -243,6 +297,309 @@ impl From<&VectorIndex> for VectorIndexJson {
             },
             similarity_function: idx.similarity_function.map(|f| f.as_str().to_string()),
         }
+    }
+}
+
+/// Parses a `VectorIndex` response entry (as found under `Table.VectorIndexes`
+/// or `TableDescription.VectorIndexes`) from raw JSON, including
+/// response-only `IndexStatus` and `Backfilling` fields.
+pub(crate) fn vector_index_from_json(value: &serde_json::Value) -> Option<VectorIndex> {
+    let index_name = value.get("IndexName")?.as_str()?.to_string();
+    let va = value.get("VectorAttribute")?;
+    let attribute_name = va.get("AttributeName")?.as_str()?.to_string();
+    let dimensions_raw = va.get("Dimensions")?.as_u64()?;
+    let dimensions = u32::try_from(dimensions_raw).ok()?;
+
+    let projection = value.get("Projection").and_then(|p| {
+        let projection_type = p.get("ProjectionType")?.as_str()?;
+        Some(match projection_type {
+            "ALL" => Projection::all(),
+            "KEYS_ONLY" => Projection::keys_only(),
+            "INCLUDE" => {
+                let attrs = p
+                    .get("NonKeyAttributes")
+                    .and_then(|a| a.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                Projection::include(attrs)
+            }
+            _ => return None,
+        })
+    });
+
+    let similarity_function = value
+        .get("SimilarityFunction")
+        .and_then(|s| s.as_str())
+        .and_then(|s| match s {
+            "COSINE" => Some(SimilarityFunction::Cosine),
+            "EUCLIDEAN" => Some(SimilarityFunction::Euclidean),
+            "DOT_PRODUCT" => Some(SimilarityFunction::DotProduct),
+            _ => None,
+        });
+
+    let index_status = value
+        .get("IndexStatus")
+        .and_then(|s| s.as_str())
+        .and_then(IndexStatus::from_str);
+
+    let backfilling = value.get("Backfilling").and_then(|b| b.as_bool());
+
+    Some(VectorIndex {
+        index_name,
+        vector_attribute: VectorAttribute {
+            attribute_name,
+            dimensions,
+        },
+        projection,
+        similarity_function,
+        index_status,
+        backfilling,
+    })
+}
+
+/// A single vector-index change for `UpdateTable.VectorIndexUpdates`.
+#[derive(Debug, Clone)]
+pub enum VectorIndexUpdate {
+    Create(VectorIndex),
+    Delete { index_name: String },
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct VectorIndexUpdateJson {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create: Option<VectorIndexJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delete: Option<VectorIndexDeleteJson>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct VectorIndexDeleteJson {
+    pub index_name: String,
+}
+
+impl From<&VectorIndexUpdate> for VectorIndexUpdateJson {
+    fn from(update: &VectorIndexUpdate) -> Self {
+        match update {
+            VectorIndexUpdate::Create(idx) => VectorIndexUpdateJson {
+                create: Some(idx.into()),
+                delete: None,
+            },
+            VectorIndexUpdate::Delete { index_name } => VectorIndexUpdateJson {
+                create: None,
+                delete: Some(VectorIndexDeleteJson {
+                    index_name: index_name.clone(),
+                }),
+            },
+        }
+    }
+}
+
+/// Score reporting mode for a [VectorSearch] query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReturnScores {
+    /// Request similarity scores alongside query results.
+    Similarity,
+}
+
+impl ReturnScores {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ReturnScores::Similarity => "SIMILARITY",
+        }
+    }
+}
+
+/// Vector-search extras for `Query.VectorSearch`.
+///
+/// The query vector is stored as a validated DynamoDB [`AttributeValue`]:
+/// either a compact `FLOAT32VECTOR` marker built by [`VectorSearch::new`],
+/// or a standard `AttributeValue::L` of numeric (`N`) values built by
+/// [`VectorSearch::from_query_vector`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorSearch {
+    pub(crate) query_vector: AttributeValue,
+    pub return_scores: Option<ReturnScores>,
+}
+
+impl VectorSearch {
+    /// Creates a [VectorSearch] with a compact `FLOAT32VECTOR` query vector
+    /// and no score reporting. Returns an error if `vector` is empty or
+    /// contains non-finite values.
+    pub fn new(vector: impl IntoIterator<Item = f32>) -> Result<Self, &'static str> {
+        let vector: Vec<f32> = vector.into_iter().collect();
+        if vector.is_empty() {
+            return Err("query vector must not be empty");
+        }
+        if vector.iter().any(|v| !v.is_finite()) {
+            return Err("query vector must contain only finite values");
+        }
+        let query_vector = crate::float32_vector::Float32Vector::to_attribute_value(vector)
+            .expect("finiteness already validated above");
+        Ok(Self {
+            query_vector,
+            return_scores: None,
+        })
+    }
+
+    /// Creates a [VectorSearch] with a standard DynamoDB `AttributeValue::L`
+    /// query vector, i.e. a list of `AttributeValue::N` values, matching the
+    /// shape a non-preserving read returns. Returns an error if `values` is
+    /// empty or contains a non-numeric member.
+    pub fn from_query_vector(
+        values: impl IntoIterator<Item = AttributeValue>,
+    ) -> Result<Self, &'static str> {
+        let values: Vec<AttributeValue> = values.into_iter().collect();
+        if values.is_empty() {
+            return Err("query vector must not be empty");
+        }
+        if !values.iter().all(|v| matches!(v, AttributeValue::N(_))) {
+            return Err("query vector list must contain only numeric (N) values");
+        }
+        Ok(Self {
+            query_vector: AttributeValue::L(values),
+            return_scores: None,
+        })
+    }
+
+    pub fn with_return_scores(mut self, return_scores: ReturnScores) -> Self {
+        self.return_scores = Some(return_scores);
+        self
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct VectorSearchJson {
+    pub query_vector: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub return_scores: Option<String>,
+}
+
+impl From<&VectorSearch> for VectorSearchJson {
+    fn from(search: &VectorSearch) -> Self {
+        VectorSearchJson {
+            query_vector: crate::float32_vector::attribute_value_to_json(&search.query_vector),
+            return_scores: search.return_scores.map(|s| s.as_str().to_string()),
+        }
+    }
+}
+
+// --- Vector response-aware output wrappers ---
+//
+// These wrap the generated AWS SDK output types with Alternator-only
+// response data. They are constructed by the response-aware operation
+// wrappers in `crate::vector_interceptor` after `.send()` on the
+// underlying `CustomizableOperation` completes.
+
+use aws_sdk_dynamodb::operation::create_table::CreateTableOutput;
+use aws_sdk_dynamodb::operation::describe_table::DescribeTableOutput;
+use aws_sdk_dynamodb::operation::query::QueryOutput;
+
+/// Wraps a generated [QueryOutput], adding similarity scores extracted from
+/// the response's `Scores` field when [`VectorSearch::with_return_scores`]
+/// requested them.
+#[derive(Debug, Clone)]
+pub struct VectorQueryOutput {
+    output: QueryOutput,
+    /// Present when the query requested [ReturnScores::Similarity]; absent
+    /// (not a stale empty `Vec`) otherwise.
+    pub scores: Option<Vec<f64>>,
+}
+
+impl VectorQueryOutput {
+    pub(crate) fn new(output: QueryOutput, scores: Option<Vec<f64>>) -> Self {
+        Self { output, scores }
+    }
+
+    /// Consumes this value, returning the generated [QueryOutput]. Rust does
+    /// not perform this conversion implicitly.
+    pub fn into_inner(self) -> QueryOutput {
+        self.output
+    }
+
+    /// Borrows the generated [QueryOutput].
+    pub fn as_inner(&self) -> &QueryOutput {
+        &self.output
+    }
+}
+
+impl From<VectorQueryOutput> for QueryOutput {
+    fn from(value: VectorQueryOutput) -> Self {
+        value.output
+    }
+}
+
+/// Wraps a generated [DescribeTableOutput], adding parsed
+/// `Table.VectorIndexes` metadata.
+#[derive(Debug, Clone)]
+pub struct DescribeTableWithVectorIndexes {
+    output: DescribeTableOutput,
+    pub vector_indexes: Vec<VectorIndex>,
+}
+
+impl DescribeTableWithVectorIndexes {
+    pub(crate) fn new(output: DescribeTableOutput, vector_indexes: Vec<VectorIndex>) -> Self {
+        Self {
+            output,
+            vector_indexes,
+        }
+    }
+
+    /// Consumes this value, returning the generated [DescribeTableOutput].
+    /// Rust does not perform this conversion implicitly.
+    pub fn into_inner(self) -> DescribeTableOutput {
+        self.output
+    }
+
+    /// Borrows the generated [DescribeTableOutput].
+    pub fn as_inner(&self) -> &DescribeTableOutput {
+        &self.output
+    }
+}
+
+impl From<DescribeTableWithVectorIndexes> for DescribeTableOutput {
+    fn from(value: DescribeTableWithVectorIndexes) -> Self {
+        value.output
+    }
+}
+
+/// Wraps a generated [CreateTableOutput], adding parsed
+/// `TableDescription.VectorIndexes` metadata.
+#[derive(Debug, Clone)]
+pub struct CreateTableWithVectorIndexes {
+    output: CreateTableOutput,
+    pub vector_indexes: Vec<VectorIndex>,
+}
+
+impl CreateTableWithVectorIndexes {
+    pub(crate) fn new(output: CreateTableOutput, vector_indexes: Vec<VectorIndex>) -> Self {
+        Self {
+            output,
+            vector_indexes,
+        }
+    }
+
+    /// Consumes this value, returning the generated [CreateTableOutput].
+    /// Rust does not perform this conversion implicitly.
+    pub fn into_inner(self) -> CreateTableOutput {
+        self.output
+    }
+
+    /// Borrows the generated [CreateTableOutput].
+    pub fn as_inner(&self) -> &CreateTableOutput {
+        &self.output
+    }
+}
+
+impl From<CreateTableWithVectorIndexes> for CreateTableOutput {
+    fn from(value: CreateTableWithVectorIndexes) -> Self {
+        value.output
     }
 }
 
@@ -418,5 +775,129 @@ mod tests {
                 .is_ok(),
             "dimensions == 16000 should still be accepted"
         );
+    }
+
+    #[test]
+    fn test_vector_index_update_create_json() {
+        let va = VectorAttribute::builder()
+            .attribute_name("v")
+            .dimensions(64)
+            .build()
+            .unwrap();
+        let idx = VectorIndex::builder()
+            .index_name("vec_idx")
+            .vector_attribute(va)
+            .build()
+            .unwrap();
+        let update = VectorIndexUpdate::Create(idx);
+        let json: VectorIndexUpdateJson = (&update).into();
+        let serialized = serde_json::to_value(&json).unwrap();
+        assert_eq!(serialized["Create"]["IndexName"], "vec_idx");
+        assert!(serialized.get("Delete").is_none());
+    }
+
+    #[test]
+    fn test_vector_index_update_delete_json() {
+        let update = VectorIndexUpdate::Delete {
+            index_name: "vec_idx".to_string(),
+        };
+        let json: VectorIndexUpdateJson = (&update).into();
+        let serialized = serde_json::to_value(&json).unwrap();
+        assert_eq!(serialized["Delete"]["IndexName"], "vec_idx");
+        assert!(serialized.get("Create").is_none());
+    }
+
+    #[test]
+    fn test_vector_search_json_without_scores() {
+        let search = VectorSearch::new(vec![1.0, 2.0, 3.0]).unwrap();
+        let json: VectorSearchJson = (&search).into();
+        let serialized = serde_json::to_value(&json).unwrap();
+        // The compact form serializes as a marker `AttributeValue::B`; the
+        // driver's request interceptor rewrites it into
+        // `{"FLOAT32VECTOR": [...]}` in the serialized wire body (see
+        // `interceptors::tests::vector_search_is_injected_on_query`).
+        assert!(serialized["QueryVector"].get("B").is_some());
+        assert!(serialized.get("ReturnScores").is_none());
+    }
+
+    #[test]
+    fn test_vector_search_json_with_scores() {
+        let search = VectorSearch::new(vec![1.0])
+            .unwrap()
+            .with_return_scores(ReturnScores::Similarity);
+        let json: VectorSearchJson = (&search).into();
+        let serialized = serde_json::to_value(&json).unwrap();
+        assert_eq!(serialized["ReturnScores"], "SIMILARITY");
+    }
+
+    #[test]
+    fn test_vector_search_rejects_empty_vector() {
+        assert!(VectorSearch::new(Vec::<f32>::new()).is_err());
+    }
+
+    #[test]
+    fn test_vector_search_rejects_non_finite_values() {
+        assert!(VectorSearch::new(vec![1.0, f32::NAN]).is_err());
+        assert!(VectorSearch::new(vec![f32::INFINITY]).is_err());
+    }
+
+    #[test]
+    fn test_vector_search_from_query_vector_json_uses_standard_list() {
+        let search = VectorSearch::from_query_vector(vec![
+            AttributeValue::N("1".to_string()),
+            AttributeValue::N("2".to_string()),
+            AttributeValue::N("3".to_string()),
+        ])
+        .unwrap();
+        let json: VectorSearchJson = (&search).into();
+        let serialized = serde_json::to_value(&json).unwrap();
+        assert_eq!(
+            serialized["QueryVector"]["L"],
+            serde_json::json!([{ "N": "1" }, { "N": "2" }, { "N": "3" }])
+        );
+    }
+
+    #[test]
+    fn test_vector_search_from_query_vector_rejects_empty_and_non_numeric() {
+        assert!(VectorSearch::from_query_vector(Vec::<AttributeValue>::new()).is_err());
+        assert!(VectorSearch::from_query_vector(vec![AttributeValue::S("x".to_string())]).is_err());
+    }
+
+    #[test]
+    fn test_vector_index_from_json_rejects_dimensions_over_u32_max() {
+        // Phase 1 (VECTOR_5.md): Dimensions > u32::MAX must be rejected
+        // rather than truncated by `as u32`. Currently
+        // `vector_index_from_json` truncates via `as_u64()? as u32`, so
+        // this fails: it returns `Some` with a truncated value instead of
+        // `None`.
+        let value = serde_json::json!({
+            "IndexName": "vec_idx",
+            "VectorAttribute": {
+                "AttributeName": "embedding",
+                "Dimensions": (u32::MAX as u64) + 1
+            }
+        });
+        assert!(
+            vector_index_from_json(&value).is_none(),
+            "Dimensions overflowing u32 must be rejected, not truncated"
+        );
+    }
+
+    #[test]
+    fn test_vector_index_from_json_parses_status_and_backfilling() {
+        let value = serde_json::json!({
+            "IndexName": "vec_idx",
+            "VectorAttribute": { "AttributeName": "embedding", "Dimensions": 128 },
+            "Projection": { "ProjectionType": "KEYS_ONLY" },
+            "SimilarityFunction": "COSINE",
+            "IndexStatus": "ACTIVE",
+            "Backfilling": false
+        });
+        let idx = vector_index_from_json(&value).unwrap();
+        assert_eq!(idx.index_name, "vec_idx");
+        assert_eq!(idx.vector_attribute.dimensions, 128);
+        assert_eq!(idx.similarity_function, Some(SimilarityFunction::Cosine));
+        assert_eq!(idx.index_status, Some(IndexStatus::Active));
+        assert_eq!(idx.backfilling, Some(false));
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,0 +1,422 @@
+use serde::Serialize;
+
+/// Similarity functions for vector search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SimilarityFunction {
+    Cosine,
+    Euclidean,
+    DotProduct,
+}
+
+impl SimilarityFunction {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SimilarityFunction::Cosine => "COSINE",
+            SimilarityFunction::Euclidean => "EUCLIDEAN",
+            SimilarityFunction::DotProduct => "DOT_PRODUCT",
+        }
+    }
+}
+
+/// Defines a vector attribute in a vector index.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorAttribute {
+    pub attribute_name: String,
+    pub dimensions: u32,
+}
+
+impl VectorAttribute {
+    pub fn builder() -> VectorAttributeBuilder {
+        VectorAttributeBuilder::default()
+    }
+}
+
+/// Builder for [VectorAttribute].
+#[derive(Debug, Default)]
+pub struct VectorAttributeBuilder {
+    attribute_name: Option<String>,
+    dimensions: Option<u32>,
+}
+
+impl VectorAttributeBuilder {
+    pub fn attribute_name(mut self, name: impl Into<String>) -> Self {
+        self.attribute_name = Some(name.into());
+        self
+    }
+
+    pub fn dimensions(mut self, dimensions: u32) -> Self {
+        self.dimensions = Some(dimensions);
+        self
+    }
+
+    pub fn build(self) -> Result<VectorAttribute, &'static str> {
+        let attribute_name = self.attribute_name.ok_or("attribute_name is required")?;
+        if attribute_name.is_empty() {
+            return Err("attribute_name must not be empty");
+        }
+        let dimensions = self.dimensions.ok_or("dimensions is required")?;
+        if dimensions == 0 {
+            return Err("dimensions must be positive");
+        }
+        if dimensions > 16000 {
+            return Err("dimensions must not exceed 16000");
+        }
+        Ok(VectorAttribute {
+            attribute_name,
+            dimensions,
+        })
+    }
+}
+
+/// Projection type for a vector index.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ProjectionType {
+    All,
+    KeysOnly,
+    Include(Vec<String>),
+}
+
+/// Projection configuration for a vector index.
+///
+/// A [VectorIndex] with no projection configured omits the `Projection`
+/// field from the request entirely, so the server applies its own default.
+/// This is distinct from explicitly requesting [ProjectionType::KeysOnly].
+#[derive(Debug, Clone, PartialEq)]
+pub struct Projection {
+    pub projection_type: ProjectionType,
+}
+
+impl Projection {
+    pub fn all() -> Self {
+        Self {
+            projection_type: ProjectionType::All,
+        }
+    }
+
+    pub fn keys_only() -> Self {
+        Self {
+            projection_type: ProjectionType::KeysOnly,
+        }
+    }
+
+    pub fn include(attributes: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            projection_type: ProjectionType::Include(
+                attributes.into_iter().map(Into::into).collect(),
+            ),
+        }
+    }
+}
+
+/// A vector index configuration for Alternator Vector Search.
+///
+/// The index automatically uses the base table's primary key schema
+/// (HASH and optional RANGE). No `KeySchema` is specified here.
+#[derive(Debug, Clone)]
+pub struct VectorIndex {
+    pub index_name: String,
+    pub vector_attribute: VectorAttribute,
+    /// When `None`, the `Projection` field is omitted from the request
+    /// entirely and the server applies its own default projection.
+    pub projection: Option<Projection>,
+    pub similarity_function: Option<SimilarityFunction>,
+}
+
+impl VectorIndex {
+    pub fn builder() -> VectorIndexBuilder {
+        VectorIndexBuilder::default()
+    }
+}
+
+/// Builder for [VectorIndex].
+#[derive(Debug, Default)]
+pub struct VectorIndexBuilder {
+    index_name: Option<String>,
+    vector_attribute: Option<VectorAttribute>,
+    projection: Option<Projection>,
+    similarity_function: Option<SimilarityFunction>,
+}
+
+impl VectorIndexBuilder {
+    pub fn index_name(mut self, name: impl Into<String>) -> Self {
+        self.index_name = Some(name.into());
+        self
+    }
+
+    pub fn vector_attribute(mut self, attr: VectorAttribute) -> Self {
+        self.vector_attribute = Some(attr);
+        self
+    }
+
+    pub fn projection(mut self, projection: Projection) -> Self {
+        self.projection = Some(projection);
+        self
+    }
+
+    pub fn similarity_function(mut self, func: SimilarityFunction) -> Self {
+        self.similarity_function = Some(func);
+        self
+    }
+
+    pub fn build(self) -> Result<VectorIndex, &'static str> {
+        let index_name = self.index_name.ok_or("index_name is required")?;
+        validate_index_name(&index_name)?;
+        let vector_attribute = self
+            .vector_attribute
+            .ok_or("vector_attribute is required")?;
+        if vector_attribute.dimensions == 0 {
+            return Err("dimensions must be positive");
+        }
+        Ok(VectorIndex {
+            index_name,
+            vector_attribute,
+            projection: self.projection,
+            similarity_function: self.similarity_function,
+        })
+    }
+}
+
+/// Validates an index name against the DynamoDB-style rule: 3-192 ASCII
+/// characters matching `[a-zA-Z0-9._-]+`.
+pub(crate) fn validate_index_name(name: &str) -> Result<(), &'static str> {
+    if name.is_empty() {
+        return Err("index_name must not be empty");
+    }
+    if !(3..=192).contains(&name.len()) {
+        return Err("index_name must be between 3 and 192 characters");
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+    {
+        return Err("index_name must match [a-zA-Z0-9._-]+");
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct VectorIndexJson {
+    pub index_name: String,
+    pub vector_attribute: VectorAttributeJson,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projection: Option<ProjectionJson>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub similarity_function: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct ProjectionJson {
+    pub projection_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub non_key_attributes: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) struct VectorAttributeJson {
+    pub attribute_name: String,
+    pub dimensions: u32,
+}
+
+impl From<&VectorIndex> for VectorIndexJson {
+    fn from(idx: &VectorIndex) -> Self {
+        let projection = idx.projection.as_ref().map(|p| {
+            let (projection_type, non_key_attributes) = match &p.projection_type {
+                ProjectionType::All => ("ALL", None),
+                ProjectionType::KeysOnly => ("KEYS_ONLY", None),
+                ProjectionType::Include(attrs) => ("INCLUDE", Some(attrs.clone())),
+            };
+            ProjectionJson {
+                projection_type: projection_type.to_string(),
+                non_key_attributes,
+            }
+        });
+
+        VectorIndexJson {
+            index_name: idx.index_name.clone(),
+            projection,
+            vector_attribute: VectorAttributeJson {
+                attribute_name: idx.vector_attribute.attribute_name.clone(),
+                dimensions: idx.vector_attribute.dimensions,
+            },
+            similarity_function: idx.similarity_function.map(|f| f.as_str().to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_similarity_function_as_str() {
+        assert_eq!(SimilarityFunction::Cosine.as_str(), "COSINE");
+        assert_eq!(SimilarityFunction::Euclidean.as_str(), "EUCLIDEAN");
+        assert_eq!(SimilarityFunction::DotProduct.as_str(), "DOT_PRODUCT");
+    }
+
+    #[test]
+    fn test_vector_attribute_builder() {
+        let attr = VectorAttribute::builder()
+            .attribute_name("embedding")
+            .dimensions(128)
+            .build()
+            .unwrap();
+        assert_eq!(attr.attribute_name, "embedding");
+        assert_eq!(attr.dimensions, 128);
+    }
+
+    #[test]
+    fn test_vector_index_builder() {
+        let va = VectorAttribute::builder()
+            .attribute_name("v")
+            .dimensions(64)
+            .build()
+            .unwrap();
+        let idx = VectorIndex::builder()
+            .index_name("my_vec_idx")
+            .vector_attribute(va)
+            .similarity_function(SimilarityFunction::Cosine)
+            .build()
+            .unwrap();
+        assert_eq!(idx.index_name, "my_vec_idx");
+        assert_eq!(idx.vector_attribute.dimensions, 64);
+        assert_eq!(idx.similarity_function, Some(SimilarityFunction::Cosine));
+    }
+
+    #[test]
+    fn test_vector_index_json_default_projection() {
+        let va = VectorAttribute::builder()
+            .attribute_name("embedding")
+            .dimensions(128)
+            .build()
+            .unwrap();
+        let idx = VectorIndex::builder()
+            .index_name("vec_idx")
+            .vector_attribute(va)
+            .build()
+            .unwrap();
+        let json: VectorIndexJson = (&idx).into();
+        let serialized = serde_json::to_value(&json).unwrap();
+
+        assert_eq!(serialized["IndexName"], "vec_idx");
+        assert_eq!(serialized["VectorAttribute"]["AttributeName"], "embedding");
+        assert_eq!(serialized["VectorAttribute"]["Dimensions"], 128);
+        // No projection was configured, so the field is omitted entirely
+        // and the server applies its own default.
+        assert!(serialized.get("Projection").is_none());
+        // No similarity function should be absent
+        assert!(serialized.get("SimilarityFunction").is_none());
+    }
+
+    #[test]
+    fn test_vector_index_json_with_explicit_keys_only_projection() {
+        let va = VectorAttribute::builder()
+            .attribute_name("v")
+            .dimensions(64)
+            .build()
+            .unwrap();
+        let idx = VectorIndex::builder()
+            .index_name("vec_idx")
+            .vector_attribute(va)
+            .projection(Projection::keys_only())
+            .build()
+            .unwrap();
+        let json: VectorIndexJson = (&idx).into();
+        let serialized = serde_json::to_value(&json).unwrap();
+
+        // Explicitly requested KEYS_ONLY is sent on the wire, unlike omission.
+        assert_eq!(serialized["Projection"]["ProjectionType"], "KEYS_ONLY");
+    }
+
+    #[test]
+    fn test_vector_index_json_with_cosine_similarity() {
+        let va = VectorAttribute::builder()
+            .attribute_name("v")
+            .dimensions(64)
+            .build()
+            .unwrap();
+        let idx = VectorIndex::builder()
+            .index_name("vec_idx")
+            .vector_attribute(va)
+            .similarity_function(SimilarityFunction::Cosine)
+            .build()
+            .unwrap();
+        let json: VectorIndexJson = (&idx).into();
+        let serialized = serde_json::to_value(&json).unwrap();
+
+        assert_eq!(serialized["SimilarityFunction"], "COSINE");
+    }
+
+    #[test]
+    fn test_vector_index_json_with_all_projection() {
+        let va = VectorAttribute::builder()
+            .attribute_name("v")
+            .dimensions(64)
+            .build()
+            .unwrap();
+        let idx = VectorIndex::builder()
+            .index_name("vec_idx")
+            .vector_attribute(va)
+            .projection(Projection::all())
+            .build()
+            .unwrap();
+        let json: VectorIndexJson = (&idx).into();
+        let serialized = serde_json::to_value(&json).unwrap();
+
+        assert_eq!(serialized["Projection"]["ProjectionType"], "ALL");
+    }
+
+    #[test]
+    fn test_index_name_validation() {
+        assert!(validate_index_name("abc").is_ok());
+        assert!(validate_index_name("ab").is_err(), "too short");
+        assert!(validate_index_name(&"a".repeat(193)).is_err(), "too long");
+        assert!(validate_index_name("valid-name.1_2").is_ok());
+        assert!(
+            validate_index_name("invalid name").is_err(),
+            "space not allowed"
+        );
+        assert!(validate_index_name("invalid$name").is_err());
+    }
+
+    #[test]
+    fn test_vector_attribute_builder_rejects_empty_name_and_zero_dimensions() {
+        assert!(
+            VectorAttribute::builder()
+                .attribute_name("")
+                .dimensions(1)
+                .build()
+                .is_err()
+        );
+        assert!(
+            VectorAttribute::builder()
+                .attribute_name("v")
+                .dimensions(0)
+                .build()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_vector_attribute_builder_rejects_dimensions_over_16000() {
+        assert!(
+            VectorAttribute::builder()
+                .attribute_name("embedding")
+                .dimensions(16001)
+                .build()
+                .is_err(),
+            "dimensions above 16000 should be rejected"
+        );
+        assert!(
+            VectorAttribute::builder()
+                .attribute_name("embedding")
+                .dimensions(16000)
+                .build()
+                .is_ok(),
+            "dimensions == 16000 should still be accepted"
+        );
+    }
+}

--- a/src/vector_interceptor.rs
+++ b/src/vector_interceptor.rs
@@ -1,6 +1,6 @@
 use crate::vector::{
     CreateTableWithVectorIndexes, DescribeTableWithVectorIndexes, VectorIndex, VectorIndexUpdate,
-    VectorSearch,
+    VectorQueryOutput, VectorSearch,
 };
 use crate::{AlternatorCustomizableOperation, AlternatorOperationBuilder};
 
@@ -9,6 +9,8 @@ use aws_sdk_dynamodb::operation::create_table::CreateTableError;
 use aws_sdk_dynamodb::operation::create_table::builders::CreateTableFluentBuilder;
 use aws_sdk_dynamodb::operation::describe_table::DescribeTableError;
 use aws_sdk_dynamodb::operation::describe_table::builders::DescribeTableFluentBuilder;
+use aws_sdk_dynamodb::operation::query::QueryError;
+use aws_sdk_dynamodb::operation::query::builders::QueryFluentBuilder;
 use aws_sdk_dynamodb::operation::update_table::UpdateTableError;
 use aws_sdk_dynamodb::operation::update_table::builders::UpdateTableFluentBuilder;
 use aws_smithy_runtime_api::box_error::BoxError;
@@ -280,20 +282,41 @@ impl<E, B> UpdateTableVectorExt
     }
 }
 
-/// Extension trait that adds `VectorSearch` support to Query's
-/// [CustomizableOperation](aws_sdk_dynamodb::client::customize::CustomizableOperation).
+/// Extension trait that adds `VectorSearch` support to `Query`.
 ///
-/// Implemented only for the generated Query customizable operation, so
-/// misuse on other operations is a compile error rather than a runtime one.
+/// Implemented for both the generated [`QueryFluentBuilder`] and its
+/// `CustomizableOperation`. `.send()` returns [`VectorQueryOutput`], which
+/// wraps the generated `QueryOutput` and adds similarity scores.
 pub trait QueryVectorExt {
-    fn vector_search(self, search: VectorSearch) -> Self;
+    type Output;
+
+    fn vector_search(self, search: VectorSearch) -> Self::Output;
 }
 
-impl<E, B> QueryVectorExt
-    for CustomizableOperation<aws_sdk_dynamodb::operation::query::QueryOutput, E, B>
+impl QueryVectorExt for QueryFluentBuilder {
+    type Output = VectorQueryOperation;
+
+    fn vector_search(self, search: VectorSearch) -> Self::Output {
+        self.customize().vector_search(search)
+    }
+}
+
+impl QueryVectorExt
+    for CustomizableOperation<
+        aws_sdk_dynamodb::operation::query::QueryOutput,
+        QueryError,
+        QueryFluentBuilder,
+    >
 {
-    fn vector_search(self, search: VectorSearch) -> Self {
-        self.interceptor(VectorRequestStoreInterceptor::for_vector_search(search))
+    type Output = VectorQueryOperation;
+
+    fn vector_search(self, search: VectorSearch) -> Self::Output {
+        let response_interceptor = VectorResponseHolderInterceptor::new();
+        let holder = response_interceptor.holder();
+        let inner = self
+            .interceptor(response_interceptor)
+            .interceptor(VectorRequestStoreInterceptor::for_vector_search(search));
+        VectorQueryOperation { inner, holder }
     }
 }
 
@@ -329,6 +352,42 @@ impl DescribeTableVectorExt
         let holder = response_interceptor.holder();
         let inner = self.interceptor(response_interceptor);
         VectorDescribeTableOperation { inner, holder }
+    }
+}
+
+/// Response-aware wrapper returned by [`QueryVectorExt::vector_search`].
+///
+/// Wraps the generated `Query` [`CustomizableOperation`]; ordinary AWS SDK
+/// request setters must precede `.vector_search(...)`, since this wrapper
+/// only forwards [`alternator_config_override`](Self::alternator_config_override)
+/// on top of the wrapped operation.
+pub struct VectorQueryOperation {
+    inner: CustomizableOperation<
+        aws_sdk_dynamodb::operation::query::QueryOutput,
+        QueryError,
+        QueryFluentBuilder,
+    >,
+    holder: Arc<Mutex<VectorResponseHolder>>,
+}
+
+impl VectorQueryOperation {
+    /// Applies a per-request [`AlternatorOperationBuilder`] override, such as
+    /// `preserve_float32_vectors`, delegating to the wrapped
+    /// `CustomizableOperation`.
+    pub fn alternator_config_override(
+        mut self,
+        config_override: impl Into<AlternatorOperationBuilder>,
+    ) -> Self {
+        self.inner = self.inner.alternator_config_override(config_override);
+        self
+    }
+
+    /// Sends the request, returning [`VectorQueryOutput`].
+    pub async fn send(self) -> Result<VectorQueryOutput, SdkError<QueryError, HttpResponse>> {
+        let holder = self.holder;
+        let output = self.inner.send().await?;
+        let scores = holder.lock().expect("holder mutex poisoned").scores.take();
+        Ok(VectorQueryOutput::new(output, scores))
     }
 }
 

--- a/src/vector_interceptor.rs
+++ b/src/vector_interceptor.rs
@@ -1,4 +1,4 @@
-use crate::vector::VectorIndex;
+use crate::vector::{VectorIndex, VectorIndexUpdate, VectorSearch};
 
 use aws_sdk_dynamodb::client::customize::CustomizableOperation;
 use aws_smithy_runtime_api::box_error::BoxError;
@@ -17,6 +17,8 @@ use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct VectorRequestStore {
     pub(crate) vector_indexes: Option<Vec<VectorIndex>>,
+    pub(crate) vector_index_updates: Option<Vec<VectorIndexUpdate>>,
+    pub(crate) vector_search: Option<VectorSearch>,
 }
 
 impl Storable for VectorRequestStore {
@@ -36,6 +38,25 @@ impl VectorRequestStoreInterceptor {
         Self {
             store: VectorRequestStore {
                 vector_indexes: Some(vector_indexes),
+                ..Default::default()
+            },
+        }
+    }
+
+    pub(crate) fn for_vector_index_updates(updates: Vec<VectorIndexUpdate>) -> Self {
+        Self {
+            store: VectorRequestStore {
+                vector_index_updates: Some(updates),
+                ..Default::default()
+            },
+        }
+    }
+
+    pub(crate) fn for_vector_search(search: VectorSearch) -> Self {
+        Self {
+            store: VectorRequestStore {
+                vector_search: Some(search),
+                ..Default::default()
             },
         }
     }
@@ -58,15 +79,73 @@ impl Intercept for VectorRequestStoreInterceptor {
     }
 }
 
-/// Extension trait that adds vector search capabilities to
+/// Extension trait that adds `VectorIndexes` support to CreateTable's
 /// [CustomizableOperation](aws_sdk_dynamodb::client::customize::CustomizableOperation).
-pub trait VectorSearchExt<T, E, B> {
+///
+/// Implemented only for the generated CreateTable customizable operation, so
+/// misuse on other operations is a compile error rather than a runtime one.
+pub trait CreateTableVectorExt {
     fn vector_indexes(self, indexes: Vec<VectorIndex>) -> Self;
 }
 
-impl<T, E, B> VectorSearchExt<T, E, B> for CustomizableOperation<T, E, B> {
+impl<E, B> CreateTableVectorExt
+    for CustomizableOperation<aws_sdk_dynamodb::operation::create_table::CreateTableOutput, E, B>
+{
     fn vector_indexes(self, indexes: Vec<VectorIndex>) -> Self {
         self.interceptor(VectorRequestStoreInterceptor::for_vector_indexes(indexes))
+    }
+}
+
+/// Extension trait that adds `VectorIndexUpdates` support to UpdateTable's
+/// [CustomizableOperation](aws_sdk_dynamodb::client::customize::CustomizableOperation).
+///
+/// Implemented only for the generated UpdateTable customizable operation, so
+/// misuse on other operations is a compile error rather than a runtime one:
+///
+/// ```compile_fail
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// use alternator_driver::{AlternatorClient, AlternatorConfig, UpdateTableVectorExt, VectorIndexUpdate};
+///
+/// let client = AlternatorClient::from_conf(
+///     AlternatorConfig::builder().behavior_version_latest().build(),
+/// );
+///
+/// // `vector_index_updates` is only defined for UpdateTable, not CreateTable.
+/// let _ = client
+///     .create_table()
+///     .table_name("t")
+///     .customize()
+///     .vector_index_updates(Vec::<VectorIndexUpdate>::new());
+/// # });
+/// ```
+pub trait UpdateTableVectorExt {
+    fn vector_index_updates(self, updates: Vec<VectorIndexUpdate>) -> Self;
+}
+
+impl<E, B> UpdateTableVectorExt
+    for CustomizableOperation<aws_sdk_dynamodb::operation::update_table::UpdateTableOutput, E, B>
+{
+    fn vector_index_updates(self, updates: Vec<VectorIndexUpdate>) -> Self {
+        self.interceptor(VectorRequestStoreInterceptor::for_vector_index_updates(
+            updates,
+        ))
+    }
+}
+
+/// Extension trait that adds `VectorSearch` support to Query's
+/// [CustomizableOperation](aws_sdk_dynamodb::client::customize::CustomizableOperation).
+///
+/// Implemented only for the generated Query customizable operation, so
+/// misuse on other operations is a compile error rather than a runtime one.
+pub trait QueryVectorExt {
+    fn vector_search(self, search: VectorSearch) -> Self;
+}
+
+impl<E, B> QueryVectorExt
+    for CustomizableOperation<aws_sdk_dynamodb::operation::query::QueryOutput, E, B>
+{
+    fn vector_search(self, search: VectorSearch) -> Self {
+        self.interceptor(VectorRequestStoreInterceptor::for_vector_search(search))
     }
 }
 

--- a/src/vector_interceptor.rs
+++ b/src/vector_interceptor.rs
@@ -1,11 +1,24 @@
-use crate::vector::{VectorIndex, VectorIndexUpdate, VectorSearch};
+use crate::vector::{
+    CreateTableWithVectorIndexes, DescribeTableWithVectorIndexes, VectorIndex, VectorIndexUpdate,
+    VectorSearch,
+};
+use crate::{AlternatorCustomizableOperation, AlternatorOperationBuilder};
 
 use aws_sdk_dynamodb::client::customize::CustomizableOperation;
+use aws_sdk_dynamodb::operation::create_table::CreateTableError;
+use aws_sdk_dynamodb::operation::create_table::builders::CreateTableFluentBuilder;
+use aws_sdk_dynamodb::operation::describe_table::DescribeTableError;
+use aws_sdk_dynamodb::operation::describe_table::builders::DescribeTableFluentBuilder;
+use aws_sdk_dynamodb::operation::update_table::UpdateTableError;
+use aws_sdk_dynamodb::operation::update_table::builders::UpdateTableFluentBuilder;
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::Intercept;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeSerializationInterceptorContextMut;
+use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
+use aws_smithy_runtime_api::client::result::SdkError;
 use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
 use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
+use std::sync::{Arc, Mutex};
 
 /// State carried through [ConfigBag] describing vector-search request
 /// extras that [crate::AlternatorInterceptor] should inject into the
@@ -79,28 +92,108 @@ impl Intercept for VectorRequestStoreInterceptor {
     }
 }
 
-/// Extension trait that adds `VectorIndexes` support to CreateTable's
-/// [CustomizableOperation](aws_sdk_dynamodb::client::customize::CustomizableOperation).
+/// Per-operation vector-search response data extracted by
+/// [crate::AlternatorInterceptor] from the raw response JSON, before
+/// generated SDK deserialization.
 ///
-/// Implemented only for the generated CreateTable customizable operation, so
-/// misuse on other operations is a compile error rather than a runtime one.
-pub trait CreateTableVectorExt {
-    fn vector_indexes(self, indexes: Vec<VectorIndex>) -> Self;
+/// Never client-global: each request creates its own holder in [ConfigBag]
+/// state, so concurrent vector requests cannot observe each other's scores
+/// or index metadata. If a server response omits an optional field, the
+/// corresponding holder field remains `None`, not stale state from a prior
+/// request.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct VectorResponseHolder {
+    pub(crate) scores: Option<Vec<f64>>,
+    pub(crate) vector_indexes: Option<Vec<VectorIndex>>,
 }
 
-impl<E, B> CreateTableVectorExt
-    for CustomizableOperation<aws_sdk_dynamodb::operation::create_table::CreateTableOutput, E, B>
-{
-    fn vector_indexes(self, indexes: Vec<VectorIndex>) -> Self {
-        self.interceptor(VectorRequestStoreInterceptor::for_vector_indexes(indexes))
+/// [ConfigBag] wrapper carrying the shared, per-operation
+/// [VectorResponseHolder] that [crate::AlternatorInterceptor] fills in
+/// during `modify_before_deserialization`.
+#[derive(Debug, Clone)]
+pub(crate) struct VectorResponseStore(pub(crate) Arc<Mutex<VectorResponseHolder>>);
+
+impl Storable for VectorResponseStore {
+    type Storer = StoreReplace<Self>;
+}
+
+/// Per-operation interceptor that attaches a fresh [VectorResponseHolder]
+/// to [ConfigBag], to be filled in later by [crate::AlternatorInterceptor]
+/// after response decompression and before generated SDK deserialization.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct VectorResponseHolderInterceptor {
+    holder: Arc<Mutex<VectorResponseHolder>>,
+}
+
+impl VectorResponseHolderInterceptor {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn holder(&self) -> Arc<Mutex<VectorResponseHolder>> {
+        self.holder.clone()
     }
 }
 
-/// Extension trait that adds `VectorIndexUpdates` support to UpdateTable's
-/// [CustomizableOperation](aws_sdk_dynamodb::client::customize::CustomizableOperation).
+impl Intercept for VectorResponseHolderInterceptor {
+    fn name(&self) -> &'static str {
+        "VectorResponseHolderInterceptor"
+    }
+
+    fn modify_before_serialization(
+        &self,
+        _: &mut BeforeSerializationInterceptorContextMut<'_>,
+        _: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        cfg.interceptor_state()
+            .store_put(VectorResponseStore(self.holder.clone()));
+
+        Ok(())
+    }
+}
+
+/// Extension trait that adds `VectorIndexes` support to `CreateTable`.
 ///
-/// Implemented only for the generated UpdateTable customizable operation, so
-/// misuse on other operations is a compile error rather than a runtime one:
+/// Implemented for both the generated
+/// [`CreateTableFluentBuilder`] and its
+/// [`CustomizableOperation`](aws_sdk_dynamodb::client::customize::CustomizableOperation),
+/// so misuse on other operations is a compile error rather than a runtime
+/// one. The fluent-builder form is the preferred direct syntax:
+///
+/// ```no_run
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// use alternator_driver::{AlternatorClient, AlternatorConfig, CreateTableVectorExt, VectorAttribute, VectorIndex};
+///
+/// let client = AlternatorClient::from_conf(
+///     AlternatorConfig::builder().behavior_version_latest().build(),
+/// );
+///
+/// let index = VectorIndex::builder()
+///     .index_name("vec_idx")
+///     .vector_attribute(
+///         VectorAttribute::builder()
+///             .attribute_name("embedding")
+///             .dimensions(128)
+///             .build()
+///             .unwrap(),
+///     )
+///     .build()
+///     .unwrap();
+///
+/// let created = client
+///     .create_table()
+///     .table_name("Documents")
+///     .vector_indexes(vec![index])
+///     .send()
+///     .await
+///     .unwrap();
+/// println!("{:?}", created.vector_indexes);
+/// # });
+/// ```
+///
+/// The `.customize()` form remains available to combine with
+/// `.alternator_config_override(...)`:
 ///
 /// ```compile_fail
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -114,18 +207,73 @@ impl<E, B> CreateTableVectorExt
 /// let _ = client
 ///     .create_table()
 ///     .table_name("t")
-///     .customize()
 ///     .vector_index_updates(Vec::<VectorIndexUpdate>::new());
 /// # });
 /// ```
+pub trait CreateTableVectorExt {
+    /// The type returned by [`vector_indexes`](Self::vector_indexes).
+    type Output;
+
+    fn vector_indexes(self, indexes: Vec<VectorIndex>) -> Self::Output;
+}
+
+impl CreateTableVectorExt for CreateTableFluentBuilder {
+    type Output = VectorCreateTableOperation;
+
+    fn vector_indexes(self, indexes: Vec<VectorIndex>) -> Self::Output {
+        self.customize().vector_indexes(indexes)
+    }
+}
+
+impl CreateTableVectorExt
+    for CustomizableOperation<
+        aws_sdk_dynamodb::operation::create_table::CreateTableOutput,
+        CreateTableError,
+        CreateTableFluentBuilder,
+    >
+{
+    type Output = VectorCreateTableOperation;
+
+    fn vector_indexes(self, indexes: Vec<VectorIndex>) -> Self::Output {
+        let response_interceptor = VectorResponseHolderInterceptor::new();
+        let holder = response_interceptor.holder();
+        let inner = self
+            .interceptor(response_interceptor)
+            .interceptor(VectorRequestStoreInterceptor::for_vector_indexes(indexes));
+        VectorCreateTableOperation { inner, holder }
+    }
+}
+
+/// Extension trait that adds `VectorIndexUpdates` support to `UpdateTable`.
+///
+/// Implemented for both the generated [`UpdateTableFluentBuilder`] and its
+/// `CustomizableOperation`. `UpdateTable` has no extended response output,
+/// so this continues to return the generated customizable operation
+/// unchanged, and `.send()` returns the generated `UpdateTableOutput`.
 pub trait UpdateTableVectorExt {
-    fn vector_index_updates(self, updates: Vec<VectorIndexUpdate>) -> Self;
+    type Output;
+
+    fn vector_index_updates(self, updates: Vec<VectorIndexUpdate>) -> Self::Output;
+}
+
+impl UpdateTableVectorExt for UpdateTableFluentBuilder {
+    type Output = CustomizableOperation<
+        aws_sdk_dynamodb::operation::update_table::UpdateTableOutput,
+        UpdateTableError,
+        UpdateTableFluentBuilder,
+    >;
+
+    fn vector_index_updates(self, updates: Vec<VectorIndexUpdate>) -> Self::Output {
+        self.customize().vector_index_updates(updates)
+    }
 }
 
 impl<E, B> UpdateTableVectorExt
     for CustomizableOperation<aws_sdk_dynamodb::operation::update_table::UpdateTableOutput, E, B>
 {
-    fn vector_index_updates(self, updates: Vec<VectorIndexUpdate>) -> Self {
+    type Output = Self;
+
+    fn vector_index_updates(self, updates: Vec<VectorIndexUpdate>) -> Self::Output {
         self.interceptor(VectorRequestStoreInterceptor::for_vector_index_updates(
             updates,
         ))
@@ -146,6 +294,113 @@ impl<E, B> QueryVectorExt
 {
     fn vector_search(self, search: VectorSearch) -> Self {
         self.interceptor(VectorRequestStoreInterceptor::for_vector_search(search))
+    }
+}
+
+/// Extension trait that adds vector-index response metadata to
+/// `DescribeTable`. `DescribeTable` has no vector-only request field, so
+/// this trait only affects the response.
+pub trait DescribeTableVectorExt {
+    type Output;
+
+    /// Requests parsed `Table.VectorIndexes` metadata in the response.
+    fn with_vector_indexes(self) -> Self::Output;
+}
+
+impl DescribeTableVectorExt for DescribeTableFluentBuilder {
+    type Output = VectorDescribeTableOperation;
+
+    fn with_vector_indexes(self) -> Self::Output {
+        self.customize().with_vector_indexes()
+    }
+}
+
+impl DescribeTableVectorExt
+    for CustomizableOperation<
+        aws_sdk_dynamodb::operation::describe_table::DescribeTableOutput,
+        DescribeTableError,
+        DescribeTableFluentBuilder,
+    >
+{
+    type Output = VectorDescribeTableOperation;
+
+    fn with_vector_indexes(self) -> Self::Output {
+        let response_interceptor = VectorResponseHolderInterceptor::new();
+        let holder = response_interceptor.holder();
+        let inner = self.interceptor(response_interceptor);
+        VectorDescribeTableOperation { inner, holder }
+    }
+}
+
+/// Response-aware wrapper returned by
+/// [`CreateTableVectorExt::vector_indexes`].
+pub struct VectorCreateTableOperation {
+    inner: CustomizableOperation<
+        aws_sdk_dynamodb::operation::create_table::CreateTableOutput,
+        CreateTableError,
+        CreateTableFluentBuilder,
+    >,
+    holder: Arc<Mutex<VectorResponseHolder>>,
+}
+
+impl VectorCreateTableOperation {
+    pub fn alternator_config_override(
+        mut self,
+        config_override: impl Into<AlternatorOperationBuilder>,
+    ) -> Self {
+        self.inner = self.inner.alternator_config_override(config_override);
+        self
+    }
+
+    /// Sends the request, returning [`CreateTableWithVectorIndexes`].
+    pub async fn send(
+        self,
+    ) -> Result<CreateTableWithVectorIndexes, SdkError<CreateTableError, HttpResponse>> {
+        let holder = self.holder;
+        let output = self.inner.send().await?;
+        let vector_indexes = holder
+            .lock()
+            .expect("holder mutex poisoned")
+            .vector_indexes
+            .take()
+            .unwrap_or_default();
+        Ok(CreateTableWithVectorIndexes::new(output, vector_indexes))
+    }
+}
+
+/// Response-aware wrapper returned by
+/// [`DescribeTableVectorExt::with_vector_indexes`].
+pub struct VectorDescribeTableOperation {
+    inner: CustomizableOperation<
+        aws_sdk_dynamodb::operation::describe_table::DescribeTableOutput,
+        DescribeTableError,
+        DescribeTableFluentBuilder,
+    >,
+    holder: Arc<Mutex<VectorResponseHolder>>,
+}
+
+impl VectorDescribeTableOperation {
+    pub fn alternator_config_override(
+        mut self,
+        config_override: impl Into<AlternatorOperationBuilder>,
+    ) -> Self {
+        self.inner = self.inner.alternator_config_override(config_override);
+        self
+    }
+
+    /// Sends the request, returning [`DescribeTableWithVectorIndexes`].
+    pub async fn send(
+        self,
+    ) -> Result<DescribeTableWithVectorIndexes, SdkError<DescribeTableError, HttpResponse>> {
+        let holder = self.holder;
+        let output = self.inner.send().await?;
+        let vector_indexes = holder
+            .lock()
+            .expect("holder mutex poisoned")
+            .vector_indexes
+            .take()
+            .unwrap_or_default();
+        Ok(DescribeTableWithVectorIndexes::new(output, vector_indexes))
     }
 }
 

--- a/src/vector_interceptor.rs
+++ b/src/vector_interceptor.rs
@@ -1,0 +1,104 @@
+use crate::vector::VectorIndex;
+
+use aws_sdk_dynamodb::client::customize::CustomizableOperation;
+use aws_smithy_runtime_api::box_error::BoxError;
+use aws_smithy_runtime_api::client::interceptors::Intercept;
+use aws_smithy_runtime_api::client::interceptors::context::BeforeSerializationInterceptorContextMut;
+use aws_smithy_runtime_api::client::runtime_components::RuntimeComponents;
+use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
+
+/// State carried through [ConfigBag] describing vector-search request
+/// extras that [crate::AlternatorInterceptor] should inject into the
+/// serialized JSON body immediately before compression.
+///
+/// This is populated by [VectorRequestStoreInterceptor] in
+/// `modify_before_serialization` and is retry-safe: it never inspects or
+/// mutates the HTTP body itself, only carries caller intent.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct VectorRequestStore {
+    pub(crate) vector_indexes: Option<Vec<VectorIndex>>,
+}
+
+impl Storable for VectorRequestStore {
+    type Storer = StoreReplace<Self>;
+}
+
+/// Per-operation interceptor that stashes vector-search request state into
+/// [ConfigBag], to be picked up later by [crate::AlternatorInterceptor]
+/// before compression.
+#[derive(Debug, Clone)]
+pub(crate) struct VectorRequestStoreInterceptor {
+    store: VectorRequestStore,
+}
+
+impl VectorRequestStoreInterceptor {
+    pub(crate) fn for_vector_indexes(vector_indexes: Vec<VectorIndex>) -> Self {
+        Self {
+            store: VectorRequestStore {
+                vector_indexes: Some(vector_indexes),
+            },
+        }
+    }
+}
+
+impl Intercept for VectorRequestStoreInterceptor {
+    fn name(&self) -> &'static str {
+        "VectorRequestStoreInterceptor"
+    }
+
+    fn modify_before_serialization(
+        &self,
+        _: &mut BeforeSerializationInterceptorContextMut<'_>,
+        _: &RuntimeComponents,
+        cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        cfg.interceptor_state().store_put(self.store.clone());
+
+        Ok(())
+    }
+}
+
+/// Extension trait that adds vector search capabilities to
+/// [CustomizableOperation](aws_sdk_dynamodb::client::customize::CustomizableOperation).
+pub trait VectorSearchExt<T, E, B> {
+    fn vector_indexes(self, indexes: Vec<VectorIndex>) -> Self;
+}
+
+impl<T, E, B> VectorSearchExt<T, E, B> for CustomizableOperation<T, E, B> {
+    fn vector_indexes(self, indexes: Vec<VectorIndex>) -> Self {
+        self.interceptor(VectorRequestStoreInterceptor::for_vector_indexes(indexes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::vector::{VectorAttribute, VectorIndexJson};
+
+    /// Test that our vector index serialization produces correct JSON
+    /// that the AlternatorInterceptor would inject into the CreateTable body.
+    #[test]
+    fn test_vector_index_json_structure() {
+        let va = VectorAttribute::builder()
+            .attribute_name("embedding")
+            .dimensions(128)
+            .build()
+            .unwrap();
+
+        let idx = crate::vector::VectorIndex::builder()
+            .index_name("vec_idx")
+            .vector_attribute(va)
+            .build()
+            .unwrap();
+
+        let json_idx: VectorIndexJson = (&idx).into();
+        let value = serde_json::to_value(&json_idx).unwrap();
+
+        assert_eq!(value["IndexName"], "vec_idx");
+        // No KeySchema — automatically inherits from base table
+        assert!(value.get("KeySchema").is_none());
+        // No projection configured, so the field is omitted entirely.
+        assert!(value.get("Projection").is_none());
+        assert_eq!(value["VectorAttribute"]["AttributeName"], "embedding");
+        assert_eq!(value["VectorAttribute"]["Dimensions"], 128);
+    }
+}

--- a/src/vector_response.rs
+++ b/src/vector_response.rs
@@ -1,0 +1,338 @@
+//! Post-decompression, pre-deserialization vector response transformation.
+//!
+//! Wraps an `SdkBody` with a lazy transformer that buffers the full
+//! response, then (for successful, JSON, `FLOAT32VECTOR`-bearing bodies)
+//! rewrites `FLOAT32VECTOR` attributes and extracts `VectorIndexes` into a
+//! per-request [VectorResponseHolder] before handing transformed bytes to
+//! the generated SDK deserializer.
+//!
+//! Errors from the inner body are propagated unchanged. Empty bodies,
+//! non-JSON bodies, and JSON parse failures are passed through unchanged
+//! rather than turned into a local error: only a successful, safe
+//! transformation replaces the original bytes.
+
+use crate::float32_vector::rewrite_response_json_markers;
+use crate::vector::vector_index_from_json;
+use crate::vector_interceptor::VectorResponseHolder;
+
+use aws_smithy_types::body::SdkBody;
+use bytes::Bytes;
+use futures_util::stream::Stream;
+use http_body::Frame;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+/// Wraps `body` with a lazy transformer. See module docs for behavior.
+pub(crate) fn wrap_vector_response_body(
+    body: SdkBody,
+    preserve: bool,
+    holder: Option<Arc<Mutex<VectorResponseHolder>>>,
+) -> SdkBody {
+    let stream = http_body_util::BodyStream::new(body);
+
+    let body_impl = VectorTransformBody {
+        inner: Box::pin(stream),
+        buffer: Vec::new(),
+        trailers: Vec::new(),
+        preserve,
+        holder,
+        done: false,
+        emitted_data: false,
+        emitted_trailers: false,
+    };
+
+    SdkBody::from_body_1_x(body_impl)
+}
+
+type BoxedError = Box<dyn std::error::Error + Send + Sync>;
+
+struct VectorTransformBody {
+    inner: Pin<Box<dyn Stream<Item = Result<Frame<Bytes>, BoxedError>> + Send + Sync>>,
+    buffer: Vec<u8>,
+    /// Non-data frames (i.e. trailers) observed on the inner stream, to be
+    /// re-emitted unchanged after the transformed data frame.
+    trailers: Vec<Frame<Bytes>>,
+    preserve: bool,
+    holder: Option<Arc<Mutex<VectorResponseHolder>>>,
+    done: bool,
+    emitted_data: bool,
+    emitted_trailers: bool,
+}
+
+impl http_body::Body for VectorTransformBody {
+    type Data = Bytes;
+    type Error = BoxedError;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+
+        loop {
+            if !this.emitted_data {
+                if !this.done {
+                    let inner = this.inner.as_mut();
+                    match inner.poll_next(cx) {
+                        Poll::Ready(Some(Ok(frame))) => match frame.into_data() {
+                            Ok(bytes) => {
+                                this.buffer.extend_from_slice(&bytes);
+                                continue;
+                            }
+                            Err(frame) => {
+                                // A non-data frame (trailers): stash it to
+                                // be emitted after the transformed data
+                                // frame, since a single data frame must be
+                                // emitted whole after full buffering.
+                                this.trailers.push(frame);
+                                continue;
+                            }
+                        },
+                        Poll::Ready(Some(Err(e))) => {
+                            // Propagate upstream errors as-is; do not
+                            // attempt a transform on a partial/failed body.
+                            this.emitted_data = true;
+                            this.emitted_trailers = true;
+                            return Poll::Ready(Some(Err(e)));
+                        }
+                        Poll::Ready(None) => {
+                            this.done = true;
+                        }
+                        Poll::Pending => return Poll::Pending,
+                    }
+                }
+
+                this.emitted_data = true;
+                return Poll::Ready(Some(
+                    match transform_bytes(&this.buffer, this.preserve, this.holder.as_ref()) {
+                        Ok(transformed) => Ok(Frame::data(Bytes::from(transformed))),
+                        Err(error) => Err(error.into()),
+                    },
+                ));
+            }
+
+            if let Some(frame) = this.trailers.pop() {
+                return Poll::Ready(Some(Ok(frame)));
+            }
+            this.emitted_trailers = true;
+            return Poll::Ready(None);
+        }
+    }
+}
+
+/// Transforms a fully-buffered response body: extracts `VectorIndexes` into
+/// `holder` (if present) and rewrites `FLOAT32VECTOR` attributes. Returns
+/// the original bytes unchanged for empty, non-JSON, or unparsable bodies.
+fn transform_bytes(
+    bytes: &[u8],
+    preserve: bool,
+    holder: Option<&Arc<Mutex<VectorResponseHolder>>>,
+) -> Result<Vec<u8>, String> {
+    if bytes.is_empty() {
+        return Ok(bytes.to_vec());
+    }
+
+    // Fast path: skip JSON parsing entirely when there is nothing for us
+    // to do (no response holder registered, and no FLOAT32VECTOR content
+    // present in the raw bytes).
+    if holder.is_none() && !contains_subslice(bytes, b"FLOAT32VECTOR") {
+        return Ok(bytes.to_vec());
+    }
+
+    let Ok(mut json) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+        return Ok(bytes.to_vec());
+    };
+
+    if let Some(holder) = holder {
+        for key in ["Table", "TableDescription"] {
+            if let Some(indexes_value) = json.get(key).and_then(|t| t.get("VectorIndexes")) {
+                let indexes = indexes_value
+                    .as_array()
+                    .ok_or("VectorIndexes response field must be an array")?;
+                let parsed: Vec<_> = indexes
+                    .iter()
+                    .map(vector_index_from_json)
+                    .collect::<Result<_, _>>()?;
+                holder.lock().expect("holder mutex poisoned").vector_indexes = Some(parsed);
+            }
+        }
+    }
+
+    rewrite_response_json_markers(&mut json, preserve);
+
+    Ok(serde_json::to_vec(&json).unwrap_or_else(|_| bytes.to_vec()))
+}
+
+fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return needle.is_empty();
+    }
+    haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::stream;
+    use http_body::Body as _;
+    use http_body_util::BodyExt;
+    use http_body_util::StreamBody;
+
+    async fn drain(body: SdkBody) -> Vec<u8> {
+        let collected = body.collect().await.expect("body should not error");
+        collected.to_bytes().to_vec()
+    }
+
+    /// Builds an [SdkBody] from multiple raw chunks, each delivered as its
+    /// own `http_body::Frame::data`, to exercise the transformer's
+    /// cross-frame buffering.
+    fn multi_frame_body(chunks: Vec<&'static [u8]>) -> SdkBody {
+        let frames: Vec<Result<Frame<Bytes>, BoxedError>> = chunks
+            .into_iter()
+            .map(|c| Ok(Frame::data(Bytes::from_static(c))))
+            .collect();
+        SdkBody::from_body_1_x(StreamBody::new(stream::iter(frames)))
+    }
+
+    #[tokio::test]
+    async fn transforms_correctly_across_multiple_input_frames() {
+        let original = serde_json::json!({
+            "Item": { "embedding": { "FLOAT32VECTOR": [1.0, 2.0] } }
+        });
+        let bytes = serde_json::to_vec(&original).unwrap();
+        // Split the JSON into two chunks delivered as separate frames.
+        let mid = bytes.len() / 2;
+        let first: &'static [u8] = Box::leak(bytes[..mid].to_vec().into_boxed_slice());
+        let second: &'static [u8] = Box::leak(bytes[mid..].to_vec().into_boxed_slice());
+
+        let body = wrap_vector_response_body(multi_frame_body(vec![first, second]), false, None);
+        let out = drain(body).await;
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(
+            parsed["Item"]["embedding"]["L"],
+            serde_json::json!([{ "N": "1" }, { "N": "2" }])
+        );
+    }
+
+    #[tokio::test]
+    async fn preserves_trailers_across_transformation() {
+        let original = serde_json::json!({
+            "Item": { "embedding": { "FLOAT32VECTOR": [1.0, 2.0] } }
+        });
+        let bytes = serde_json::to_vec(&original).unwrap();
+
+        let mut trailer_map = http::HeaderMap::new();
+        trailer_map.insert(
+            "x-amz-trailer-test",
+            http::HeaderValue::from_static("present"),
+        );
+
+        let frames: Vec<Result<Frame<Bytes>, BoxedError>> = vec![
+            Ok(Frame::data(Bytes::from(bytes))),
+            Ok(Frame::trailers(trailer_map)),
+        ];
+        let input = SdkBody::from_body_1_x(StreamBody::new(stream::iter(frames)));
+
+        let mut body = wrap_vector_response_body(input, false, None);
+        let mut saw_trailers = false;
+        loop {
+            match std::future::poll_fn(|cx| Pin::new(&mut body).poll_frame(cx)).await {
+                Some(Ok(frame)) => {
+                    if frame.is_trailers() {
+                        saw_trailers = true;
+                    }
+                }
+                Some(Err(e)) => panic!("body should not error: {e}"),
+                None => break,
+            }
+        }
+
+        assert!(
+            saw_trailers,
+            "trailers must survive vector response transformation"
+        );
+    }
+
+    #[tokio::test]
+    async fn passes_through_empty_body_unchanged() {
+        let body = wrap_vector_response_body(SdkBody::empty(), false, None);
+        assert_eq!(drain(body).await, Vec::<u8>::new());
+    }
+
+    #[tokio::test]
+    async fn passes_through_non_json_body_unchanged() {
+        let body = wrap_vector_response_body(SdkBody::from("not json"), false, None);
+        assert_eq!(drain(body).await, b"not json".to_vec());
+    }
+
+    #[tokio::test]
+    async fn passes_through_body_without_marker_unchanged() {
+        let original = serde_json::json!({ "Item": { "pk": { "S": "x" } } });
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let body = wrap_vector_response_body(SdkBody::from(bytes.clone()), false, None);
+        assert_eq!(drain(body).await, bytes);
+    }
+
+    #[tokio::test]
+    async fn converts_float32vector_to_l_n_by_default() {
+        let original = serde_json::json!({
+            "Item": { "embedding": { "FLOAT32VECTOR": [1.0, 2.0] } }
+        });
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let body = wrap_vector_response_body(SdkBody::from(bytes), false, None);
+        let out = drain(body).await;
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(
+            parsed["Item"]["embedding"]["L"],
+            serde_json::json!([{ "N": "1" }, { "N": "2" }])
+        );
+    }
+
+    #[tokio::test]
+    async fn converts_float32vector_to_marker_binary_when_preserving() {
+        let original = serde_json::json!({
+            "Item": { "embedding": { "FLOAT32VECTOR": [1.0, 2.0] } }
+        });
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let body = wrap_vector_response_body(SdkBody::from(bytes), true, None);
+        let out = drain(body).await;
+        let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert!(parsed["Item"]["embedding"].get("B").is_some());
+    }
+
+    #[tokio::test]
+    async fn extracts_vector_indexes_from_table_description_into_holder() {
+        let original = serde_json::json!({
+            "TableDescription": {
+                "VectorIndexes": [{
+                    "IndexName": "vec_idx",
+                    "VectorAttribute": { "AttributeName": "embedding", "Dimensions": 4 },
+                    "IndexStatus": "ACTIVE",
+                    "Backfilling": false
+                }]
+            }
+        });
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let holder = Arc::new(Mutex::new(VectorResponseHolder::default()));
+        let body = wrap_vector_response_body(SdkBody::from(bytes), false, Some(holder.clone()));
+        let _ = drain(body).await;
+        let indexes = holder.lock().unwrap().vector_indexes.clone().unwrap();
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].index_name, "vec_idx");
+    }
+
+    #[tokio::test]
+    async fn rejects_non_array_vector_indexes() {
+        let original = serde_json::json!({ "Table": { "VectorIndexes": {} } });
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let holder = Arc::new(Mutex::new(VectorResponseHolder::default()));
+        let body = wrap_vector_response_body(SdkBody::from(bytes), false, Some(holder));
+
+        let error = body.collect().await.unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "VectorIndexes response field must be an array"
+        );
+    }
+}

--- a/src/vector_response.rs
+++ b/src/vector_response.rs
@@ -2,9 +2,9 @@
 //!
 //! Wraps an `SdkBody` with a lazy transformer that buffers the full
 //! response, then (for successful, JSON, `FLOAT32VECTOR`-bearing bodies)
-//! rewrites `FLOAT32VECTOR` attributes and extracts `VectorIndexes` into a
-//! per-request [VectorResponseHolder] before handing transformed bytes to
-//! the generated SDK deserializer.
+//! rewrites `FLOAT32VECTOR` attributes and extracts `Scores` /
+//! `VectorIndexes` into a per-request [VectorResponseHolder] before handing
+//! transformed bytes to the generated SDK deserializer.
 //!
 //! Errors from the inner body are propagated unchanged. Empty bodies,
 //! non-JSON bodies, and JSON parse failures are passed through unchanged
@@ -121,9 +121,10 @@ impl http_body::Body for VectorTransformBody {
     }
 }
 
-/// Transforms a fully-buffered response body: extracts `VectorIndexes` into
-/// `holder` (if present) and rewrites `FLOAT32VECTOR` attributes. Returns
-/// the original bytes unchanged for empty, non-JSON, or unparsable bodies.
+/// Transforms a fully-buffered response body: extracts `Scores` and
+/// `VectorIndexes` into `holder` (if present) and rewrites `FLOAT32VECTOR`
+/// attributes. Returns the original bytes unchanged for empty, non-JSON,
+/// or unparsable bodies.
 fn transform_bytes(
     bytes: &[u8],
     preserve: bool,
@@ -145,6 +146,27 @@ fn transform_bytes(
     };
 
     if let Some(holder) = holder {
+        if let Some(scores_value) = json.get("Scores") {
+            let scores = scores_value
+                .as_array()
+                .ok_or("Scores response field must be an array")?
+                .iter()
+                .map(|value| {
+                    value
+                        .as_f64()
+                        .ok_or("Scores response field must contain numbers")
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            if let Some(items) = json.get("Items").and_then(serde_json::Value::as_array)
+                && items.len() != scores.len()
+            {
+                return Err("Items and Scores response fields must have the same length".into());
+            }
+
+            holder.lock().expect("holder mutex poisoned").scores = Some(scores);
+        }
+
         for key in ["Table", "TableDescription"] {
             if let Some(indexes_value) = json.get(key).and_then(|t| t.get("VectorIndexes")) {
                 let indexes = indexes_value
@@ -299,6 +321,30 @@ mod tests {
         let out = drain(body).await;
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert!(parsed["Item"]["embedding"].get("B").is_some());
+    }
+
+    #[tokio::test]
+    async fn extracts_scores_into_holder() {
+        let original = serde_json::json!({ "Items": [{}, {}], "Scores": [0.9, 0.1] });
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let holder = Arc::new(Mutex::new(VectorResponseHolder::default()));
+        let body = wrap_vector_response_body(SdkBody::from(bytes), false, Some(holder.clone()));
+        let _ = drain(body).await;
+        assert_eq!(holder.lock().unwrap().scores, Some(vec![0.9, 0.1]));
+    }
+
+    #[tokio::test]
+    async fn rejects_scores_with_mismatched_items() {
+        let original = serde_json::json!({ "Items": [], "Scores": [0.9] });
+        let bytes = serde_json::to_vec(&original).unwrap();
+        let holder = Arc::new(Mutex::new(VectorResponseHolder::default()));
+        let body = wrap_vector_response_body(SdkBody::from(bytes), false, Some(holder));
+
+        let error = body.collect().await.unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Items and Scores response fields must have the same length"
+        );
     }
 
     #[tokio::test]

--- a/tests/ccm_wrapper/ccm.rs
+++ b/tests/ccm_wrapper/ccm.rs
@@ -68,6 +68,24 @@ impl Ccm {
         alternator_port: u16,
         scylla_version: String,
     ) -> anyhow::Result<Cluster> {
+        Self::create_cluster_with_node_config(
+            cluster_name,
+            topology,
+            ip_prefix,
+            alternator_port,
+            scylla_version,
+            &[],
+        )
+    }
+
+    pub(crate) fn create_cluster_with_node_config(
+        cluster_name: String,
+        topology: &TopologySpec,
+        ip_prefix: IpPrefix,
+        alternator_port: u16,
+        scylla_version: String,
+        node_config: &[String],
+    ) -> anyhow::Result<Cluster> {
         // String of form nodes_in_dc1_RAC1:nodes_in_dc2_RAC1:nodes_in_dc3_RAC1...
         let first_rack_nodes_per_dc = topology.datacenters.iter().map(|dc| dc.racks[0]).join(":");
 
@@ -84,6 +102,7 @@ impl Ccm {
             topology,
             scylla_version,
             alternator_port,
+            node_config,
         ) {
             Ok(cluster) => Ok(cluster),
             Err(e) => {
@@ -105,6 +124,7 @@ impl Ccm {
         topology: &TopologySpec,
         scylla_version: String,
         alternator_port: u16,
+        node_config: &[String],
     ) -> anyhow::Result<Cluster> {
         let mut cluster = Cluster::new(cluster_name, ip_prefix, scylla_version);
 
@@ -150,7 +170,7 @@ impl Ccm {
                             CcmCommandRunner::add_node(&node_name, &ip, &dc_name, &rack_name)?;
                         }
                         let node = Node::new(node_name, ip, alternator_port);
-                        let child = Self::add_alternator_to_node(&node)?;
+                        let child = Self::add_alternator_to_node(&node, node_config)?;
                         pending_updateconfs.push(node.name.clone(), child);
                         rack.add_node(node);
                     }
@@ -206,13 +226,20 @@ impl Ccm {
         Ok(())
     }
 
-    fn add_alternator_to_node(node: &Node) -> anyhow::Result<std::process::Child> {
+    fn add_alternator_to_node(
+        node: &Node,
+        node_config: &[String],
+    ) -> anyhow::Result<std::process::Child> {
         let address = format!("alternator_address:{}", node.ip);
         let port = format!("alternator_port:{}", node.alternator_port);
-        CcmCommandRunner::spawn_update_node_conf(
-            &node.name,
-            &[&address, &port, "alternator_write_isolation:always"],
-        )
+        let mut config = vec![
+            address,
+            port,
+            "alternator_write_isolation:always".to_string(),
+        ];
+        config.extend_from_slice(node_config);
+        let config_refs: Vec<&str> = config.iter().map(String::as_str).collect();
+        CcmCommandRunner::spawn_update_node_conf(&node.name, &config_refs)
     }
 }
 
@@ -236,12 +263,15 @@ impl CcmCommandRunner {
             .output()
             .with_context(|| format!("Failed to run {}", command_str))?;
 
-        // ccm outputs errors on stdout.
+        // ccm outputs errors on stdout, but tracebacks/underlying tool
+        // output (e.g. Docker, download errors) frequently land on stderr;
+        // include both so failures are diagnosable.
         anyhow::ensure!(
             output.status.success(),
-            "\nCommand failed: {}\nccm error message: {}",
+            "\nCommand failed: {}\nccm stdout: {}\nccm stderr: {}",
             command_str,
             String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
         );
 
         Ok(())

--- a/tests/http_content/mod.rs
+++ b/tests/http_content/mod.rs
@@ -10,3 +10,4 @@ mod driver_utils;
 pub mod body_compression;
 pub mod correct_line;
 pub mod optimize_headers;
+pub mod vector_search;

--- a/tests/http_content/vector_search.rs
+++ b/tests/http_content/vector_search.rs
@@ -1,0 +1,159 @@
+use crate::http_content::driver_utils::*;
+use crate::http_content::http_test::*;
+use crate::http_content::proxy::*;
+
+use http_body_util::Full;
+use hyper::body::{Bytes, Incoming};
+use hyper::client::conn::http1::SendRequest;
+use hyper::{Request, Response};
+
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType,
+};
+use std::sync::Arc;
+use test_context::test_context;
+use tokio::sync::Mutex as TokioMutex;
+use uuid::Uuid;
+
+use alternator_driver::*;
+
+async fn cleanup_calls(resources: Vec<String>, alternator_address: &str) {
+    let client = aws_sdk_dynamodb::Client::from_conf(
+        aws_sdk_dynamodb::Config::builder()
+            .endpoint_url(format!("http://{}", alternator_address))
+            .region(aws_sdk_dynamodb::config::Region::new("eu-central-1"))
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .credentials_provider(
+                aws_sdk_dynamodb::config::Credentials::for_tests_with_session_token(),
+            )
+            .build(),
+    );
+
+    for resource in resources {
+        delete_table_cleanup(&client, &resource).await;
+    }
+}
+
+struct VectorSearchConfig;
+
+impl HttpTestConfig for VectorSearchConfig {
+    async fn on_request(
+        request: Request<Incoming>,
+        sender: Arc<TokioMutex<SendRequest<Full<Bytes>>>>,
+    ) -> Response<Full<Bytes>> {
+        let (parts, body) = collect_request(request).await;
+
+        let is_create_table = parts
+            .headers
+            .get("x-amz-target")
+            .map(|v| v.as_bytes() == b"DynamoDB_20120810.CreateTable")
+            .unwrap_or(false);
+
+        if is_create_table {
+            let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+            assert!(
+                json.get("VectorIndexes").is_some(),
+                "VectorIndexes should be present in CreateTable request"
+            );
+
+            let indexes = json["VectorIndexes"].as_array().unwrap();
+            assert_eq!(indexes.len(), 1, "Should have 1 vector index");
+            assert_eq!(indexes[0]["IndexName"], "vec_idx");
+            assert_eq!(
+                indexes[0]["VectorAttribute"]["AttributeName"],
+                "vector_attr"
+            );
+            // VectorAttribute has no VectorType field in the API
+            assert_eq!(indexes[0]["VectorAttribute"]["Dimensions"], 128);
+
+            // Strip VectorIndexes before forwarding to Alternator
+            let mut stripped = json.clone();
+            stripped.as_object_mut().unwrap().remove("VectorIndexes");
+            let new_body = serde_json::to_vec(&stripped).unwrap();
+
+            let mut mod_parts = parts.clone();
+            mod_parts.headers.insert(
+                "content-length",
+                new_body.len().to_string().try_into().unwrap(),
+            );
+
+            let (parts, body) =
+                collect_received_response(mod_parts, Bytes::from(new_body), sender).await;
+            build_response(parts, body)
+        } else {
+            let (parts, body) = collect_received_response(parts, body, sender).await;
+            build_response(parts, body)
+        }
+    }
+
+    async fn cleanup(resources: Vec<String>, alternator_address: &str) {
+        cleanup_calls(resources, alternator_address).await;
+    }
+}
+
+#[test_context(HttpTestContext<VectorSearchConfig>)]
+#[tokio::test]
+pub async fn test_create_table_with_vector_indexes(ctx: &mut HttpTestContext<VectorSearchConfig>) {
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .allow_no_auth()
+            .build(),
+    );
+
+    let table_name = format!("table_vec_{}", Uuid::new_v4());
+    ctx.register_resource(table_name.clone());
+
+    let va = VectorAttribute::builder()
+        .attribute_name("vector_attr")
+        .dimensions(128)
+        .build()
+        .unwrap();
+
+    let vi = VectorIndex::builder()
+        .index_name("vec_idx")
+        .vector_attribute(va)
+        .build()
+        .unwrap();
+
+    let created = client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()
+                .unwrap(),
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()
+                .unwrap(),
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .customize()
+        .vector_indexes(vec![vi])
+        .send()
+        .await
+        .unwrap();
+
+    assert!(created.table_description().is_some());
+
+    // Verify table was actually created by performing DescribeTable
+    let desc = client
+        .describe_table()
+        .table_name(&table_name)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(desc.table().unwrap().table_name().unwrap(), &table_name);
+
+    // Cleanup is done by teardown
+}

--- a/tests/http_content/vector_search.rs
+++ b/tests/http_content/vector_search.rs
@@ -5,8 +5,9 @@ use crate::http_content::proxy::*;
 use http_body_util::Full;
 use hyper::body::{Bytes, Incoming};
 use hyper::client::conn::http1::SendRequest;
-use hyper::{Request, Response};
+use hyper::{Request, Response, StatusCode};
 
+use aws_sdk_dynamodb::error::ProvideErrorMetadata;
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, BillingMode, KeySchemaElement, KeyType, ScalarAttributeType,
 };
@@ -137,15 +138,16 @@ pub async fn test_create_table_with_vector_indexes(ctx: &mut HttpTestContext<Vec
                 .unwrap(),
         )
         .billing_mode(BillingMode::PayPerRequest)
-        .customize()
         .vector_indexes(vec![vi])
         .send()
         .await
         .unwrap();
 
-    assert!(created.table_description().is_some());
+    // as_inner()/into_inner() convert to the generated CreateTableOutput.
+    assert!(created.as_inner().table_description().is_some());
 
-    // Verify table was actually created by performing DescribeTable
+    // The forwarding proxy strips VectorIndexes, so only ordinary table
+    // metadata is available from this real-Scylla request.
     let desc = client
         .describe_table()
         .table_name(&table_name)
@@ -154,6 +156,448 @@ pub async fn test_create_table_with_vector_indexes(ctx: &mut HttpTestContext<Vec
         .unwrap();
 
     assert_eq!(desc.table().unwrap().table_name().unwrap(), &table_name);
+    let _: aws_sdk_dynamodb::operation::create_table::CreateTableOutput = created.into_inner();
 
     // Cleanup is done by teardown
+}
+
+/// Config used by the tests below: instead of forwarding to the real
+/// backend, it returns a caller-supplied synthetic 200 JSON response and
+/// captures the last request body, both stored per-test via
+/// [HttpTestContext::set_on_request]. This lets us assert on HTTP JSON
+/// content and client-side response decoding without depending on the
+/// backend supporting Alternator vector search.
+struct SyntheticResponseConfig;
+
+impl HttpTestConfig for SyntheticResponseConfig {
+    async fn on_request(
+        request: Request<Incoming>,
+        _sender: Arc<TokioMutex<SendRequest<Full<Bytes>>>>,
+    ) -> Response<Full<Bytes>> {
+        let (_parts, _body) = collect_request(request).await;
+        Response::builder()
+            .status(200)
+            .header("content-type", "application/x-amz-json-1.0")
+            .body(Full::new(Bytes::from(b"{}".to_vec())))
+            .unwrap()
+    }
+
+    async fn cleanup(_resources: Vec<String>, _alternator_address: &str) {}
+}
+
+/// Sets up `ctx`'s `on_request` hook to record every request body into
+/// `last_body` and reply with `response_body`, for the current test only.
+async fn capture_and_respond(
+    ctx: &HttpTestContext<SyntheticResponseConfig>,
+    status: StatusCode,
+    response_body: serde_json::Value,
+    last_body: Arc<TokioMutex<Option<serde_json::Value>>>,
+) {
+    let response_bytes = serde_json::to_vec(&response_body).unwrap();
+    ctx.set_on_request(move |request, _sender| {
+        let last_body = last_body.clone();
+        let response_bytes = response_bytes.clone();
+        async move {
+            let (_parts, body) = collect_request(request).await;
+            if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&body) {
+                *last_body.lock().await = Some(json);
+            }
+            Response::builder()
+                .status(status)
+                .header("content-type", "application/x-amz-json-1.0")
+                .body(Full::new(Bytes::from(response_bytes)))
+                .unwrap()
+        }
+    })
+    .await;
+}
+
+fn synthetic_client(ctx: &HttpTestContext<SyntheticResponseConfig>) -> AlternatorClient {
+    AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .allow_no_auth()
+            .build(),
+    )
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
+pub async fn test_update_table_sends_vector_index_updates(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({ "TableDescription": {} }),
+        last_body.clone(),
+    )
+    .await;
+    let client = synthetic_client(ctx);
+
+    let va = VectorAttribute::builder()
+        .attribute_name("vector_attr")
+        .dimensions(64)
+        .build()
+        .unwrap();
+    let vi = VectorIndex::builder()
+        .index_name("new_idx")
+        .vector_attribute(va)
+        .build()
+        .unwrap();
+
+    client
+        .update_table()
+        .table_name("some_table")
+        .vector_index_updates(vec![VectorIndexUpdate::Create(vi)])
+        .send()
+        .await
+        .unwrap();
+
+    let body = last_body.lock().await.take().unwrap();
+    let updates = body["VectorIndexUpdates"].as_array().unwrap();
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0]["Create"]["IndexName"], "new_idx");
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
+pub async fn test_vector_response_wrappers_parse_metadata_and_absent_fields(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({
+            "TableDescription": {
+                "VectorIndexes": [{
+                    "IndexName": "vec_idx",
+                    "VectorAttribute": { "AttributeName": "embedding", "Dimensions": 3 },
+                    "Projection": { "ProjectionType": "INCLUDE", "NonKeyAttributes": ["title"] },
+                    "SimilarityFunction": "COSINE",
+                    "IndexStatus": "ACTIVE",
+                    "Backfilling": false
+                }]
+            }
+        }),
+        last_body.clone(),
+    )
+    .await;
+    let client = synthetic_client(ctx);
+    let index = VectorIndex::builder()
+        .index_name("vec_idx")
+        .vector_attribute(
+            VectorAttribute::builder()
+                .attribute_name("embedding")
+                .dimensions(3)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    let created = client
+        .create_table()
+        .table_name("some_table")
+        .vector_indexes(vec![index])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.vector_indexes.len(), 1);
+    let parsed = &created.vector_indexes[0];
+    assert_eq!(parsed.vector_attribute.attribute_name, "embedding");
+    assert_eq!(parsed.vector_attribute.dimensions, 3);
+    assert_eq!(parsed.similarity_function, Some(SimilarityFunction::Cosine));
+    assert_eq!(parsed.index_status, Some(IndexStatus::Active));
+    assert_eq!(parsed.backfilling, Some(false));
+
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({ "Table": {} }),
+        last_body,
+    )
+    .await;
+    let described = client
+        .describe_table()
+        .table_name("some_table")
+        .with_vector_indexes()
+        .send()
+        .await
+        .unwrap();
+    assert!(described.vector_indexes.is_empty());
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
+pub async fn test_vector_response_wrappers_preserve_service_errors(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    let error = serde_json::json!({
+        "__type": "com.amazonaws.dynamodb.v20120810#ValidationException",
+        "message": "Vector index is not ready"
+    });
+    capture_and_respond(ctx, StatusCode::INTERNAL_SERVER_ERROR, error, last_body).await;
+    let client = synthetic_client(ctx);
+
+    let index = VectorIndex::builder()
+        .index_name("vec_idx")
+        .vector_attribute(
+            VectorAttribute::builder()
+                .attribute_name("embedding")
+                .dimensions(3)
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+    let create_error = client
+        .create_table()
+        .table_name("some_table")
+        .vector_indexes(vec![index])
+        .send()
+        .await
+        .unwrap_err();
+    let service_error = create_error.as_service_error().unwrap();
+    assert_eq!(service_error.code(), Some("ValidationException"));
+    assert_eq!(service_error.message(), Some("Vector index is not ready"));
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
+pub async fn test_preserve_float32_vectors_operation_override_takes_precedence(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({
+            "Item": {
+                "pk": { "S": "row1" },
+                "embedding": { "FLOAT32VECTOR": [1.0, 2.0, 3.0] }
+            }
+        }),
+        last_body,
+    )
+    .await;
+
+    // Client default is `false` (ordinary L/N conversion); a per-operation
+    // override of `true` should take precedence and return a marker binary.
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .allow_no_auth()
+            .preserve_float32_vectors(false)
+            .build(),
+    );
+
+    let output = client
+        .get_item()
+        .table_name("some_table")
+        .key(
+            "pk",
+            aws_sdk_dynamodb::types::AttributeValue::S("row1".into()),
+        )
+        .customize()
+        .alternator_config_override(
+            AlternatorConfig::operation_builder().preserve_float32_vectors(true),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let item = output.item().unwrap();
+    let embedding = item.get("embedding").unwrap();
+    assert!(embedding.is_float32_vector());
+    assert_eq!(embedding.float32_vector().unwrap(), vec![1.0, 2.0, 3.0]);
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
+pub async fn test_preserve_float32_vectors_operation_override_false_beats_client_true(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({
+            "Item": {
+                "pk": { "S": "row1" },
+                "embedding": { "FLOAT32VECTOR": [1.0, 2.0, 3.0] }
+            }
+        }),
+        last_body,
+    )
+    .await;
+
+    // Client default is `true`; a per-operation override of `false` should
+    // take precedence and return an ordinary L/N representation.
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .allow_no_auth()
+            .preserve_float32_vectors(true)
+            .build(),
+    );
+
+    let output = client
+        .get_item()
+        .table_name("some_table")
+        .key(
+            "pk",
+            aws_sdk_dynamodb::types::AttributeValue::S("row1".into()),
+        )
+        .customize()
+        .alternator_config_override(
+            AlternatorConfig::operation_builder().preserve_float32_vectors(false),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let item = output.item().unwrap();
+    let embedding = item.get("embedding").unwrap();
+    assert!(matches!(
+        embedding,
+        aws_sdk_dynamodb::types::AttributeValue::L(_)
+    ));
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
+pub async fn test_put_item_rewrites_marker_binary_to_float32vector(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({}),
+        last_body.clone(),
+    )
+    .await;
+    let client = synthetic_client(ctx);
+
+    let av = Float32Vector::to_attribute_value(vec![1.0, 2.0, 3.0]).unwrap();
+
+    client
+        .put_item()
+        .table_name("some_table")
+        .item(
+            "pk",
+            aws_sdk_dynamodb::types::AttributeValue::S("row1".into()),
+        )
+        .item("embedding", av)
+        .send()
+        .await
+        .unwrap();
+
+    let body = last_body.lock().await.take().unwrap();
+    assert_eq!(
+        body["Item"]["embedding"]["FLOAT32VECTOR"],
+        serde_json::json!([1.0, 2.0, 3.0])
+    );
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
+pub async fn test_get_item_response_converts_float32vector_to_l_n_by_default(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({
+            "Item": {
+                "pk": { "S": "row1" },
+                "embedding": { "FLOAT32VECTOR": [1.0, 2.0, 3.0] }
+            }
+        }),
+        last_body,
+    )
+    .await;
+    let client = synthetic_client(ctx);
+
+    let output = client
+        .get_item()
+        .table_name("some_table")
+        .key(
+            "pk",
+            aws_sdk_dynamodb::types::AttributeValue::S("row1".into()),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let item = output.item().unwrap();
+    let embedding = item.get("embedding").unwrap();
+    assert!(matches!(
+        embedding,
+        aws_sdk_dynamodb::types::AttributeValue::L(_)
+    ));
+    if let aws_sdk_dynamodb::types::AttributeValue::L(list) = embedding {
+        assert_eq!(list.len(), 3);
+        assert!(matches!(
+            &list[0],
+            aws_sdk_dynamodb::types::AttributeValue::N(_)
+        ));
+    }
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
+pub async fn test_get_item_response_preserves_marker_binary_when_enabled(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({
+            "Item": {
+                "pk": { "S": "row1" },
+                "embedding": { "FLOAT32VECTOR": [1.0, 2.0, 3.0] }
+            }
+        }),
+        last_body,
+    )
+    .await;
+
+    let client = AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(format!("http://{}", ctx.get_proxy_address()))
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version(aws_sdk_dynamodb::config::BehaviorVersion::latest())
+            .allow_no_auth()
+            .preserve_float32_vectors(true)
+            .build(),
+    );
+
+    let output = client
+        .get_item()
+        .table_name("some_table")
+        .key(
+            "pk",
+            aws_sdk_dynamodb::types::AttributeValue::S("row1".into()),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let item = output.item().unwrap();
+    let embedding = item.get("embedding").unwrap();
+    assert!(embedding.is_float32_vector());
+    assert_eq!(embedding.float32_vector().unwrap(), vec![1.0, 2.0, 3.0]);
 }

--- a/tests/http_content/vector_search.rs
+++ b/tests/http_content/vector_search.rs
@@ -265,6 +265,56 @@ pub async fn test_update_table_sends_vector_index_updates(
 
 #[test_context(HttpTestContext<SyntheticResponseConfig>)]
 #[tokio::test]
+pub async fn test_query_sends_vector_search_and_exposes_scores(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({
+            "Items": [{}, {}],
+            "Count": 2,
+            "ScannedCount": 2,
+            "Scores": [0.95, 0.42]
+        }),
+        last_body.clone(),
+    )
+    .await;
+    let client = synthetic_client(ctx);
+
+    let search = VectorSearch::new(vec![1.0, 2.0, 3.0])
+        .unwrap()
+        .with_return_scores(ReturnScores::Similarity);
+
+    let result = client
+        .query()
+        .table_name("some_table")
+        .index_name("embedding_idx")
+        .limit(10)
+        .expression_attribute_names("#pk", "pk")
+        .key_condition_expression("#pk = :pk")
+        .vector_search(search)
+        .send()
+        .await
+        .unwrap();
+
+    let body = last_body.lock().await.take().unwrap();
+    assert_eq!(
+        body["VectorSearch"]["QueryVector"]["FLOAT32VECTOR"],
+        serde_json::json!([1.0, 2.0, 3.0])
+    );
+    assert_eq!(body["VectorSearch"]["ReturnScores"], "SIMILARITY");
+    assert_eq!(result.scores, Some(vec![0.95, 0.42]));
+
+    // as_inner()/into_inner() convert to the generated QueryOutput.
+    assert_eq!(result.as_inner().count(), 2);
+    let plain: aws_sdk_dynamodb::operation::query::QueryOutput = result.into_inner();
+    assert_eq!(plain.count(), 2);
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
 pub async fn test_vector_response_wrappers_parse_metadata_and_absent_fields(
     ctx: &mut HttpTestContext<SyntheticResponseConfig>,
 ) {
@@ -340,11 +390,32 @@ pub async fn test_vector_response_wrappers_preserve_service_errors(
     let last_body = Arc::new(TokioMutex::new(None));
     let error = serde_json::json!({
         "__type": "com.amazonaws.dynamodb.v20120810#ValidationException",
-        "message": "Vector index is not ready"
+        "message": "Vector index is not ready",
+        "Scores": [0.95]
     });
-    capture_and_respond(ctx, StatusCode::INTERNAL_SERVER_ERROR, error, last_body).await;
+    capture_and_respond(
+        ctx,
+        StatusCode::BAD_REQUEST,
+        error.clone(),
+        last_body.clone(),
+    )
+    .await;
     let client = synthetic_client(ctx);
 
+    let query_error = client
+        .query()
+        .table_name("some_table")
+        .index_name("embedding_idx")
+        .limit(10)
+        .vector_search(VectorSearch::new([1.0]).unwrap())
+        .send()
+        .await
+        .unwrap_err();
+    let service_error = query_error.as_service_error().unwrap();
+    assert_eq!(service_error.code(), Some("ValidationException"));
+    assert_eq!(service_error.message(), Some("Vector index is not ready"));
+
+    capture_and_respond(ctx, StatusCode::INTERNAL_SERVER_ERROR, error, last_body).await;
     let index = VectorIndex::builder()
         .index_name("vec_idx")
         .vector_attribute(
@@ -366,6 +437,80 @@ pub async fn test_vector_response_wrappers_preserve_service_errors(
     let service_error = create_error.as_service_error().unwrap();
     assert_eq!(service_error.code(), Some("ValidationException"));
     assert_eq!(service_error.message(), Some("Vector index is not ready"));
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
+pub async fn test_query_customize_form_coexists_with_config_override(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({
+            "Items": [{}, {}],
+            "Count": 2,
+            "ScannedCount": 2,
+            "Scores": [0.95, 0.42]
+        }),
+        last_body.clone(),
+    )
+    .await;
+    let client = synthetic_client(ctx);
+
+    let search = VectorSearch::new(vec![1.0, 2.0, 3.0])
+        .unwrap()
+        .with_return_scores(ReturnScores::Similarity);
+
+    // The `.customize()` form is equivalent to the direct form, and can be
+    // combined with a per-request `alternator_config_override(...)`.
+    let result = client
+        .query()
+        .table_name("some_table")
+        .index_name("embedding_idx")
+        .limit(10)
+        .customize()
+        .vector_search(search)
+        .alternator_config_override(
+            AlternatorConfig::operation_builder().preserve_float32_vectors(true),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let body = last_body.lock().await.take().unwrap();
+    assert_eq!(
+        body["VectorSearch"]["QueryVector"]["FLOAT32VECTOR"],
+        serde_json::json!([1.0, 2.0, 3.0])
+    );
+    assert_eq!(result.scores, Some(vec![0.95, 0.42]));
+}
+
+#[test_context(HttpTestContext<SyntheticResponseConfig>)]
+#[tokio::test]
+pub async fn test_ordinary_query_remains_aws_sdk_compatible(
+    ctx: &mut HttpTestContext<SyntheticResponseConfig>,
+) {
+    let last_body = Arc::new(TokioMutex::new(None));
+    capture_and_respond(
+        ctx,
+        StatusCode::OK,
+        serde_json::json!({ "Items": [], "Count": 0, "ScannedCount": 0 }),
+        last_body,
+    )
+    .await;
+    let client = synthetic_client(ctx);
+
+    // `query()` still returns the AWS SDK's own `QueryFluentBuilder`, not a
+    // vector builder, and its output is the generated `QueryOutput`.
+    let output: aws_sdk_dynamodb::operation::query::QueryOutput = client
+        .query()
+        .table_name("some_table")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(output.count(), 0);
 }
 
 #[test_context(HttpTestContext<SyntheticResponseConfig>)]

--- a/tests/vector_store_e2e.rs
+++ b/tests/vector_store_e2e.rs
@@ -1,0 +1,485 @@
+//! Opt-in Vector Store integration coverage.
+//!
+//! Run with `RUSTFLAGS='--cfg ccm_tests' cargo test --test vector_store_e2e
+//! -- --nocapture`. It requires Docker (for Vector Store only) plus these
+//! variables:
+//!
+//! - `SCYLLA_VECTOR_STORE_IMAGE`: the Vector Store Docker image, e.g.
+//!   `scylladb/vector-store:1.9.1`.
+//! - `SCYLLA_VECTOR_STORE_PORT`: the Vector Store HTTP API port, e.g. `6080`.
+//! - `SCYLLA_VECTOR_STORE_SCYLLA_VERSION`: the CCM-resolvable Scylla version
+//!   used for the dedicated single-node cluster, e.g. `unstable/master:latest`.
+//!   Native `Vector`/`Scores` support requires a sufficiently new nightly;
+//!   released `release:*` versions do not support it yet. This is passed
+//!   directly as `ccm create -v <value>`, so any value documented by
+//!   `ccmlib.scylla_repository.setup` works (e.g. `unstable/master:<UTC
+//!   timestamp>`, `release:2025.1`).
+//! - `SCYLLA_VECTOR_STORE_SCYLLA_CONFIG`: newline-separated `key:value`
+//!   entries passed directly to `ccm node1 updateconf`. Must at minimum wire
+//!   Scylla to the Vector Store instance, e.g.
+//!   `vector_store_primary_uri:http://127.0.0.1:<SCYLLA_VECTOR_STORE_PORT>`.
+//!
+//! The Scylla cluster is created with CCM's normal package-based flow (`ccm
+//! create -v ...`), not Docker, so it binds directly to a host loopback
+//! alias (e.g. `127.0.2.1`) like every other CCM-based test in this repo. The
+//! Vector Store container is started with `--network host` so it can reach
+//! that address directly, and `VECTOR_STORE_URI` / `VECTOR_STORE_SCYLLADB_URI`
+//! are set explicitly so both processes agree on `127.0.0.1` addressing.
+//!
+//! Example, using `make vector-store-e2e` (equivalent to the `cargo test`
+//! invocation above):
+//!
+//! ```text
+//! export RUSTFLAGS='--cfg ccm_tests'
+//! export SCYLLA_VECTOR_STORE_IMAGE=scylladb/vector-store:1.9.1
+//! export SCYLLA_VECTOR_STORE_PORT=6080
+//! export SCYLLA_VECTOR_STORE_SCYLLA_VERSION='unstable/master:latest'
+//! export SCYLLA_VECTOR_STORE_SCYLLA_CONFIG='vector_store_primary_uri:http://127.0.0.1:6080'
+//! make vector-store-e2e
+//! ```
+
+mod ccm_wrapper;
+
+use crate::ccm_wrapper::ccm::{Ccm, ClusterGuard};
+use crate::ccm_wrapper::cluster::IpPrefix;
+use crate::ccm_wrapper::topology_spec::{DatacenterSpec, TopologySpecBuilder};
+
+use alternator_driver::*;
+use anyhow::Context;
+use aws_sdk_dynamodb::types::{
+    AttributeDefinition, AttributeValue, BillingMode, KeySchemaElement, KeyType,
+    ScalarAttributeType,
+};
+use std::env;
+use std::fmt::Write as _;
+use std::process::Command;
+use std::time::Duration;
+use uuid::Uuid;
+
+const INDEX_NAME: &str = "embedding_idx";
+const VECTOR_ATTR: &str = "embedding";
+const DIMENSIONS: u32 = 3;
+
+struct VectorStoreContainer {
+    name: String,
+}
+
+impl VectorStoreContainer {
+    /// Starts the Vector Store container on the host network, pointed at
+    /// the given Scylla (Alternator/CQL) address.
+    fn start(image: &str, port: u16, scylladb_uri: &str) -> anyhow::Result<Self> {
+        let name = format!("alternator-vector-store-{}", Uuid::new_v4());
+        let status = Command::new("docker")
+            .args(["run", "--detach", "--rm", "--network", "host", "--name"])
+            .arg(&name)
+            .arg("-e")
+            .arg(format!("VECTOR_STORE_URI=127.0.0.1:{port}"))
+            .arg("-e")
+            .arg(format!("VECTOR_STORE_SCYLLADB_URI={scylladb_uri}"))
+            .arg(image)
+            .status()
+            .context("failed to start Docker Vector Store container")?;
+        anyhow::ensure!(
+            status.success(),
+            "Docker failed to start Vector Store container"
+        );
+        Ok(Self { name })
+    }
+
+    /// Returns `true` if the container is still running.
+    fn is_running(&self) -> bool {
+        let output = Command::new("docker")
+            .args(["inspect", "--format", "{{.State.Running}}", &self.name])
+            .output();
+        matches!(output, Ok(o) if o.status.success() && o.stdout == b"true\n")
+    }
+
+    /// Returns the container's combined stdout/stderr logs.
+    fn logs(&self) -> String {
+        let output = Command::new("docker").args(["logs", &self.name]).output();
+        match output {
+            Ok(o) => {
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                format!("stdout:\n{stdout}\nstderr:\n{stderr}")
+            }
+            Err(e) => format!("failed to get container logs: {e}"),
+        }
+    }
+}
+
+impl Drop for VectorStoreContainer {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["rm", "--force", &self.name])
+            .status();
+    }
+}
+
+fn required_env(name: &str) -> anyhow::Result<String> {
+    env::var(name).with_context(|| format!("{name} must be set for the Vector Store E2E test"))
+}
+
+struct VectorStoreConfig {
+    image: String,
+    port: u16,
+    scylla_version: String,
+    node_config: Vec<String>,
+}
+
+fn vector_store_config() -> anyhow::Result<VectorStoreConfig> {
+    let image = required_env("SCYLLA_VECTOR_STORE_IMAGE")?;
+    let port = required_env("SCYLLA_VECTOR_STORE_PORT")?
+        .parse()
+        .context("SCYLLA_VECTOR_STORE_PORT must be a valid port")?;
+    let scylla_version = required_env("SCYLLA_VECTOR_STORE_SCYLLA_VERSION")?;
+    let node_config: Vec<String> = required_env("SCYLLA_VECTOR_STORE_SCYLLA_CONFIG")?
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(String::from)
+        .collect();
+    anyhow::ensure!(
+        !node_config.is_empty() && node_config.iter().all(|entry| entry.contains(':')),
+        "SCYLLA_VECTOR_STORE_SCYLLA_CONFIG must contain newline-separated key:value entries"
+    );
+    Ok(VectorStoreConfig {
+        image,
+        port,
+        scylla_version,
+        node_config,
+    })
+}
+
+fn vector_client(endpoint_url: String, preserve_float32_vectors: bool) -> AlternatorClient {
+    AlternatorClient::from_conf(
+        AlternatorConfig::builder()
+            .endpoint_url(endpoint_url)
+            .seed_hosts(Vec::<String>::new())
+            .behavior_version_latest()
+            .allow_no_auth()
+            .preserve_float32_vectors(preserve_float32_vectors)
+            .build(),
+    )
+}
+
+/// Formats a [`VectorIndex`]'s response-only fields for timeout
+/// diagnostics, so a failed wait for `Active` shows what was last observed
+/// instead of nothing.
+fn describe_index_metadata(indexes: &[VectorIndex]) -> String {
+    if indexes.is_empty() {
+        return "<no vector indexes observed>".to_string();
+    }
+    let mut out = String::new();
+    for index in indexes {
+        let _ = write!(
+            out,
+            "\n  - index_name={} attribute={} dimensions={} status={:?} backfilling={:?}",
+            index.index_name,
+            index.vector_attribute.attribute_name,
+            index.vector_attribute.dimensions,
+            index.index_status,
+            index.backfilling,
+        );
+    }
+    out
+}
+
+/// Polls `DescribeTable` for `table_name` until `INDEX_NAME` reports
+/// [`IndexStatus::Active`], returning its final metadata. On timeout, the
+/// error includes the last observed vector-index metadata.
+async fn wait_for_index_active(
+    client: &AlternatorClient,
+    table_name: &str,
+) -> anyhow::Result<VectorIndex> {
+    let mut last_observed: Vec<VectorIndex> = Vec::new();
+    let result = tokio::time::timeout(Duration::from_secs(90), async {
+        loop {
+            let described = client
+                .describe_table()
+                .table_name(table_name)
+                .with_vector_indexes()
+                .send()
+                .await?;
+            last_observed = described.vector_indexes.clone();
+            if let Some(index) = last_observed.iter().find(|index| {
+                index.index_name == INDEX_NAME && index.index_status == Some(IndexStatus::Active)
+            }) {
+                return Ok::<_, anyhow::Error>(index.clone());
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await;
+
+    match result {
+        Ok(inner) => inner,
+        Err(_) => anyhow::bail!(
+            "timed out waiting for vector index '{INDEX_NAME}' to become ACTIVE; last observed metadata:{}",
+            describe_index_metadata(&last_observed)
+        ),
+    }
+}
+
+/// Asserts response-only vector-index metadata matches what was configured
+/// (name, attribute, dimensions, similarity function), independent of
+/// `IndexStatus`.
+fn assert_index_metadata_matches(index: &VectorIndex) {
+    assert_eq!(index.index_name, INDEX_NAME);
+    assert_eq!(index.vector_attribute.attribute_name, VECTOR_ATTR);
+    assert_eq!(index.vector_attribute.dimensions, DIMENSIONS);
+    assert_eq!(index.similarity_function, Some(SimilarityFunction::Cosine));
+}
+
+#[tokio::test]
+#[cfg_attr(not(ccm_tests), ignore)]
+async fn vector_store_end_to_end() -> anyhow::Result<()> {
+    let config = vector_store_config()?;
+
+    let topology = TopologySpecBuilder::new()
+        .datacenter(DatacenterSpec::new().rack(1))
+        .build()?;
+    let cluster_name = format!("vector-store-{}", Uuid::new_v4());
+    let mut cluster = ClusterGuard(Ccm::create_cluster_with_node_config(
+        cluster_name,
+        &topology,
+        IpPrefix::new("127.0.2.")?,
+        8001,
+        config.scylla_version,
+        &config.node_config,
+    )?);
+    Ccm::start_cluster(&mut cluster)?;
+
+    let node_ip = cluster.nodes()[0].ip.clone();
+    let scylladb_uri = format!("{node_ip}:9042");
+
+    // Vector Store must be started only after Scylla is reachable; the
+    // container connects to ScyllaDB on first use.
+    let _vector_store = VectorStoreContainer::start(&config.image, config.port, &scylladb_uri)?;
+
+    // Wait for the Vector Store HTTP server to be reachable before proceeding.
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            if !_vector_store.is_running() {
+                anyhow::bail!(
+                    "Vector Store container exited unexpectedly:\n{}",
+                    _vector_store.logs()
+                );
+            }
+            if tokio::net::TcpStream::connect(format!("127.0.0.1:{}", config.port))
+                .await
+                .is_ok()
+            {
+                break Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    })
+    .await
+    .context("Vector Store container did not become ready")??;
+
+    let endpoint = cluster.nodes()[0].address();
+    let client = vector_client(endpoint.clone(), false);
+    let preserving_client = vector_client(endpoint, true);
+    let table_name = format!("vector_store_{}", Uuid::new_v4().simple());
+    let index = VectorIndex::builder()
+        .index_name(INDEX_NAME)
+        .vector_attribute(
+            VectorAttribute::builder()
+                .attribute_name(VECTOR_ATTR)
+                .dimensions(DIMENSIONS)
+                .build()
+                .map_err(anyhow::Error::msg)?,
+        )
+        .similarity_function(SimilarityFunction::Cosine)
+        .build()
+        .map_err(anyhow::Error::msg)?;
+
+    let result = client
+        .create_table()
+        .table_name(&table_name)
+        .attribute_definitions(
+            AttributeDefinition::builder()
+                .attribute_name("pk")
+                .attribute_type(ScalarAttributeType::S)
+                .build()?,
+        )
+        .key_schema(
+            KeySchemaElement::builder()
+                .attribute_name("pk")
+                .key_type(KeyType::Hash)
+                .build()?,
+        )
+        .billing_mode(BillingMode::PayPerRequest)
+        .vector_indexes(vec![index])
+        .send()
+        .await?;
+    assert_eq!(result.vector_indexes.len(), 1);
+    assert_index_metadata_matches(&result.vector_indexes[0]);
+
+    let test_result: anyhow::Result<()> = async {
+        let active_index = wait_for_index_active(&client, &table_name).await?;
+        assert_index_metadata_matches(&active_index);
+
+        // Deterministic corpus: two vectors near the (1,0,0) axis, one near
+        // the (0,1,0) axis, so a query for (1,0,0) has an unambiguous
+        // nearest-first order.
+        for (key, embedding) in [
+            ("near_a", [1.0, 0.0, 0.0]),
+            ("near_b", [0.9, 0.1, 0.0]),
+            ("far", [0.0, 1.0, 0.0]),
+        ] {
+            client
+                .put_item()
+                .table_name(&table_name)
+                .item("pk", AttributeValue::S(key.into()))
+                .item(
+                    VECTOR_ATTR,
+                    Float32Vector::to_attribute_value(embedding).unwrap(),
+                )
+                .send()
+                .await?;
+        }
+
+        // Compact FLOAT32VECTOR query vector.  The Vector Store indexes
+        // items asynchronously after they are written to ScyllaDB, so poll
+        // until it has caught up.
+        let compact_query = tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                let query = client
+                    .query()
+                    .table_name(&table_name)
+                    .index_name(INDEX_NAME)
+                    .limit(2)
+                    .vector_search(
+                        VectorSearch::new([1.0, 0.0, 0.0])
+                            .map_err(anyhow::Error::msg)?
+                            .with_return_scores(ReturnScores::Similarity),
+                    )
+                    .send()
+                    .await?;
+                if !query.as_inner().items().is_empty() {
+                    return Ok::<_, anyhow::Error>(query);
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        })
+        .await
+        .context("timed out waiting for Vector Store to index items")??;
+        assert_query_result_is_nearest_first(&compact_query);
+
+        // Default client reads the vector attribute as an ordinary L/N list.
+        let item = client
+            .get_item()
+            .table_name(&table_name)
+            .key("pk", AttributeValue::S("near_a".into()))
+            .send()
+            .await?
+            .item()
+            .cloned()
+            .context("missing inserted item")?;
+        assert!(matches!(item[VECTOR_ATTR], AttributeValue::L(_)));
+
+        // Preserving client reads the same attribute as a compact vector.
+        let preserved = preserving_client
+            .get_item()
+            .table_name(&table_name)
+            .key("pk", AttributeValue::S("near_a".into()))
+            .send()
+            .await?
+            .item()
+            .cloned()
+            .context("missing inserted item")?;
+        assert_eq!(
+            preserved[VECTOR_ATTR].float32_vector()?,
+            vec![1.0, 0.0, 0.0]
+        );
+
+        // Writing the preserved item back unchanged, then reading it again
+        // with preservation enabled, must still yield a compact vector
+        // (round trip does not silently widen it to L/N).
+        preserving_client
+            .put_item()
+            .table_name(&table_name)
+            .set_item(Some(preserved))
+            .send()
+            .await?;
+        let roundtripped = preserving_client
+            .get_item()
+            .table_name(&table_name)
+            .key("pk", AttributeValue::S("near_a".into()))
+            .send()
+            .await?
+            .item()
+            .cloned()
+            .context("missing item after preserving round trip")?;
+        assert_eq!(
+            roundtripped[VECTOR_ATTR].float32_vector()?,
+            vec![1.0, 0.0, 0.0]
+        );
+
+        Ok(())
+    }
+    .await;
+
+    let cleanup_result = client
+        .delete_table()
+        .table_name(&table_name)
+        .send()
+        .await
+        .context("failed to delete Vector Store E2E table");
+    match (test_result, cleanup_result) {
+        (Err(test_error), Ok(_)) => {
+            eprintln!("Vector Store container logs:\n{}", _vector_store.logs());
+            Err(test_error)
+        }
+        (Ok(()), Err(cleanup_error)) => Err(cleanup_error),
+        (Err(test_error), Err(cleanup_error)) => {
+            eprintln!("Vector Store container logs:\n{}", _vector_store.logs());
+            Err(test_error.context(format!("additionally, cleanup failed: {cleanup_error}")))
+        }
+        (Ok(()), Ok(_)) => Ok(()),
+    }
+}
+
+/// Asserts a vector-search query result over the `near_a`/`near_b`/`far`
+/// corpus is nearest-first for a query vector at `(1,0,0)`: exactly the two
+/// requested (`limit(2)`) results, `near_a` before `near_b`, scores present
+/// with matching cardinality, finite, and descending (most similar first).
+fn assert_query_result_is_nearest_first(query: &VectorQueryOutput) {
+    let items = query.as_inner().items();
+    assert_eq!(items.len(), 2, "expected exactly 2 results from limit(2)");
+
+    let keys: Vec<&str> = items
+        .iter()
+        .map(|item| {
+            item.get("pk")
+                .and_then(|v| v.as_s().ok())
+                .map(String::as_str)
+                .unwrap_or_default()
+        })
+        .collect();
+    assert_eq!(
+        keys,
+        vec!["near_a", "near_b"],
+        "results must be ordered nearest-first"
+    );
+
+    let scores = query
+        .scores
+        .as_ref()
+        .expect("ReturnScores::Similarity must populate scores");
+    assert_eq!(
+        scores.len(),
+        items.len(),
+        "scores and items must have matching cardinality"
+    );
+    assert!(
+        scores.iter().all(|score| score.is_finite()),
+        "all scores must be finite"
+    );
+    assert!(
+        scores.windows(2).all(|pair| pair[0] >= pair[1]),
+        "scores must be descending (most similar first): {scores:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Add typed client support for Alternator vector-search extensions.

- Add vector index creation, update, and describe support through fluent-builder extension traits.
- Add vector-search queries with typed `VectorSearch`, optional similarity scores, and local validation of invalid request combinations.
- Add `FLOAT32VECTOR` write support plus configurable response decoding and lossless read-modify-write preservation.
- Document the API, server-version caveats, and Vector Store E2E setup.
- Add synthetic HTTP coverage and opt-in CCM/Vector Store end-to-end coverage.

## Testing

- Added unit and synthetic HTTP tests for request injection, response parsing, validation, `FLOAT32VECTOR` conversion, and per-operation configuration.
- Added opt-in Vector Store E2E coverage via `make vector-store-e2e`.

Closes #98 